### PR TITLE
fix: restore teacher answer-time in chat bubble

### DIFF
--- a/frontend/src/components/ui/ChatMessageBubble.test.tsx
+++ b/frontend/src/components/ui/ChatMessageBubble.test.tsx
@@ -188,7 +188,7 @@ describe("ChatMessageBubble", () => {
     expect(screen.queryByText("...")).not.toBeInTheDocument();
   });
 
-  it("does not render assistant response time as visible copy", () => {
+  it("renders assistant response time as visible copy", () => {
     render(
       <ChatMessageBubble
         role="assistant"
@@ -197,7 +197,7 @@ describe("ChatMessageBubble", () => {
       />,
     );
 
-    expect(screen.queryByText(/Teacher responded in/i)).not.toBeInTheDocument();
+    expect(screen.getByText("Teacher responded in 1.4 s")).toBeInTheDocument();
   });
 
   it("does not render response time for user messages", () => {

--- a/frontend/src/components/ui/ChatMessageBubble.tsx
+++ b/frontend/src/components/ui/ChatMessageBubble.tsx
@@ -386,31 +386,34 @@ export const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = ({
           <Box
             sx={{
               display: "flex",
-              justifyContent: "space-between",
               alignItems: "center",
               gap: 1,
               mt: 1,
             }}
           >
-            <Typography
-              sx={{
-                color: "rgba(255, 255, 255, 0.42)",
-                fontSize: "0.72rem",
-                lineHeight: 1,
-              }}
-            >
-              {responseTimeLabel}
-            </Typography>
-            <Typography
-              sx={{
-                color: "rgba(255, 255, 255, 0.42)",
-                fontSize: "0.72rem",
-                lineHeight: 1,
-                textAlign: "right",
-              }}
-            >
-              {messageTime}
-            </Typography>
+            {responseTimeLabel && (
+              <Typography
+                sx={{
+                  color: "rgba(255, 255, 255, 0.42)",
+                  fontSize: "0.72rem",
+                  lineHeight: 1,
+                }}
+              >
+                {responseTimeLabel}
+              </Typography>
+            )}
+            {messageTime && (
+              <Typography
+                sx={{
+                  color: "rgba(255, 255, 255, 0.42)",
+                  fontSize: "0.72rem",
+                  lineHeight: 1,
+                  ml: "auto",
+                }}
+              >
+                {messageTime}
+              </Typography>
+            )}
           </Box>
         )}
       </Box>

--- a/frontend/src/components/ui/ChatMessageBubble.tsx
+++ b/frontend/src/components/ui/ChatMessageBubble.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { TeacherAvatar } from "../chat/TeacherAvatar";
 import { AssistantMessageContent } from "./AssistantMessageContent";
+import { formatResponseTime } from "./ChatMessageBubble.utils";
 import type { TeacherEmotion } from "../../types/teacherEmotion";
 
 interface ChatMessageBubbleProps {
@@ -43,6 +44,7 @@ export const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = ({
   content,
   sources,
   teacherEmotion,
+  responseTimeMs,
   createdAt,
   isLast,
   isLatestByRole = false,
@@ -60,6 +62,14 @@ export const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = ({
   const isCollapsed = !shouldKeepExpanded && isLongMessage && !isExpanded;
   const hasSources = role === "assistant" && sources && sources.length > 0;
   const messageTime = formatMessageTime(createdAt);
+  const showResponseTime =
+    role === "assistant" &&
+    typeof responseTimeMs === "number" &&
+    Number.isFinite(responseTimeMs) &&
+    responseTimeMs >= 0;
+  const responseTimeLabel = showResponseTime
+    ? `Teacher responded in ${formatResponseTime(responseTimeMs)}`
+    : null;
   const resolveSafeUrl = (url: string) => {
     try {
       const parsed = new URL(url);
@@ -372,18 +382,36 @@ export const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = ({
             </Box>
           </Box>
         )}
-        {messageTime && (
-          <Typography
+        {(responseTimeLabel || messageTime) && (
+          <Box
             sx={{
-              color: "rgba(255, 255, 255, 0.42)",
-              fontSize: "0.72rem",
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              gap: 1,
               mt: 1,
-              textAlign: "right",
-              lineHeight: 1,
             }}
           >
-            {messageTime}
-          </Typography>
+            <Typography
+              sx={{
+                color: "rgba(255, 255, 255, 0.42)",
+                fontSize: "0.72rem",
+                lineHeight: 1,
+              }}
+            >
+              {responseTimeLabel}
+            </Typography>
+            <Typography
+              sx={{
+                color: "rgba(255, 255, 255, 0.42)",
+                fontSize: "0.72rem",
+                lineHeight: 1,
+                textAlign: "right",
+              }}
+            >
+              {messageTime}
+            </Typography>
+          </Box>
         )}
       </Box>
     </Box>


### PR DESCRIPTION
## Summary
- restore visible teacher answer-time metadata in assistant chat bubbles
- move answer-time label to the left side of the bubble footer
- keep message timestamp on the right side of the footer
- update ChatMessageBubble tests to assert the restored visible label

## Verification
- make test
- make lint-check