### PR TITLE
Add ElevenLabs STT for chat voice input

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,7 @@ NEWS_AGENT_TEMPERATURE=0.0
 
 # Voice Transcription Configuration
 VOICE_TRANSCRIPTION_PROVIDER=openai
+# Use whisper-1 for OpenAI STT or scribe_v2 for ElevenLabs STT.
 VOICE_TRANSCRIPTION_MODEL=whisper-1
 VOICE_ENHANCEMENT_MODEL=gpt-4o-mini
 VOICE_MAX_DURATION_SECONDS=300

--- a/.env.test
+++ b/.env.test
@@ -79,6 +79,7 @@ NEWS_AGENT_TEMPERATURE=0.0
 
 # Voice Transcription Configuration
 VOICE_TRANSCRIPTION_PROVIDER=openai
+# Use whisper-1 for OpenAI STT or scribe_v2 for ElevenLabs STT.
 VOICE_TRANSCRIPTION_MODEL=whisper-1
 VOICE_ENHANCEMENT_MODEL=gpt-4o-mini
 VOICE_MAX_DURATION_SECONDS=300

--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ Design docs:
 
 **Voice Configuration:**
 - `VOICE_TRANSCRIPTION_PROVIDER`: Voice transcription provider (`openai` or `elevenlabs`, default: `openai`)
-- `VOICE_TRANSCRIPTION_MODEL`: Transcription model name (default: `whisper-1`)
+- `VOICE_TRANSCRIPTION_MODEL`: Provider-specific transcription model name (`whisper-1` for OpenAI, `scribe_v2` for ElevenLabs; default: `whisper-1`)
 - `VOICE_ENHANCEMENT_MODEL`: Post-transcription cleanup model (default: `gpt-4o-mini`)
 - `TTS_PROVIDER`: Text-to-speech provider (`openai` or `elevenlabs`, default: `openai`)
 - `TTS_MODEL`: OpenAI text-to-speech model (default: `gpt-4o-mini-tts`)
@@ -544,6 +544,10 @@ VOICE_TRANSCRIPTION_MODEL=whisper-1
 TTS_PROVIDER=openai
 TTS_MODEL=gpt-4o-mini-tts
 TTS_VOICE=onyx
+
+# ElevenLabs STT option
+# VOICE_TRANSCRIPTION_PROVIDER=elevenlabs
+# VOICE_TRANSCRIPTION_MODEL=scribe_v2
 
 # ElevenLabs settings (if using ElevenLabs for voice)
 ELEVENLABS_API_KEY=your_elevenlabs_api_key_here

--- a/docs/todo/elevenlabs-voice-migration-plan.md
+++ b/docs/todo/elevenlabs-voice-migration-plan.md
@@ -4,29 +4,31 @@
 
 Runestone does **not** use Whisper for both speech directions today.
 
-- Speech-to-text (voice recognition) currently uses OpenAI `whisper-1`.
-- Text-to-speech currently uses OpenAI `gpt-4o-mini-tts`.
+- Speech-to-text (voice recognition) defaults to OpenAI `whisper-1`, with ElevenLabs Scribe available through `VOICE_TRANSCRIPTION_PROVIDER=elevenlabs`.
+- Text-to-speech defaults to OpenAI `gpt-4o-mini-tts`, with ElevenLabs available through `TTS_PROVIDER=elevenlabs`.
 - The chat LLM flow itself is separate and does not depend on the voice provider.
 
-Because of that, the safest migration path is:
+The migration path is now:
 
 1. Switch **TTS first** to ElevenLabs.
-2. Keep transcription on OpenAI initially.
-3. Evaluate whether moving STT to ElevenLabs is worth the added scope.
+2. Add ElevenLabs STT behind the existing chat upload endpoint.
+3. Compare OpenAI Whisper and ElevenLabs Scribe on real recordings before changing global defaults.
 
-This gives us the user-facing quality win with the smallest architecture change.
+This keeps global defaults conservative while allowing local/provider-level trials.
 
 ## Verified Current State
 
 ### Backend
 
 - `src/runestone/config.py`
+  - `voice_transcription_provider = "openai"`
   - `voice_transcription_model = "whisper-1"`
+  - use `voice_transcription_model = "scribe_v2"` when `VOICE_TRANSCRIPTION_PROVIDER=elevenlabs`
   - `tts_model = "gpt-4o-mini-tts"`
   - `tts_voice = "onyx"`
 - `src/runestone/services/voice_service.py`
-  - Uses `OpenAI.audio.transcriptions.create(...)`
-  - Optionally runs a second OpenAI chat completion to clean up the transcript
+  - Uses the configured transcription client for raw STT
+  - Optionally runs an OpenAI chat completion to clean up the transcript
 - `src/runestone/services/tts_service.py`
   - Uses `AsyncOpenAI.audio.speech.with_streaming_response.create(...)`
   - Streams MP3 chunks to the client over WebSocket
@@ -72,20 +74,20 @@ Useful docs:
 
 ## Recommendation
 
-### Recommended path: TTS-first migration
+### Recommended path: provider-level trials
 
-Move assistant speech generation to ElevenLabs first and leave transcription on OpenAI for now.
+Move assistant speech generation and speech recognition to ElevenLabs behind independent provider switches, while keeping OpenAI as the global default until real chat recordings prove the migration is better.
 
-Why this is the best first step:
+Why this is the safest path:
 
 - It targets the part users hear directly, where ElevenLabs is likely to matter most.
-- It avoids changing both upload transcription and reply playback at the same time.
+- It allows STT and TTS to be enabled independently.
 - It preserves the current frontend contract if we keep sending MP3 chunks over the existing `/api/ws/audio` socket.
 - It keeps rollback simple.
 
-### Optional later path: STT migration
+### STT comparison path
 
-Only move transcription after we compare real user recordings for:
+Before changing production defaults, compare OpenAI Whisper and ElevenLabs Scribe on:
 
 - Swedish accuracy
 - mixed-language handling
@@ -181,7 +183,7 @@ Create an ElevenLabs voice client that:
 Important compatibility note:
 
 - The current frontend expects MP3 chunks over `/api/ws/audio`.
-- Preserve that contract in phase 1 of the migration to avoid unnecessary frontend changes.
+- Preserve that contract to avoid unnecessary frontend changes.
 
 Files most likely touched:
 
