### PR TITLE
Add explicit STT language selection for chat voice transcription

### DIFF
--- a/.codex/skills/runestone-orchestration/SKILL.md
+++ b/.codex/skills/runestone-orchestration/SKILL.md
@@ -20,6 +20,7 @@ Load those files when this skill triggers. Do not copy their rules into this ski
 
 - Repository: `/Users/40min/www/runestone`.
 - Task wrapper skill: `runestone-task-management`.
+- Branch names: use `feat/<slug>` for new functionality and `fix/<slug>` for bug fixes. Do not use the generic `codex/` branch prefix for Runestone work.
 
 ## Adapter Map
 

--- a/frontend/src/components/ChatView.audio-controls.test.tsx
+++ b/frontend/src/components/ChatView.audio-controls.test.tsx
@@ -70,6 +70,14 @@ vi.mock("../hooks/useVoiceRecording", () => ({
   useVoiceRecording: () => mockVoiceRecordingState,
 }));
 
+vi.mock("../context/AuthContext", () => ({
+  useAuth: () => ({
+    userData: {
+      mother_tongue: "Finnish",
+    },
+  }),
+}));
+
 vi.mock("./chat/AgentMemoryModal", () => ({
   default: () => null,
 }));

--- a/frontend/src/components/ChatView.test.tsx
+++ b/frontend/src/components/ChatView.test.tsx
@@ -188,6 +188,108 @@ describe('ChatView', () => {
     });
   });
 
