### PR TITLE
[codex] test teacher avatar crossfade

### DIFF
--- a/frontend/src/components/chat/TeacherAvatar.test.tsx
+++ b/frontend/src/components/chat/TeacherAvatar.test.tsx
@@ -1,0 +1,79 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TeacherAvatar } from "./TeacherAvatar";
+
+describe("TeacherAvatar", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps the previous emotion image during crossfade and clears it after the transition", () => {
+    vi.useFakeTimers();
+
+    const { container, rerender } = render(<TeacherAvatar emotion="neutral" />);
+
+    expect(
+      screen.getByRole("img", { name: /björn, your swedish teacher/i }),
+    ).toHaveAttribute("src", expect.stringContaining("bjorn_neutral"));
+    expect(container.querySelectorAll("img")).toHaveLength(1);
+
+    rerender(<TeacherAvatar emotion="happy" />);
+
+    expect(
+      screen.getByRole("img", { name: /björn, your swedish teacher/i }),
+    ).toHaveAttribute("src", expect.stringContaining("bjorn_happy"));
+    expect(container.querySelectorAll("img")).toHaveLength(2);
+    expect(container.querySelector("img[aria-hidden='true']")).toHaveAttribute(
+      "src",
+      expect.stringContaining("bjorn_neutral"),
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(1799);
+    });
+    expect(container.querySelectorAll("img")).toHaveLength(2);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(container.querySelectorAll("img")).toHaveLength(1);
+    expect(
+      screen.getByRole("img", { name: /björn, your swedish teacher/i }),
+    ).toHaveAttribute("src", expect.stringContaining("bjorn_happy"));
+  });
+
+  it("resets the cleanup timer when the emotion changes again mid-crossfade", () => {
+    vi.useFakeTimers();
+
+    const { container, rerender } = render(<TeacherAvatar emotion="neutral" />);
+
+    rerender(<TeacherAvatar emotion="happy" />);
+    act(() => {
+      vi.advanceTimersByTime(900);
+    });
+
+    rerender(<TeacherAvatar emotion="sad" />);
+
+    expect(
+      screen.getByRole("img", { name: /björn, your swedish teacher/i }),
+    ).toHaveAttribute("src", expect.stringContaining("bjorn_sad"));
+    expect(container.querySelectorAll("img")).toHaveLength(2);
+    expect(container.querySelector("img[aria-hidden='true']")).toHaveAttribute(
+      "src",
+      expect.stringContaining("bjorn_happy"),
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(900);
+    });
+    expect(container.querySelectorAll("img")).toHaveLength(2);
+
+    act(() => {
+      vi.advanceTimersByTime(900);
+    });
+    expect(container.querySelectorAll("img")).toHaveLength(1);
+    expect(
+      screen.getByRole("img", { name: /björn, your swedish teacher/i }),
+    ).toHaveAttribute("src", expect.stringContaining("bjorn_sad"));
+  });
+});

--- a/frontend/src/components/chat/TeacherAvatar.test.tsx
+++ b/frontend/src/components/chat/TeacherAvatar.test.tsx
@@ -1,15 +1,20 @@
 import { act, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TeacherAvatar } from "./TeacherAvatar";
 
 describe("TeacherAvatar", () => {
+  const CROSSFADE_MS = 1800;
+  const HALF_CROSSFADE_MS = CROSSFADE_MS / 2;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
   afterEach(() => {
     vi.useRealTimers();
   });
 
   it("keeps the previous emotion image during crossfade and clears it after the transition", () => {
-    vi.useFakeTimers();
-
     const { container, rerender } = render(<TeacherAvatar emotion="neutral" />);
 
     expect(
@@ -29,7 +34,7 @@ describe("TeacherAvatar", () => {
     );
 
     act(() => {
-      vi.advanceTimersByTime(1799);
+      vi.advanceTimersByTime(CROSSFADE_MS - 1);
     });
     expect(container.querySelectorAll("img")).toHaveLength(2);
 
@@ -43,13 +48,11 @@ describe("TeacherAvatar", () => {
   });
 
   it("resets the cleanup timer when the emotion changes again mid-crossfade", () => {
-    vi.useFakeTimers();
-
     const { container, rerender } = render(<TeacherAvatar emotion="neutral" />);
 
     rerender(<TeacherAvatar emotion="happy" />);
     act(() => {
-      vi.advanceTimersByTime(900);
+      vi.advanceTimersByTime(HALF_CROSSFADE_MS);
     });
 
     rerender(<TeacherAvatar emotion="sad" />);
@@ -64,12 +67,12 @@ describe("TeacherAvatar", () => {
     );
 
     act(() => {
-      vi.advanceTimersByTime(900);
+      vi.advanceTimersByTime(HALF_CROSSFADE_MS);
     });
     expect(container.querySelectorAll("img")).toHaveLength(2);
 
     act(() => {
-      vi.advanceTimersByTime(900);
+      vi.advanceTimersByTime(HALF_CROSSFADE_MS);
     });
     expect(container.querySelectorAll("img")).toHaveLength(1);
     expect(


### PR DESCRIPTION
## Summary
- Add focused tests for TeacherAvatar emotion crossfade behavior
- Cover previous image retention during the transition, cleanup after 1800ms, and timer reset on rapid emotion changes

## Validation
- cd frontend && npm run test:run -- src/components/chat/TeacherAvatar.test.tsx
- make frontend-test
- make frontend-lint