@@ -208,9 +210,9 @@ Also verify:
 - end-of-stream signaling
 - reconnect behavior remains acceptable with the existing frontend hook
 
-### Phase 4: Optional ElevenLabs STT spike
+### Phase 4: ElevenLabs STT opt-in
 
-If we want a single vendor for voice, build a limited STT spike behind the same client seam.
+Build ElevenLabs STT behind the same client seam and keep it opt-in until comparison data supports changing defaults.
 
 Files most likely touched:
 
@@ -322,19 +324,21 @@ Check in the browser:
 3. Move existing OpenAI TTS/STT behind those interfaces.
 4. Implement ElevenLabs TTS.
 5. Validate streaming contract end to end.
-6. Decide whether STT should remain on OpenAI or move later.
+6. Add ElevenLabs STT as an opt-in provider.
+7. Decide whether OpenAI or ElevenLabs should become the production STT default after comparison.
 
 ## Bottom Line
 
 Today:
 
-- Whisper/OpenAI is used for **recognition**
-- OpenAI TTS is used for **speech output**
-- not Whisper for both
+- OpenAI Whisper is the default for **recognition**
+- ElevenLabs Scribe is available as an opt-in **recognition** provider
+- OpenAI TTS is the default for **speech output**
+- ElevenLabs TTS is available as an opt-in **speech output** provider
 
 Best next move:
 
-- migrate **assistant TTS to ElevenLabs first**
-- keep **voice transcription on OpenAI** until we run a focused STT comparison
+- compare OpenAI STT and ElevenLabs STT on real chat recordings
+- keep global defaults unchanged until that comparison is convincing
 
 That gives the cleanest path to better voice quality without taking on unnecessary migration risk all at once.

--- a/src/runestone/api/main.py
+++ b/src/runestone/api/main.py
@@ -21,7 +21,11 @@ from runestone.api.memory_endpoints import router as memory_router
 from runestone.api.user_endpoints import router as user_router
 from runestone.config import settings
 from runestone.core.clients.factory import create_llm_client
-from runestone.core.clients.voice.voice_factory import create_voice_synthesis_client, create_voice_transcription_client
+from runestone.core.clients.voice.voice_factory import (
+    create_voice_enhancement_client,
+    create_voice_synthesis_client,
+    create_voice_transcription_client,
+)
 from runestone.core.logging_config import setup_logging
 from runestone.db.database import setup_database
 from runestone.rag.index import GrammarIndex
@@ -63,6 +67,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     app.state.voice_service = VoiceService(
         settings=settings,
         transcription_client=create_voice_transcription_client(settings),
+        enhancement_client=create_voice_enhancement_client(settings),
     )
     yield
     # Shutdown

--- a/src/runestone/core/clients/voice/elevenlabs_voice_client.py
+++ b/src/runestone/core/clients/voice/elevenlabs_voice_client.py
@@ -1,22 +1,64 @@
 """
-ElevenLabs-backed voice client for text-to-speech synthesis.
+ElevenLabs-backed voice clients for STT and TTS.
 """
 
+import io
 from typing import AsyncIterator
 
 from elevenlabs import VoiceSettings
 from elevenlabs.client import AsyncElevenLabs
 
-from runestone.core.exceptions import APIKeyError, RunestoneError
 
-
-class ElevenLabsVoiceClient:
-    """Voice client that wraps ElevenLabs TTS streaming for Runestone."""
+class ElevenLabsSTTClient:
+    """ElevenLabs Scribe client for speech-to-text."""
 
     def __init__(
         self,
         api_key: str,
-        model_id: str,
+        transcription_model: str,
+    ):
+        """
+        Initialize the ElevenLabs STT client.
+
+        Args:
+            api_key: ElevenLabs API key
+            transcription_model: ElevenLabs speech-to-text model identifier
+        """
+        self._client = AsyncElevenLabs(api_key=api_key)
+        self._transcription_model = transcription_model
+
+    async def transcribe_audio(self, audio_content: bytes, language: str | None = None) -> str:
+        """
+        Transcribe raw audio bytes with ElevenLabs Scribe.
+
+        Args:
+            audio_content: Raw audio bytes from the browser recorder
+            language: Optional ISO-639-1 language code
+
+        Returns:
+            Transcribed text or an empty string when provider returns no text
+        """
+        audio_file = io.BytesIO(audio_content)
+        audio_file.name = "recording.webm"
+
+        params = {
+            "model_id": self._transcription_model,
+            "file": ("recording.webm", audio_file, "audio/webm"),
+        }
+        if language:
+            params["language_code"] = language
+
+        response = await self._client.speech_to_text.convert(**params)
+        return (getattr(response, "text", None) or "").strip()
+
+
+class ElevenLabsTTSClient:
+    """ElevenLabs client for streaming text-to-speech synthesis."""
+
+    def __init__(
+        self,
+        api_key: str,
+        tts_model_id: str,
         voice_id: str,
         output_format: str,
         stability: float,
@@ -25,11 +67,11 @@ class ElevenLabsVoiceClient:
         use_speaker_boost: bool,
     ):
         """
-        Initialize the ElevenLabs voice client.
+        Initialize the ElevenLabs TTS client.
 
         Args:
             api_key: ElevenLabs API key
-            model_id: ElevenLabs model identifier
+            tts_model_id: ElevenLabs text-to-speech model identifier
             voice_id: ElevenLabs voice identifier
             output_format: Requested audio format for generated speech
             stability: ElevenLabs stability tuning
@@ -37,20 +79,8 @@ class ElevenLabsVoiceClient:
             style: ElevenLabs style tuning
             use_speaker_boost: Whether to enable speaker boost
         """
-        if not api_key:
-            raise APIKeyError("ElevenLabs API key is required for voice features. Set ELEVENLABS_API_KEY.")
-        if not voice_id:
-            raise RunestoneError(
-                "ElevenLabs voice ID is required for TTS. Set ELEVENLABS_TTS_VOICE_ID when TTS_PROVIDER=elevenlabs."
-            )
-        if not output_format.startswith("mp3_"):
-            raise RunestoneError(
-                "ElevenLabs TTS output format must be an MP3 variant for browser playback. "
-                "Set ELEVENLABS_TTS_OUTPUT_FORMAT to an mp3_* value."
-            )
-
         self._client = AsyncElevenLabs(api_key=api_key)