+  it('syncs speech language from profile when user data updates later', async () => {
+    render(
+      <AuthProvider>
+        <ChatView />
+      </AuthProvider>
+    );
+
+    expect(screen.getByRole('combobox', { name: /speech language/i })).toHaveTextContent('Swedish');
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: 'runestone_user_data',
+          newValue: JSON.stringify({
+            id: '1',
+            email: 'test@example.com',
+            username: 'testuser',
+            mother_tongue: 'Finnish',
+          }),
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox', { name: /speech language/i })).toHaveTextContent('Finnish');
+    });
+  });
+
+  it('does not override stored speech language when profile updates later', async () => {
+    mockLocalStorage.getItem.mockImplementation((key) => {
+      if (key === 'runestone_token') return 'test-token';
+      if (key === 'runestone_stt_language') return 'German';
+      if (key === 'runestone_user_data') {
+        return JSON.stringify({
+          id: '1',
+          email: 'test@example.com',
+          username: 'testuser',
+        });
+      }
+      return null;
+    });
+
+    render(
+      <AuthProvider>
+        <ChatView />
+      </AuthProvider>
+    );
+
+    expect(screen.getByRole('combobox', { name: /speech language/i })).toHaveTextContent('German');
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: 'runestone_user_data',
+          newValue: JSON.stringify({
+            id: '1',
+            email: 'test@example.com',
+            username: 'testuser',
+            mother_tongue: 'Finnish',
+          }),
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox', { name: /speech language/i })).toHaveTextContent('German');
+    });
+  });
+
+  it('does not override manual speech language selection when profile updates later', async () => {
+    render(
+      <AuthProvider>
+        <ChatView />
+      </AuthProvider>
+    );
+
+    fireEvent.mouseDown(screen.getByRole('combobox', { name: /speech language/i }));
+    fireEvent.click(screen.getByRole('option', { name: 'German' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox', { name: /speech language/i })).toHaveTextContent('German');
+    });
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: 'runestone_user_data',
+          newValue: JSON.stringify({
+            id: '1',
+            email: 'test@example.com',
+            username: 'testuser',
+            mother_tongue: 'Finnish',
+          }),
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox', { name: /speech language/i })).toHaveTextContent('German');
+    });
+  });
+
   it('shows empty state when no messages', () => {
     render(
       <AuthProvider>

--- a/frontend/src/components/ChatView.test.tsx
+++ b/frontend/src/components/ChatView.test.tsx
@@ -73,15 +73,15 @@ const getSendButton = () => {
 };
 
 describe('ChatView', () => {
-  const resetLocalStorage = () => {
+  const resetLocalStorage = (userData: Record<string, unknown> = {
+    id: '1',
+    email: 'test@example.com',
+    username: 'testuser',
+  }) => {
     mockLocalStorage.getItem.mockImplementation((key) => {
       if (key === 'runestone_token') return 'test-token';
       if (key === 'runestone_user_data') {
-        return JSON.stringify({
-          id: '1',
-          email: 'test@example.com',
-          username: 'testuser',
-        });
+        return JSON.stringify(userData);
       }
       return null;
     });
@@ -106,6 +106,86 @@ describe('ChatView', () => {
       screen.getByText(/Ask questions about Swedish vocabulary, grammar/i)
     ).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Type your message...')).toBeInTheDocument();
+  });
+
+  it('defaults speech language from the user profile', () => {
+    resetLocalStorage({
+      id: '1',
+      email: 'test@example.com',
+      username: 'testuser',
+      mother_tongue: 'Finnish',
+    });
+
+    render(
+      <AuthProvider>
+        <ChatView />
+      </AuthProvider>
+    );
+
+    expect(screen.getByRole('combobox', { name: /speech language/i })).toHaveTextContent('Finnish');
+  });
+
+  it('uses stored speech language before profile language', () => {
+    mockLocalStorage.getItem.mockImplementation((key) => {
+      if (key === 'runestone_token') return 'test-token';
+      if (key === 'runestone_stt_language') return 'German';
+      if (key === 'runestone_user_data') {
+        return JSON.stringify({
+          id: '1',
+          email: 'test@example.com',
+          username: 'testuser',
+          mother_tongue: 'Finnish',
+        });
+      }
+      return null;
+    });
+
+    render(
+      <AuthProvider>
+        <ChatView />
+      </AuthProvider>
+    );
+
+    expect(screen.getByRole('combobox', { name: /speech language/i })).toHaveTextContent('German');
+  });
+
+  it('falls back to profile language when stored speech language is unsupported', () => {
+    mockLocalStorage.getItem.mockImplementation((key) => {
+      if (key === 'runestone_token') return 'test-token';
+      if (key === 'runestone_stt_language') return 'Klingon';
+      if (key === 'runestone_user_data') {
+        return JSON.stringify({
+          id: '1',
+          email: 'test@example.com',
+          username: 'testuser',
+          mother_tongue: 'Finnish',
+        });
+      }
+      return null;
+    });
+
+    render(
+      <AuthProvider>
+        <ChatView />
+      </AuthProvider>
+    );
+
+    expect(screen.getByRole('combobox', { name: /speech language/i })).toHaveTextContent('Finnish');
+  });
+
+  it('persists speech language changes', async () => {
+    render(
+      <AuthProvider>
+        <ChatView />
+      </AuthProvider>
+    );
+
+    fireEvent.mouseDown(screen.getByRole('combobox', { name: /speech language/i }));
+    fireEvent.click(screen.getByRole('option', { name: 'Finnish' }));
+
+    await waitFor(() => {
+      expect(mockLocalStorage.setItem).toHaveBeenCalledWith('runestone_stt_language', 'Finnish');
+    });
   });
 
   it('shows empty state when no messages', () => {

--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -98,6 +98,9 @@ const ChatView: React.FC = () => {
     const profileLanguage = getSupportedSpeechLanguage(userData?.mother_tongue);
     return stored ?? profileLanguage ?? "Swedish";
   });
+  const [hasSpeechLanguageOverride, setHasSpeechLanguageOverride] = useState(
+    () => getSupportedSpeechLanguage(localStorage.getItem(STT_LANGUAGE_KEY)) !== null,
+  );
 
   const {
     isRecording,
@@ -177,6 +180,17 @@ const ChatView: React.FC = () => {
   useEffect(() => {
     localStorage.setItem(STT_LANGUAGE_KEY, speechLanguage);
   }, [speechLanguage]);
+
+  useEffect(() => {
+    if (hasSpeechLanguageOverride) {
+      return;
+    }
+
+    const profileLanguage = getSupportedSpeechLanguage(userData?.mother_tongue);
+    if (profileLanguage && profileLanguage !== speechLanguage) {
+      setSpeechLanguage(profileLanguage);
+    }
+  }, [userData?.mother_tongue, speechLanguage, hasSpeechLanguageOverride]);
 
   // Show voice errors in snackbar
   useEffect(() => {
@@ -535,7 +549,10 @@ const ChatView: React.FC = () => {
                 </Typography>
                 <Select
                   value={speechLanguage}
-                  onChange={(e) => setSpeechLanguage(e.target.value)}
+                  onChange={(e) => {
+                    setHasSpeechLanguageOverride(true);
+                    setSpeechLanguage(e.target.value);
+                  }}
                   size="small"
                   variant="standard"
                   inputProps={{ "aria-label": "Speech language" }}

--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -28,14 +28,23 @@ import { useChat } from "../hooks/useChat";
 import { useChatImageUpload } from "../hooks/useChatImageUpload";
 import { useVoiceRecording } from "../hooks/useVoiceRecording";
 import { useAudioPlayback } from "../hooks/useAudioPlayback";
+import { useAuth } from "../context/AuthContext";
+import { LANGUAGES } from "../constants";
 
 const IMPROVE_TRANSCRIPTION_KEY = "runestone_improve_transcription";
 const VOICE_ENABLED_KEY = "runestone_voice_enabled";
 const SPEECH_SPEED_KEY = "runestone_speech_speed";
 const AUTOSEND_KEY = "runestone_autosend";
+const STT_LANGUAGE_KEY = "runestone_stt_language";
+
+const getSupportedSpeechLanguage = (language?: string | null) =>
+  language && LANGUAGES.includes(language as (typeof LANGUAGES)[number])
+    ? language
+    : null;
 
 const ChatView: React.FC = () => {
   const [inputMessage, setInputMessage] = useState("");
+  const { userData } = useAuth();
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const lastMessageRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -82,6 +91,14 @@ const ChatView: React.FC = () => {
     return stored === null ? false : stored === "true";
   });
 
+  const [speechLanguage, setSpeechLanguage] = useState(() => {
+    const stored = getSupportedSpeechLanguage(
+      localStorage.getItem(STT_LANGUAGE_KEY),
+    );
+    const profileLanguage = getSupportedSpeechLanguage(userData?.mother_tongue);
+    return stored ?? profileLanguage ?? "Swedish";
+  });
+
   const {
     isRecording,
     isProcessing: isTranscribing,
@@ -90,7 +107,7 @@ const ChatView: React.FC = () => {
     stopRecording,
     error: voiceError,
     clearError: clearVoiceError,
-  } = useVoiceRecording(improveTranscription);
+  } = useVoiceRecording(improveTranscription, speechLanguage);
 
   const {
     isPlaying: isAudioPlaying,
@@ -156,6 +173,10 @@ const ChatView: React.FC = () => {
   useEffect(() => {
     localStorage.setItem(AUTOSEND_KEY, String(autoSend));
   }, [autoSend]);
+
+  useEffect(() => {
+    localStorage.setItem(STT_LANGUAGE_KEY, speechLanguage);
+  }, [speechLanguage]);
 
   // Show voice errors in snackbar
   useEffect(() => {
@@ -507,6 +528,35 @@ const ChatView: React.FC = () => {
                   },
                 }}
               />
+
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                <Typography variant="caption" sx={{ color: "#9ca3af" }}>
+                  Speech language:
+                </Typography>
+                <Select
+                  value={speechLanguage}
+                  onChange={(e) => setSpeechLanguage(e.target.value)}
+                  size="small"
+                  variant="standard"
+                  inputProps={{ "aria-label": "Speech language" }}
+                  sx={{
+                    color: "#9ca3af",
+                    fontSize: "0.8rem",
+                    minWidth: 120,
+                    "& .MuiSelect-select": { py: 0, pr: 3 },
+                    "&:before": { borderColor: "#4b5563" },
+                    "&:hover:not(.Mui-disabled):before": {
+                      borderColor: "#9ca3af",
+                    },
+                  }}
+                >
+                  {LANGUAGES.map((language) => (
+                    <MenuItem key={language} value={language}>
+                      {language}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </Box>
             </Box>
           </Box>
 

--- a/frontend/src/components/auth/LanguageAutocomplete.tsx
+++ b/frontend/src/components/auth/LanguageAutocomplete.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Autocomplete, TextField, Box } from "@mui/material";
+import { LANGUAGES } from "../../constants";
 
 interface LanguageAutocompleteProps {
   label: string;
@@ -8,48 +9,6 @@ interface LanguageAutocompleteProps {
   error?: boolean;
   helperText?: string;
 }
-
-const LANGUAGES = [
-  "English",
-  "Russian",
-  "Spanish",
-  "French",
-  "German",
-  "Italian",
-  "Chinese",
-  "Japanese",
-  "Korean",
-  "Portuguese",
-  "Arabic",
-  "Dutch",
-  "Swedish",
-  "Finnish",
-  "Norwegian",
-  "Danish",
-  "Polish",
-  "Turkish",
-  "Vietnamese",
-  "Hindi",
-  "Bengali",
-  "Urdu",
-  "Czech",
-  "Slovak",
-  "Hungarian",
-  "Romanian",
-  "Greek",
-  "Hebrew",
-  "Indonesian",
-  "Thai",
-  "Malay",
-  "Persian",
-  "Bulgarian",
-  "Croatian",
-  "Serbian",
-  "Slovenian",
-  "Lithuanian",
-  "Latvian",
-  "Estonian",
-];
 
 const LanguageAutocomplete: React.FC<LanguageAutocompleteProps> = ({
   label,

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -9,3 +9,47 @@ export const VOCABULARY_IMPROVEMENT_MODES = {
 } as const;
 
 export type VocabularyImprovementMode = typeof VOCABULARY_IMPROVEMENT_MODES[keyof typeof VOCABULARY_IMPROVEMENT_MODES];
+
+export const LANGUAGES = [
+  "English",
+  "Russian",
+  "Spanish",
+  "French",
+  "German",
+  "Italian",
+  "Chinese",
+  "Japanese",
+  "Korean",
+  "Portuguese",
+  "Arabic",
+  "Dutch",
+  "Swedish",
+  "Finnish",
+  "Norwegian",
+  "Danish",
+  "Polish",
+  "Turkish",
+  "Vietnamese",
+  "Hindi",
+  "Bengali",
+  "Urdu",
+  "Czech",
+  "Slovak",
+  "Hungarian",
+  "Romanian",
+  "Greek",
+  "Hebrew",
+  "Indonesian",
+  "Thai",
+  "Malay",
+  "Persian",
+  "Bulgarian",
+  "Croatian",
+  "Serbian",
+  "Slovenian",
+  "Lithuanian",
+  "Latvian",
+  "Estonian",
+] as const;
+
+export type LanguageName = (typeof LANGUAGES)[number];

--- a/frontend/src/hooks/useVoiceRecording.test.tsx
+++ b/frontend/src/hooks/useVoiceRecording.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useVoiceRecording } from "./useVoiceRecording";
+
+const mockPost = vi.hoisted(() => vi.fn());
+
+vi.mock("../utils/api", () => ({
+  useApi: () => ({
+    post: mockPost,
+  }),
+}));
+
+vi.mock("../context/AuthContext", () => ({
+  useAuth: () => ({
+    token: "test-token",
+  }),
+}));
+
+class MockMediaRecorder {
+  ondataavailable: ((event: { data: Blob }) => void) | null = null;
+  onstop: (() => void) | null = null;
+
+  static isTypeSupported = vi.fn(() => true);
+
+  start = vi.fn();
+
+  stop = vi.fn(() => {
+    this.ondataavailable?.({ data: new Blob(["audio"], { type: "audio/webm" }) });
+    this.onstop?.();
+  });
+}
+
+const stream = {
+  getTracks: () => [
+    {
+      stop: vi.fn(),
+    },
+  ],
+};
+
+const TestComponent = () => {
+  const { startRecording, stopRecording } = useVoiceRecording(true, "Finnish");
+
+  return (
+    <>
+      <button type="button" onClick={() => void startRecording()}>
+        Start
+      </button>
+      <button type="button" onClick={() => void stopRecording()}>
+        Stop
+      </button>
+    </>
+  );
+};
+
+describe("useVoiceRecording", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPost.mockResolvedValue({ text: "Hei" });
+
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: vi.fn().mockResolvedValue(stream),
+      },
+    });
+    Object.defineProperty(window, "MediaRecorder", {
+      configurable: true,
+      value: MockMediaRecorder,
+    });
+    Object.defineProperty(globalThis, "MediaRecorder", {
+      configurable: true,
+      value: MockMediaRecorder,
+    });
+  });
+
+  it("includes selected language in the transcription form data", async () => {
+    render(<TestComponent />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Start" }));
+
+    await waitFor(() => {
+      expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({ audio: true });
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith(
+        "/api/chat/transcribe-voice",
+        expect.any(FormData),
+      );
+    });
+
+    const formData = mockPost.mock.calls[0][1] as FormData;
+    expect(formData.get("language")).toBe("Finnish");
+    expect(formData.get("improve")).toBe("true");
+    expect(formData.get("file")).toBeInstanceOf(Blob);
+  });
+});

--- a/frontend/src/hooks/useVoiceRecording.ts
+++ b/frontend/src/hooks/useVoiceRecording.ts
@@ -15,7 +15,10 @@ interface UseVoiceRecordingReturn {
 
 const MAX_DURATION_SECONDS = 300;
 
-export const useVoiceRecording = (improve: boolean = true): UseVoiceRecordingReturn => {
+export const useVoiceRecording = (
+  improve: boolean = true,
+  language?: string,
+): UseVoiceRecordingReturn => {
   const [isRecording, setIsRecording] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
   const [recordedDuration, setRecordedDuration] = useState(0);
@@ -157,6 +160,9 @@ export const useVoiceRecording = (improve: boolean = true): UseVoiceRecordingRet
           const formData = new FormData();
           formData.append('file', audioBlob, 'recording.webm');
           formData.append('improve', String(improve));
+          if (language) {
+            formData.append('language', language);
+          }
 
           const data = await post<{ text: string }>('/api/chat/transcribe-voice', formData);
 
@@ -172,7 +178,7 @@ export const useVoiceRecording = (improve: boolean = true): UseVoiceRecordingRet
 
       mediaRecorder.stop();
     });
-  }, [isRecording, improve, post, cleanup]);
+  }, [isRecording, improve, language, post, cleanup]);
 
   const cancelRecording = useCallback(() => {
     if (mediaRecorderRef.current && isRecording) {

--- a/src/runestone/api/chat_endpoints.py
+++ b/src/runestone/api/chat_endpoints.py
@@ -236,7 +236,12 @@ async def transcribe_voice(
             detail="Empty audio file.",
         )
 
-    transcription_language = _validate_transcription_language(language) or current_user.mother_tongue
+    transcription_language = _validate_transcription_language(language)
+    if transcription_language is None:
+        profile_language = current_user.mother_tongue.strip() if current_user.mother_tongue else None
+        transcription_language = (
+            profile_language if profile_language in SUPPORTED_TRANSCRIPTION_LANGUAGES else "Swedish"
+        )
 
     try:
         logger.info(f"User {current_user.email} requested voice transcription (improve={improve})")

--- a/src/runestone/api/chat_endpoints.py
+++ b/src/runestone/api/chat_endpoints.py
@@ -19,6 +19,7 @@ from runestone.agents.schemas import (
 )
 from runestone.auth.dependencies import get_current_user
 from runestone.config import settings
+from runestone.core.constants import LANGUAGE_CODE_MAP
 from runestone.core.exceptions import RunestoneError
 from runestone.db.models import User
 from runestone.dependencies import get_chat_service, get_voice_service
@@ -28,6 +29,23 @@ from runestone.services.voice_service import VoiceService
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+SUPPORTED_TRANSCRIPTION_LANGUAGES = set(LANGUAGE_CODE_MAP) | set(LANGUAGE_CODE_MAP.values())
+
+
+def _validate_transcription_language(language: str | None) -> str | None:
+    """Validate explicit speech-to-text language form values."""
+    if language is None:
+        return None
+
+    selected_language = language.strip()
+    if not selected_language or selected_language not in SUPPORTED_TRANSCRIPTION_LANGUAGES:
+        raise HTTPException(
+            status_code=400,
+            detail="Unsupported speech language.",
+        )
+
+    return selected_language
 
 
 @router.post("/message", response_model=ChatResponse)
@@ -181,6 +199,9 @@ async def start_new_chat(
 async def transcribe_voice(
     file: Annotated[UploadFile, File(description="Audio file to transcribe (WebM format)")],
     improve: Annotated[bool, Form(description="Whether to enhance the transcription")] = True,
+    language: Annotated[
+        str | None, Form(description="Speech language as a supported full name or ISO-639-1 code")
+    ] = None,
     voice_service: Annotated[VoiceService, Depends(get_voice_service)] = None,
     current_user: Annotated[User, Depends(get_current_user)] = None,
 ) -> VoiceTranscriptionResponse:
@@ -215,11 +236,12 @@ async def transcribe_voice(
             detail="Empty audio file.",
         )
 
+    transcription_language = _validate_transcription_language(language) or current_user.mother_tongue
+
     try:
         logger.info(f"User {current_user.email} requested voice transcription (improve={improve})")
-
         transcribed_text = await voice_service.process_voice_input(
-            content, improve=improve, language=current_user.mother_tongue
+            content, improve=improve, language=transcription_language
         )
 
         logger.info(f"Voice transcription completed for user {current_user.email}")

--- a/tests/api/test_chat_endpoints.py
+++ b/tests/api/test_chat_endpoints.py
@@ -441,3 +441,57 @@ async def test_transcribe_voice_rejects_unsupported_explicit_language(client_wit
         assert response.status_code == 400
         assert response.json()["detail"] == "Unsupported speech language."
         mock_voice_service.process_voice_input.assert_not_called()
+
+
+async def test_transcribe_voice_defaults_to_swedish_for_unsupported_profile_language(client_with_overrides):
+    """Test unsupported profile language falls back to Swedish."""
+    import io
+    from unittest.mock import AsyncMock, Mock
+
+    mock_voice_service = Mock()
+    mock_voice_service.process_voice_input = AsyncMock(return_value="Hej varlden")
+
+    async for client, mocks in client_with_overrides(voice_service=mock_voice_service):
+        mocks["current_user"].mother_tongue = "Klingon"
+        files = {"file": ("recording.webm", io.BytesIO(b"audio"), "audio/webm")}
+
+        response = await client.post(
+            "/api/chat/transcribe-voice",
+            files=files,
+            data={"improve": "true"},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"text": "Hej varlden"}
+        mock_voice_service.process_voice_input.assert_awaited_once_with(
+            b"audio",
+            improve=True,
+            language="Swedish",
+        )
+
+
+async def test_transcribe_voice_defaults_to_swedish_for_missing_profile_language(client_with_overrides):
+    """Test missing profile language falls back to Swedish."""
+    import io
+    from unittest.mock import AsyncMock, Mock
+
+    mock_voice_service = Mock()
+    mock_voice_service.process_voice_input = AsyncMock(return_value="Hej igen")
+
+    async for client, mocks in client_with_overrides(voice_service=mock_voice_service):
+        mocks["current_user"].mother_tongue = None
+        files = {"file": ("recording.webm", io.BytesIO(b"audio"), "audio/webm")}
+
+        response = await client.post(
+            "/api/chat/transcribe-voice",
+            files=files,
+            data={"improve": "true"},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"text": "Hej igen"}
+        mock_voice_service.process_voice_input.assert_awaited_once_with(
+            b"audio",
+            improve=True,
+            language="Swedish",
+        )

--- a/tests/api/test_chat_endpoints.py
+++ b/tests/api/test_chat_endpoints.py
@@ -365,3 +365,79 @@ async def test_send_image_whitespace_only_ocr(client_with_mock_agent_service, mo
 
     assert response.status_code == 400
     assert "Could not recognize text from image" in response.json()["detail"]
+
+
+async def test_transcribe_voice_uses_explicit_language(client_with_overrides):
+    """Test voice transcription prefers explicit form language over profile language."""
+    import io
+    from unittest.mock import AsyncMock, Mock
+
+    mock_voice_service = Mock()
+    mock_voice_service.process_voice_input = AsyncMock(return_value="Hei maailma")
+
+    async for client, mocks in client_with_overrides(voice_service=mock_voice_service):
+        mocks["current_user"].mother_tongue = "Spanish"
+        files = {"file": ("recording.webm", io.BytesIO(b"audio"), "audio/webm")}
+
+        response = await client.post(
+            "/api/chat/transcribe-voice",
+            files=files,
+            data={"improve": "true", "language": "Finnish"},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"text": "Hei maailma"}
+        mock_voice_service.process_voice_input.assert_awaited_once_with(
+            b"audio",
+            improve=True,
+            language="Finnish",
+        )
+
+
+async def test_transcribe_voice_falls_back_to_profile_language(client_with_overrides):
+    """Test omitted voice language keeps the existing profile-language behavior."""
+    import io
+    from unittest.mock import AsyncMock, Mock
+
+    mock_voice_service = Mock()
+    mock_voice_service.process_voice_input = AsyncMock(return_value="Hola mundo")
+
+    async for client, mocks in client_with_overrides(voice_service=mock_voice_service):
+        mocks["current_user"].mother_tongue = "Spanish"
+        files = {"file": ("recording.webm", io.BytesIO(b"audio"), "audio/webm")}
+
+        response = await client.post(
+            "/api/chat/transcribe-voice",
+            files=files,
+            data={"improve": "true"},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"text": "Hola mundo"}
+        mock_voice_service.process_voice_input.assert_awaited_once_with(
+            b"audio",
+            improve=True,
+            language="Spanish",
+        )
+
+
+async def test_transcribe_voice_rejects_unsupported_explicit_language(client_with_overrides):
+    """Test unsupported explicit voice languages are rejected before transcription."""
+    import io
+    from unittest.mock import AsyncMock, Mock
+
+    mock_voice_service = Mock()
+    mock_voice_service.process_voice_input = AsyncMock(return_value="ignored")
+
+    async for client, _mocks in client_with_overrides(voice_service=mock_voice_service):
+        files = {"file": ("recording.webm", io.BytesIO(b"audio"), "audio/webm")}
+
+        response = await client.post(
+            "/api/chat/transcribe-voice",
+            files=files,
+            data={"improve": "true", "language": "Klingon"},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Unsupported speech language."
+        mock_voice_service.process_voice_input.assert_not_called()


### PR DESCRIPTION
## Summary
- Add a shared frontend language list and reuse it in profile language autocomplete and chat voice controls
- Add a "Speech language" selector in chat that initializes from local storage, then user profile `mother_tongue`, then defaults to `Swedish`
- Persist selected STT language in local storage and send it with voice transcription requests
- Extend `/api/chat/transcribe-voice` to accept optional `language`, validate supported values, and fallback to profile language when omitted
- Add coverage for chat selector behavior, voice hook form payload, and backend explicit/fallback/invalid language handling
- Update Runestone orchestration skill guidance to prefer `feat/` and `fix/` branch naming

## Testing
- `make lint`
- `npm run build` (from `frontend/`)
- `uv run pytest tests/api/test_chat_endpoints.py tests/services/test_voice_service.py`
- `npm test -- --run src/components/ChatView.test.tsx src/components/ChatView.audio-controls.test.tsx src/hooks/useVoiceRecording.test.tsx`
- `make test`