-        self._model_id = model_id
+        self._tts_model_id = tts_model_id
         self._voice_id = voice_id
         self._output_format = output_format
         self._stability = stability
@@ -88,7 +118,7 @@ class ElevenLabsVoiceClient:
         async for chunk in self._client.text_to_speech.stream(
             voice_id=self._voice_id,
             text=text,
-            model_id=self._model_id,
+            model_id=self._tts_model_id,
             output_format=self._output_format,
             voice_settings=voice_settings,
         ):

--- a/src/runestone/core/clients/voice/openai_voice_client.py
+++ b/src/runestone/core/clients/voice/openai_voice_client.py
@@ -31,7 +31,7 @@ class OpenAISTTClient:
         Transcribe raw audio bytes into text.
 
         Args:
-            audio_content: Raw audio bytes (e.g., WebM, WAV, MP3)
+            audio_content: Raw audio bytes from the browser recorder (currently WebM Opus)
             language: Optional ISO-639-1 language code
 
         Returns:

--- a/src/runestone/core/clients/voice/openai_voice_client.py
+++ b/src/runestone/core/clients/voice/openai_voice_client.py
@@ -1,5 +1,5 @@
 """
-OpenAI-backed voice client for transcription, text enhancement, and TTS.
+OpenAI-backed voice clients for STT, transcript enhancement, and TTS.
 """
 
 import io
@@ -7,38 +7,24 @@ from typing import AsyncIterator
 
 from openai import AsyncOpenAI
 
-from runestone.core.exceptions import APIKeyError
 
-
-class OpenAIVoiceClient:
-    """Voice client that wraps OpenAI APIs used by Runestone voice services."""
+class OpenAISTTClient:
+    """OpenAI client for speech-to-text transcription."""
 
     def __init__(
         self,
         api_key: str,
         transcription_model: str,
-        enhancement_model: str,
-        tts_model: str,
-        tts_voice: str,
     ):
         """
-        Initialize OpenAI voice clients.
+        Initialize OpenAI STT client.
 
         Args:
             api_key: OpenAI API key
             transcription_model: Model used for speech-to-text
-            enhancement_model: Model used for transcript cleanup
-            tts_model: Model used for speech synthesis
-            tts_voice: OpenAI voice identifier
         """
-        if not api_key:
-            raise APIKeyError("OpenAI API key is required for voice features. Set OPENAI_API_KEY.")
-
         self._async_client = AsyncOpenAI(api_key=api_key)
         self._transcription_model = transcription_model
-        self._enhancement_model = enhancement_model
-        self._tts_model = tts_model
-        self._tts_voice = tts_voice
 
     async def transcribe_audio(self, audio_content: bytes, language: str | None = None) -> str:
         """
@@ -64,6 +50,25 @@ class OpenAIVoiceClient:
         response = await self._async_client.audio.transcriptions.create(**params)
         return (response.text or "").strip()
 
+
+class OpenAIVoiceEnhancementClient:
+    """OpenAI client for transcript cleanup."""
+
+    def __init__(
+        self,
+        api_key: str,
+        enhancement_model: str,
+    ):
+        """
+        Initialize OpenAI transcript enhancement client.
+
+        Args:
+            api_key: OpenAI API key
+            enhancement_model: Model used for transcript cleanup
+        """
+        self._async_client = AsyncOpenAI(api_key=api_key)
+        self._enhancement_model = enhancement_model
+
     async def enhance_text(self, text: str, system_prompt: str) -> str:
         """
         Improve transcript quality using a system prompt.
@@ -83,6 +88,28 @@ class OpenAIVoiceClient:
             ],
         )
         return (response.choices[0].message.content or "").strip()
+
+
+class OpenAITTSClient:
+    """OpenAI client for streaming text-to-speech synthesis."""
+
+    def __init__(
+        self,
+        api_key: str,
+        tts_model: str,
+        tts_voice: str,
+    ):
+        """
+        Initialize OpenAI TTS client.
+
+        Args:
+            api_key: OpenAI API key
+            tts_model: Model used for speech synthesis
+            tts_voice: OpenAI voice identifier
+        """
+        self._async_client = AsyncOpenAI(api_key=api_key)
+        self._tts_model = tts_model
+        self._tts_voice = tts_voice
 
     async def synthesize_speech_stream(self, text: str, speed: float = 1.0) -> AsyncIterator[bytes]:
         """

--- a/src/runestone/core/clients/voice/voice_factory.py
+++ b/src/runestone/core/clients/voice/voice_factory.py
@@ -5,16 +5,24 @@ Factory helpers and contracts for voice provider clients.
 from typing import AsyncIterator, Protocol
 
 from runestone.config import Settings
-from runestone.core.clients.voice.elevenlabs_voice_client import ElevenLabsVoiceClient
-from runestone.core.clients.voice.openai_voice_client import OpenAIVoiceClient
-from runestone.core.exceptions import RunestoneError
+from runestone.core.clients.voice.elevenlabs_voice_client import ElevenLabsSTTClient, ElevenLabsTTSClient
+from runestone.core.clients.voice.openai_voice_client import (
+    OpenAISTTClient,
+    OpenAITTSClient,
+    OpenAIVoiceEnhancementClient,
+)
+from runestone.core.exceptions import APIKeyError, RunestoneError
 
 
 class VoiceTranscriptionClient(Protocol):
-    """Contract for speech-to-text and transcript cleanup providers."""
+    """Contract for speech-to-text providers."""
 
     async def transcribe_audio(self, audio_content: bytes, language: str | None = None) -> str:
         """Transcribe raw audio bytes to text."""
+
+
+class VoiceEnhancementClient(Protocol):
+    """Contract for transcript cleanup providers."""
 
     async def enhance_text(self, text: str, system_prompt: str) -> str:
         """Enhance transcript text with provider-specific language model support."""
@@ -27,24 +35,105 @@ class VoiceSynthesisClient(Protocol):
         """Yield synthesized audio bytes for the input text."""
 
 
-def _create_openai_voice_client(settings: Settings) -> OpenAIVoiceClient:
-    """Create the OpenAI voice client using current app settings."""
-    return OpenAIVoiceClient(
-        api_key=settings.openai_api_key,
-        transcription_model=settings.voice_transcription_model,
-        enhancement_model=settings.voice_enhancement_model,
-        tts_model=settings.tts_model,
-        tts_voice=settings.tts_voice,
+def _require_value(value: str | None, message: str) -> str:
+    """Return a non-empty config value or raise a setup error."""
+    if value is None or not str(value).strip():
+        raise RunestoneError(message)
+    return str(value).strip()
+
+
+def _validate_openai_api_key(settings: Settings) -> str:
+    """Validate OpenAI API key for voice operations."""
+    api_key = settings.openai_api_key
+    if not api_key or not api_key.strip():
+        raise APIKeyError("OpenAI API key is required for voice features. Set OPENAI_API_KEY.")
+    return api_key
+
+
+def _validate_elevenlabs_api_key(settings: Settings) -> str:
+    """Validate ElevenLabs API key for voice operations."""
+    api_key = settings.elevenlabs_api_key
+    if not api_key or not api_key.strip():
+        raise APIKeyError("ElevenLabs API key is required for voice features. Set ELEVENLABS_API_KEY.")
+    return api_key
+
+
+def _create_openai_stt_client(settings: Settings) -> OpenAISTTClient:
+    """Create OpenAI STT client from validated config."""
+    api_key = _validate_openai_api_key(settings)
+    transcription_model = _require_value(
+        settings.voice_transcription_model,
+        "VOICE_TRANSCRIPTION_MODEL is required when VOICE_TRANSCRIPTION_PROVIDER=openai.",
+    )
+    return OpenAISTTClient(
+        api_key=api_key,
+        transcription_model=transcription_model,
     )
 
 
-def _create_elevenlabs_voice_client(settings: Settings) -> ElevenLabsVoiceClient:
-    """Create the ElevenLabs voice client using current app settings."""
-    return ElevenLabsVoiceClient(
-        api_key=settings.elevenlabs_api_key,
-        model_id=settings.elevenlabs_tts_model,
-        voice_id=settings.elevenlabs_tts_voice_id,
-        output_format=settings.elevenlabs_tts_output_format,
+def _create_openai_enhancement_client(settings: Settings) -> OpenAIVoiceEnhancementClient:
+    """Create OpenAI transcript enhancement client from validated config."""
+    api_key = _validate_openai_api_key(settings)
+    enhancement_model = _require_value(
+        settings.voice_enhancement_model,
+        "VOICE_ENHANCEMENT_MODEL is required for transcript cleanup.",
+    )
+    return OpenAIVoiceEnhancementClient(
+        api_key=api_key,
+        enhancement_model=enhancement_model,
+    )
+
+
+def _create_openai_tts_client(settings: Settings) -> OpenAITTSClient:
+    """Create OpenAI TTS client from validated config."""
+    api_key = _validate_openai_api_key(settings)
+    tts_model = _require_value(settings.tts_model, "TTS_MODEL is required when TTS_PROVIDER=openai.")
+    tts_voice = _require_value(settings.tts_voice, "TTS_VOICE is required when TTS_PROVIDER=openai.")
+    return OpenAITTSClient(
+        api_key=api_key,
+        tts_model=tts_model,
+        tts_voice=tts_voice,
+    )
+
+
+def _create_elevenlabs_stt_client(settings: Settings) -> ElevenLabsSTTClient:
+    """Create ElevenLabs STT client from validated config."""
+    api_key = _validate_elevenlabs_api_key(settings)
+    transcription_model = _require_value(
+        settings.voice_transcription_model,
+        "VOICE_TRANSCRIPTION_MODEL is required when VOICE_TRANSCRIPTION_PROVIDER=elevenlabs.",
+    )
+    return ElevenLabsSTTClient(
+        api_key=api_key,
+        transcription_model=transcription_model,
+    )
+
+
+def _create_elevenlabs_tts_client(settings: Settings) -> ElevenLabsTTSClient:
+    """Create ElevenLabs TTS client from validated config."""
+    api_key = _validate_elevenlabs_api_key(settings)
+    voice_id = _require_value(
+        settings.elevenlabs_tts_voice_id,
+        "ElevenLabs voice ID is required for TTS. Set ELEVENLABS_TTS_VOICE_ID when TTS_PROVIDER=elevenlabs.",
+    )
+    model_id = _require_value(
+        settings.elevenlabs_tts_model,
+        "ELEVENLABS_TTS_MODEL is required when TTS_PROVIDER=elevenlabs.",
+    )
+    output_format = _require_value(
+        settings.elevenlabs_tts_output_format,
+        "ELEVENLABS_TTS_OUTPUT_FORMAT is required when TTS_PROVIDER=elevenlabs.",
+    )
+    if not output_format.startswith("mp3_"):
+        raise RunestoneError(
+            "ElevenLabs TTS output format must be an MP3 variant for browser playback. "
+            "Set ELEVENLABS_TTS_OUTPUT_FORMAT to an mp3_* value."
+        )
+    return ElevenLabsTTSClient(
+        api_key=api_key,
+        tts_model_id=model_id,
+        voice_id=voice_id,
+        output_format=output_format,
         stability=settings.elevenlabs_tts_stability,
         similarity_boost=settings.elevenlabs_tts_similarity_boost,
         style=settings.elevenlabs_tts_style,
@@ -60,13 +149,15 @@ def create_voice_transcription_client(settings: Settings) -> VoiceTranscriptionC
     """
     provider = settings.voice_transcription_provider.lower()
     if provider == "openai":
-        return _create_openai_voice_client(settings)
+        return _create_openai_stt_client(settings)
     if provider == "elevenlabs":
-        raise RunestoneError(
-            "VOICE_TRANSCRIPTION_PROVIDER=elevenlabs is not implemented yet. "
-            "Use VOICE_TRANSCRIPTION_PROVIDER=openai for now."
-        )
+        return _create_elevenlabs_stt_client(settings)
     raise RunestoneError(f"Unsupported voice transcription provider: {provider}")
+
+
+def create_voice_enhancement_client(settings: Settings) -> VoiceEnhancementClient:
+    """Create the transcript cleanup client used after any STT provider."""
+    return _create_openai_enhancement_client(settings)
 
 
 def create_voice_synthesis_client(settings: Settings) -> VoiceSynthesisClient:
@@ -77,7 +168,7 @@ def create_voice_synthesis_client(settings: Settings) -> VoiceSynthesisClient:
     """
     provider = settings.tts_provider.lower()
     if provider == "openai":
-        return _create_openai_voice_client(settings)
+        return _create_openai_tts_client(settings)
     if provider == "elevenlabs":
-        return _create_elevenlabs_voice_client(settings)
+        return _create_elevenlabs_tts_client(settings)
     raise RunestoneError(f"Unsupported TTS provider: {provider}")

--- a/src/runestone/services/voice_service.py
+++ b/src/runestone/services/voice_service.py
@@ -42,7 +42,7 @@ class VoiceService:
         Transcribe audio to text using the configured transcription provider.
 
         Args:
-            audio_content: Raw audio bytes (WebM, WAV, MP3, etc. supported by Whisper)
+            audio_content: Raw audio bytes from the browser recorder (currently WebM Opus)
             language: Optional ISO-639-1 language code
 
         Returns:
@@ -107,8 +107,8 @@ class VoiceService:
     async def process_voice_input(self, audio_content: bytes, improve: bool = True, language: str | None = None) -> str:
         """
         Process voice input:
-        1. Transcribe audio (Whisper handles auto-detection if language is None)
-        2. Optionally enhance text with GPT
+        1. Transcribe audio with the configured STT provider
+        2. Optionally enhance text with the configured cleanup model
 
         Args:
             audio_content: Raw audio bytes

--- a/src/runestone/services/voice_service.py
+++ b/src/runestone/services/voice_service.py
@@ -9,7 +9,7 @@ in voice clients.
 import logging
 
 from runestone.config import Settings
-from runestone.core.clients.voice.voice_factory import VoiceTranscriptionClient
+from runestone.core.clients.voice.voice_factory import VoiceEnhancementClient, VoiceTranscriptionClient
 from runestone.core.constants import LANGUAGE_CODE_MAP
 from runestone.core.exceptions import RunestoneError
 
@@ -17,18 +17,25 @@ logger = logging.getLogger(__name__)
 
 
 class VoiceService:
-    """Service for voice transcription and text enhancement."""
+    """Service coordinating speech-to-text and optional transcript cleanup."""
 
-    def __init__(self, settings: Settings, transcription_client: VoiceTranscriptionClient):
+    def __init__(
+        self,
+        settings: Settings,
+        transcription_client: VoiceTranscriptionClient,
+        enhancement_client: VoiceEnhancementClient,
+    ):
         """
         Initialize the voice service.
 
         Args:
             settings: Application settings containing model configuration
-            transcription_client: Provider client handling transcription and enhancement
+            transcription_client: Provider client handling raw transcription
+            enhancement_client: Provider client handling transcript cleanup
         """
         self.settings = settings
         self._transcription_client = transcription_client
+        self._enhancement_client = enhancement_client
 
     async def transcribe_audio(self, audio_content: bytes, language: str | None = None) -> str:
         """
@@ -80,7 +87,7 @@ class VoiceService:
                 "the original meaning and tone. Return only the corrected text."
                 "The text is transcribed so could have some mistakes, please correct them."
             )
-            enhanced_text = await self._transcription_client.enhance_text(
+            enhanced_text = await self._enhancement_client.enhance_text(
                 text=text,
                 system_prompt=system_prompt,
             )

--- a/tests/core/test_elevenlabs_voice_client.py
+++ b/tests/core/test_elevenlabs_voice_client.py
@@ -1,60 +1,82 @@
-"""Tests for the ElevenLabs voice client."""
+"""Tests for ElevenLabs STT/TTS clients."""
 
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-
-from runestone.core.clients.voice.elevenlabs_voice_client import ElevenLabsVoiceClient
-from runestone.core.exceptions import APIKeyError, RunestoneError
+from runestone.core.clients.voice.elevenlabs_voice_client import ElevenLabsSTTClient, ElevenLabsTTSClient
 
 
-class TestElevenLabsVoiceClient:
-    """Test cases for ElevenLabsVoiceClient."""
+class TestElevenLabsSTTClient:
+    """Test cases for ElevenLabs STT client."""
 
     @patch("runestone.core.clients.voice.elevenlabs_voice_client.AsyncElevenLabs")
-    def test_instantiation_requires_api_key(self, mock_client_class):
-        """Client should reject missing API key."""
-        with pytest.raises(APIKeyError, match="ElevenLabs API key is required"):
-            ElevenLabsVoiceClient(
-                api_key="",
-                model_id="eleven_multilingual_v2",
-                voice_id="voice-id",
-                output_format="mp3_44100_128",
-                stability=0.5,
-                similarity_boost=0.75,
-                style=0.0,
-                use_speaker_boost=True,
-            )
+    def test_instantiation_passes_api_key_to_sdk(self, mock_client_class):
+        """STT client should wire the API key into the async SDK."""
+        ElevenLabsSTTClient(
+            api_key="test-key",
+            transcription_model="scribe_v2",
+        )
+        mock_client_class.assert_called_once_with(api_key="test-key")
 
     @patch("runestone.core.clients.voice.elevenlabs_voice_client.AsyncElevenLabs")
-    def test_instantiation_requires_voice_id(self, mock_client_class):
-        """Client should reject missing voice ID for TTS."""
-        with pytest.raises(RunestoneError, match="ElevenLabs voice ID is required for TTS"):
-            ElevenLabsVoiceClient(
-                api_key="test-key",
-                model_id="eleven_multilingual_v2",
-                voice_id="",
-                output_format="mp3_44100_128",
-                stability=0.5,
-                similarity_boost=0.75,
-                style=0.0,
-                use_speaker_boost=True,
-            )
+    async def test_transcribe_audio_uses_speech_to_text_convert(self, mock_client_class):
+        """Client should send WebM bytes to ElevenLabs Scribe with optional language."""
+        mock_client = mock_client_class.return_value
+        mock_client.speech_to_text.convert = AsyncMock(return_value=SimpleNamespace(text=" hello "))
+
+        client = ElevenLabsSTTClient(
+            api_key="test-key",
+            transcription_model="scribe_v2",
+        )
+
+        result = await client.transcribe_audio(b"audio-bytes", language="sv")
+
+        assert result == "hello"
+        mock_client.speech_to_text.convert.assert_awaited_once()
+        call_kwargs = mock_client.speech_to_text.convert.await_args.kwargs
+        assert call_kwargs["model_id"] == "scribe_v2"
+        assert call_kwargs["language_code"] == "sv"
+        filename, audio_file, content_type = call_kwargs["file"]
+        assert filename == "recording.webm"
+        assert audio_file.name == "recording.webm"
+        assert audio_file.getvalue() == b"audio-bytes"
+        assert content_type == "audio/webm"
 
     @patch("runestone.core.clients.voice.elevenlabs_voice_client.AsyncElevenLabs")
-    def test_instantiation_rejects_non_mp3_output_format(self, mock_client_class):
-        """Client should fail fast on formats the browser playback path cannot decode."""
-        with pytest.raises(RunestoneError, match="output format must be an MP3 variant"):
-            ElevenLabsVoiceClient(
-                api_key="test-key",
-                model_id="eleven_multilingual_v2",
-                voice_id="voice-id",
-                output_format="opus_48000_128",
-                stability=0.5,
-                similarity_boost=0.75,
-                style=0.0,
-                use_speaker_boost=True,
-            )
+    async def test_transcribe_audio_omits_language_when_not_provided(self, mock_client_class):
+        """Client should let ElevenLabs auto-detect language when none is supplied."""
+        mock_client = mock_client_class.return_value
+        mock_client.speech_to_text.convert = AsyncMock(return_value=SimpleNamespace(text="hello"))
+
+        client = ElevenLabsSTTClient(
+            api_key="test-key",
+            transcription_model="scribe_v2",
+        )
+
+        result = await client.transcribe_audio(b"audio-bytes")
+
+        assert result == "hello"
+        call_kwargs = mock_client.speech_to_text.convert.await_args.kwargs
+        assert "language_code" not in call_kwargs
+
+    @patch("runestone.core.clients.voice.elevenlabs_voice_client.AsyncElevenLabs")
+    async def test_transcribe_audio_returns_empty_string_for_blank_response(self, mock_client_class):
+        """Client should normalize empty provider text to an empty string."""
+        mock_client = mock_client_class.return_value
+        mock_client.speech_to_text.convert = AsyncMock(return_value=SimpleNamespace(text="   "))
+
+        client = ElevenLabsSTTClient(
+            api_key="test-key",
+            transcription_model="scribe_v2",
+        )
+
+        result = await client.transcribe_audio(b"audio-bytes")
+
+        assert result == ""
+
+
+class TestElevenLabsTTSClient:
+    """Test cases for ElevenLabs TTS client."""
 
     @patch("runestone.core.clients.voice.elevenlabs_voice_client.VoiceSettings")
     @patch("runestone.core.clients.voice.elevenlabs_voice_client.AsyncElevenLabs")
@@ -69,9 +91,9 @@ class TestElevenLabsVoiceClient:
         mock_client.text_to_speech.stream = MagicMock(side_effect=stream_audio)
         mock_voice_settings.return_value = "voice-settings"
 
-        client = ElevenLabsVoiceClient(
+        client = ElevenLabsTTSClient(
             api_key="test-key",
-            model_id="eleven_multilingual_v2",
+            tts_model_id="eleven_multilingual_v2",
             voice_id="voice-id",
             output_format="mp3_44100_128",
             stability=0.5,

--- a/tests/core/test_elevenlabs_voice_client.py
+++ b/tests/core/test_elevenlabs_voice_client.py
@@ -3,6 +3,8 @@
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from runestone.core.clients.voice.elevenlabs_voice_client import ElevenLabsSTTClient, ElevenLabsTTSClient
 
 
@@ -19,6 +21,7 @@ class TestElevenLabsSTTClient:
         mock_client_class.assert_called_once_with(api_key="test-key")
 
     @patch("runestone.core.clients.voice.elevenlabs_voice_client.AsyncElevenLabs")
+    @pytest.mark.anyio
     async def test_transcribe_audio_uses_speech_to_text_convert(self, mock_client_class):
         """Client should send WebM bytes to ElevenLabs Scribe with optional language."""
         mock_client = mock_client_class.return_value
@@ -43,6 +46,7 @@ class TestElevenLabsSTTClient:
         assert content_type == "audio/webm"
 
     @patch("runestone.core.clients.voice.elevenlabs_voice_client.AsyncElevenLabs")
+    @pytest.mark.anyio
     async def test_transcribe_audio_omits_language_when_not_provided(self, mock_client_class):
         """Client should let ElevenLabs auto-detect language when none is supplied."""
         mock_client = mock_client_class.return_value
@@ -60,6 +64,7 @@ class TestElevenLabsSTTClient:
         assert "language_code" not in call_kwargs
 
     @patch("runestone.core.clients.voice.elevenlabs_voice_client.AsyncElevenLabs")
+    @pytest.mark.anyio
     async def test_transcribe_audio_returns_empty_string_for_blank_response(self, mock_client_class):
         """Client should normalize empty provider text to an empty string."""
         mock_client = mock_client_class.return_value
@@ -80,6 +85,7 @@ class TestElevenLabsTTSClient:
 
     @patch("runestone.core.clients.voice.elevenlabs_voice_client.VoiceSettings")
     @patch("runestone.core.clients.voice.elevenlabs_voice_client.AsyncElevenLabs")
+    @pytest.mark.anyio
     async def test_synthesize_speech_stream(self, mock_client_class, mock_voice_settings):
         """Client should stream raw bytes from ElevenLabs SDK."""
         mock_client = mock_client_class.return_value

--- a/tests/core/test_openai_voice_client.py
+++ b/tests/core/test_openai_voice_client.py
@@ -1,27 +1,25 @@
-"""Tests for the OpenAI voice client."""
+"""Tests for OpenAI voice capability clients."""
 
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from runestone.core.clients.voice.openai_voice_client import OpenAIVoiceClient
-from runestone.core.exceptions import APIKeyError
+from runestone.core.clients.voice.openai_voice_client import (
+    OpenAISTTClient,
+    OpenAITTSClient,
+    OpenAIVoiceEnhancementClient,
+)
 
 
 @patch("runestone.core.clients.voice.openai_voice_client.AsyncOpenAI")
-def test_instantiation_requires_api_key(mock_async_openai):
-    """Client should reject missing API key."""
-    with pytest.raises(APIKeyError, match="OpenAI API key is required"):
-        OpenAIVoiceClient(
-            api_key="",
-            transcription_model="whisper-1",
-            enhancement_model="gpt-4o-mini",
-            tts_model="gpt-4o-mini-tts",
-            tts_voice="alloy",
-        )
-
-    mock_async_openai.assert_not_called()
+def test_stt_instantiation_wires_api_key(mock_async_openai):
+    """STT client should pass API key into OpenAI async SDK."""
+    OpenAISTTClient(
+        api_key="test-key",
+        transcription_model="whisper-1",
+    )
+    mock_async_openai.assert_called_once_with(api_key="test-key")
 
 
 @pytest.mark.anyio
@@ -31,12 +29,9 @@ async def test_transcribe_audio_uses_async_client(mock_async_openai):
     mock_client = mock_async_openai.return_value
     mock_client.audio.transcriptions.create = AsyncMock(return_value=SimpleNamespace(text=" hello "))
 
-    client = OpenAIVoiceClient(
+    client = OpenAISTTClient(
         api_key="test-key",
         transcription_model="whisper-1",
-        enhancement_model="gpt-4o-mini",
-        tts_model="gpt-4o-mini-tts",
-        tts_voice="alloy",
     )
 
     result = await client.transcribe_audio(b"audio-bytes", language="sv")
@@ -51,18 +46,26 @@ async def test_transcribe_audio_uses_async_client(mock_async_openai):
 
 @pytest.mark.anyio
 @patch("runestone.core.clients.voice.openai_voice_client.AsyncOpenAI")
-async def test_enhance_text_uses_async_client(mock_async_openai):
+def test_enhancement_instantiation_wires_api_key(mock_async_openai):
+    """Enhancement client should pass API key into OpenAI async SDK."""
+    OpenAIVoiceEnhancementClient(
+        api_key="test-key",
+        enhancement_model="gpt-4o-mini",
+    )
+    mock_async_openai.assert_called_once_with(api_key="test-key")
+
+
+@pytest.mark.anyio
+@patch("runestone.core.clients.voice.openai_voice_client.AsyncOpenAI")
+async def test_enhancement_client_uses_async_chat_client(mock_async_openai):
     """Enhancement should call the async OpenAI chat client."""
     mock_client = mock_async_openai.return_value
     mock_response = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=" enhanced text "))])
     mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
 
-    client = OpenAIVoiceClient(
+    client = OpenAIVoiceEnhancementClient(
         api_key="test-key",
-        transcription_model="whisper-1",
         enhancement_model="gpt-4o-mini",
-        tts_model="gpt-4o-mini-tts",
-        tts_voice="alloy",
     )
 
     result = await client.enhance_text("raw text", "fix grammar")
@@ -75,3 +78,14 @@ async def test_enhance_text_uses_async_client(mock_async_openai):
             {"role": "user", "content": "raw text"},
         ],
     )
+
+
+@patch("runestone.core.clients.voice.openai_voice_client.AsyncOpenAI")
+def test_tts_instantiation_wires_api_key(mock_async_openai):
+    """TTS client should pass API key into OpenAI async SDK."""
+    OpenAITTSClient(
+        api_key="test-key",
+        tts_model="gpt-4o-mini-tts",
+        tts_voice="alloy",
+    )
+    mock_async_openai.assert_called_once_with(api_key="test-key")

--- a/tests/core/test_voice_factory.py
+++ b/tests/core/test_voice_factory.py
@@ -5,56 +5,112 @@ from unittest.mock import Mock, patch
 import pytest
 
 from runestone.config import Settings
-from runestone.core.clients.voice.voice_factory import create_voice_synthesis_client, create_voice_transcription_client
-from runestone.core.exceptions import RunestoneError
+from runestone.core.clients.voice.voice_factory import (
+    create_voice_enhancement_client,
+    create_voice_synthesis_client,
+    create_voice_transcription_client,
+)
+from runestone.core.exceptions import APIKeyError, RunestoneError
 
 
-@patch("runestone.core.clients.voice.voice_factory._create_openai_voice_client")
-def test_create_voice_transcription_client_openai(mock_create_openai):
+@patch("runestone.core.clients.voice.voice_factory._create_openai_stt_client")
+def test_create_voice_transcription_client_openai(mock_create_openai_stt):
     """OpenAI transcription provider should resolve to OpenAI voice client."""
     settings = Mock(spec=Settings)
     settings.voice_transcription_provider = "openai"
     expected = Mock()
-    mock_create_openai.return_value = expected
+    mock_create_openai_stt.return_value = expected
 
     result = create_voice_transcription_client(settings)
 
     assert result is expected
-    mock_create_openai.assert_called_once_with(settings)
+    mock_create_openai_stt.assert_called_once_with(settings)
 
 
-def test_create_voice_transcription_client_elevenlabs_not_implemented():
-    """ElevenLabs transcription provider is intentionally not available in phase 1."""
+@patch("runestone.core.clients.voice.voice_factory._create_elevenlabs_stt_client")
+def test_create_voice_transcription_client_elevenlabs(mock_create_elevenlabs_stt):
+    """ElevenLabs transcription provider should resolve to ElevenLabs voice client."""
     settings = Mock(spec=Settings)
     settings.voice_transcription_provider = "elevenlabs"
+    expected = Mock()
+    mock_create_elevenlabs_stt.return_value = expected
 
-    with pytest.raises(RunestoneError, match="VOICE_TRANSCRIPTION_PROVIDER=elevenlabs is not implemented yet"):
-        create_voice_transcription_client(settings)
+    result = create_voice_transcription_client(settings)
+
+    assert result is expected
+    mock_create_elevenlabs_stt.assert_called_once_with(settings)
 
 
-@patch("runestone.core.clients.voice.voice_factory._create_openai_voice_client")
-def test_create_voice_synthesis_client_openai(mock_create_openai):
+@patch("runestone.core.clients.voice.voice_factory._create_openai_enhancement_client")
+def test_create_voice_enhancement_client_uses_openai(mock_create_openai_enhancement):
+    """Transcript cleanup should stay on OpenAI regardless of raw STT provider."""
+    settings = Mock(spec=Settings)
+    expected = Mock()
+    mock_create_openai_enhancement.return_value = expected
+
+    result = create_voice_enhancement_client(settings)
+
+    assert result is expected
+    mock_create_openai_enhancement.assert_called_once_with(settings)
+
+
+@patch("runestone.core.clients.voice.voice_factory._create_openai_tts_client")
+def test_create_voice_synthesis_client_openai(mock_create_openai_tts):
     """OpenAI TTS provider should resolve to OpenAI voice client."""
     settings = Mock(spec=Settings)
     settings.tts_provider = "openai"
     expected = Mock()
-    mock_create_openai.return_value = expected
+    mock_create_openai_tts.return_value = expected
 
     result = create_voice_synthesis_client(settings)
 
     assert result is expected
-    mock_create_openai.assert_called_once_with(settings)
+    mock_create_openai_tts.assert_called_once_with(settings)
 
 
-@patch("runestone.core.clients.voice.voice_factory._create_elevenlabs_voice_client")
-def test_create_voice_synthesis_client_elevenlabs(mock_create_elevenlabs):
+@patch("runestone.core.clients.voice.voice_factory._create_elevenlabs_tts_client")
+def test_create_voice_synthesis_client_elevenlabs(mock_create_elevenlabs_tts):
     """ElevenLabs TTS provider should resolve to ElevenLabs voice client."""
     settings = Mock(spec=Settings)
     settings.tts_provider = "elevenlabs"
     expected = Mock()
-    mock_create_elevenlabs.return_value = expected
+    mock_create_elevenlabs_tts.return_value = expected
 
     result = create_voice_synthesis_client(settings)
 
     assert result is expected
-    mock_create_elevenlabs.assert_called_once_with(settings)
+    mock_create_elevenlabs_tts.assert_called_once_with(settings)
+
+
+def test_create_voice_synthesis_client_elevenlabs_requires_voice_id():
+    """Factory should fail fast when ElevenLabs API key is missing."""
+    settings = Mock(spec=Settings)
+    settings.tts_provider = "elevenlabs"
+    settings.elevenlabs_api_key = None
+
+    with pytest.raises(APIKeyError, match="ElevenLabs API key is required"):
+        create_voice_synthesis_client(settings)
+
+
+def test_create_voice_synthesis_client_elevenlabs_requires_mp3_output():
+    """Factory should fail fast when ElevenLabs TTS voice ID is missing."""
+    settings = Mock(spec=Settings)
+    settings.tts_provider = "elevenlabs"
+    settings.elevenlabs_api_key = "test-elevenlabs-key"
+    settings.elevenlabs_tts_voice_id = None
+
+    with pytest.raises(RunestoneError, match="ElevenLabs voice ID is required for TTS"):
+        create_voice_synthesis_client(settings)
+
+
+def test_create_voice_synthesis_client_elevenlabs_requires_mp3_format():
+    """Factory should fail fast when ElevenLabs TTS format is not MP3."""
+    settings = Mock(spec=Settings)
+    settings.tts_provider = "elevenlabs"
+    settings.elevenlabs_api_key = "test-elevenlabs-key"
+    settings.elevenlabs_tts_voice_id = "voice-id"
+    settings.elevenlabs_tts_model = "eleven_multilingual_v2"
+    settings.elevenlabs_tts_output_format = "opus_48000_128"
+
+    with pytest.raises(RunestoneError, match="output format must be an MP3 variant"):
+        create_voice_synthesis_client(settings)

--- a/tests/services/test_voice_service.py
+++ b/tests/services/test_voice_service.py
@@ -19,13 +19,19 @@ def mock_settings():
 def mock_transcription_client():
     client = MagicMock()
     client.transcribe_audio = AsyncMock(return_value="Hello world")
+    return client
+
+
+@pytest.fixture
+def mock_enhancement_client():
+    client = MagicMock()
     client.enhance_text = AsyncMock(return_value="Hello world.")
     return client
 
 
 @pytest.fixture
-def voice_service(mock_settings, mock_transcription_client):
-    return VoiceService(mock_settings, mock_transcription_client)
+def voice_service(mock_settings, mock_transcription_client, mock_enhancement_client):
+    return VoiceService(mock_settings, mock_transcription_client, mock_enhancement_client)
 
 
 @pytest.mark.anyio
@@ -67,31 +73,31 @@ async def test_transcribe_audio_api_error(voice_service, mock_transcription_clie
 
 
 @pytest.mark.anyio
-async def test_enhance_text_success(voice_service, mock_transcription_client):
+async def test_enhance_text_success(voice_service, mock_enhancement_client):
     """Test successful text enhancement."""
     original_text = "hello world"
     result = await voice_service.enhance_text(original_text)
 
     assert result == "Hello world."
-    assert mock_transcription_client.enhance_text.await_count == 1
-    call_kwargs = mock_transcription_client.enhance_text.call_args.kwargs
+    assert mock_enhancement_client.enhance_text.await_count == 1
+    call_kwargs = mock_enhancement_client.enhance_text.call_args.kwargs
     assert call_kwargs["text"] == original_text
     assert "Fix grammar, punctuation, and clarity" in call_kwargs["system_prompt"]
 
 
 @pytest.mark.anyio
-async def test_enhance_text_empty_response(voice_service, mock_transcription_client):
+async def test_enhance_text_empty_response(voice_service, mock_enhancement_client):
     """Test enhancement returning empty result (should return original)."""
-    mock_transcription_client.enhance_text.return_value = ""
+    mock_enhancement_client.enhance_text.return_value = ""
 
     result = await voice_service.enhance_text("original")
     assert result == "original"
 
 
 @pytest.mark.anyio
-async def test_enhance_text_api_error(voice_service, mock_transcription_client):
+async def test_enhance_text_api_error(voice_service, mock_enhancement_client):
     """Test enhancement API error (should return original)."""
-    mock_transcription_client.enhance_text.side_effect = Exception("API Error")
+    mock_enhancement_client.enhance_text.side_effect = Exception("API Error")
 
     result = await voice_service.enhance_text("original")
     assert result == "original"


### PR DESCRIPTION
## Summary
- add ElevenLabs Scribe STT behind VOICE_TRANSCRIPTION_PROVIDER=elevenlabs
- split voice provider clients by capability: STT, TTS, and transcript enhancement
- keep OpenAI transcript cleanup for improve=true and document provider-specific STT model values

## Checks
- make test
- make lint-check