### PR TITLE
feat: add Telegram self-link fallback for RuneRecall

### DIFF
--- a/alembic/versions/6b7c2e1a9d4f_add_telegram_username_to_users.py
+++ b/alembic/versions/6b7c2e1a9d4f_add_telegram_username_to_users.py
@@ -10,7 +10,7 @@ from typing import Sequence, Union
 
 import sqlalchemy as sa
 
-from alembic import op
+from alembic import context, op
 
 # revision identifiers, used by Alembic.
 revision: str = "6b7c2e1a9d4f"
@@ -21,13 +21,19 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """Upgrade schema."""
-    with op.batch_alter_table("users", schema=None) as batch_op:
-        batch_op.add_column(sa.Column("telegram_username", sa.String(), nullable=True))
-        batch_op.create_index("ix_users_telegram_username", ["telegram_username"], unique=True)
+    op.add_column("users", sa.Column("telegram_username", sa.String(), nullable=True))
+    with context.get_context().autocommit_block():
+        op.create_index(
+            "ix_users_telegram_username",
+            "users",
+            ["telegram_username"],
+            unique=True,
+            postgresql_concurrently=True,
+        )
 
 
 def downgrade() -> None:
     """Downgrade schema."""
-    with op.batch_alter_table("users", schema=None) as batch_op:
-        batch_op.drop_index("ix_users_telegram_username")
-        batch_op.drop_column("telegram_username")
+    with context.get_context().autocommit_block():
+        op.drop_index("ix_users_telegram_username", table_name="users", postgresql_concurrently=True)
+    op.drop_column("users", "telegram_username")

--- a/alembic/versions/6b7c2e1a9d4f_add_telegram_username_to_users.py
+++ b/alembic/versions/6b7c2e1a9d4f_add_telegram_username_to_users.py
@@ -1,0 +1,33 @@
+"""add telegram_username to users
+
+Revision ID: 6b7c2e1a9d4f
+Revises: 2b8fd9c1a4e6
+Create Date: 2026-04-20 10:30:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "6b7c2e1a9d4f"
+down_revision: Union[str, Sequence[str], None] = "2b8fd9c1a4e6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table("users", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("telegram_username", sa.String(), nullable=True))
+        batch_op.create_index("ix_users_telegram_username", ["telegram_username"], unique=True)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("users", schema=None) as batch_op:
+        batch_op.drop_index("ix_users_telegram_username")
+        batch_op.drop_column("telegram_username")

--- a/frontend/src/components/auth/Profile.test.tsx
+++ b/frontend/src/components/auth/Profile.test.tsx
@@ -49,6 +49,7 @@ describe("Profile", () => {
     email: "test@example.com",
     name: "Test",
     surname: "User",
+    telegram_username: "someuser",
     mother_tongue: "English",
     timezone: "UTC",
     pages_recognised_count: 10,
@@ -94,6 +95,7 @@ describe("Profile", () => {
 
     expect(screen.getByDisplayValue("Test")).toBeInTheDocument(); // name
     expect(screen.getByDisplayValue("User")).toBeInTheDocument(); // surname
+    expect(screen.getByDisplayValue("someuser")).toBeInTheDocument(); // telegram_username
     expect(screen.getByDisplayValue("English")).toBeInTheDocument(); // mother_tongue
     expect(screen.getByDisplayValue("UTC")).toBeInTheDocument(); // timezone
   });
@@ -201,9 +203,57 @@ describe("Profile", () => {
         expect.objectContaining({
           name: "Test",
           surname: "User",
+          telegram_username: "someuser",
           timezone: "UTC",
         })
       );
+    });
+  });
+
+  it("submits changed Telegram username", async () => {
+    const updateProfileMock = vi.fn().mockResolvedValue({
+      ...mockUserData,
+      telegram_username: "newuser",
+    });
+
+    setupAuthActionsMock({
+      updateProfile: updateProfileMock,
+    });
+
+    render(<Profile />, { wrapper });
+
+    const telegramInput = screen.getByLabelText("Telegram Username");
+    const updateButton = screen.getByRole("button", { name: "Update Profile" });
+
+    await userEvent.clear(telegramInput);
+    await userEvent.type(telegramInput, "@NewUser");
+    await userEvent.click(updateButton);
+
+    await waitFor(() => {
+      expect(updateProfileMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          telegram_username: "@NewUser",
+        })
+      );
+    });
+  });
+
+  it("shows error when updating to duplicate Telegram username", async () => {
+    setupAuthActionsMock({
+      updateProfile: vi.fn().mockRejectedValue(new Error("Telegram username is already linked to another account")),
+    });
+
+    render(<Profile />, { wrapper });
+
+    const telegramInput = screen.getByLabelText("Telegram Username");
+    const updateButton = screen.getByRole("button", { name: "Update Profile" });
+
+    await userEvent.clear(telegramInput);
+    await userEvent.type(telegramInput, "@TakenUser");
+    await userEvent.click(updateButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("Telegram username is already linked to another account")).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/auth/Profile.tsx
+++ b/frontend/src/components/auth/Profile.tsx
@@ -14,6 +14,7 @@ const Profile: React.FC = () => {
   const [formData, setFormData] = useState<{
     name: string;
     surname: string;
+    telegram_username: string;
     mother_tongue: string;
     timezone: string;
     password: string;
@@ -22,6 +23,7 @@ const Profile: React.FC = () => {
   }>({
     name: "",
     surname: "",
+    telegram_username: "",
     mother_tongue: "",
     timezone: "UTC",
     password: "",
@@ -43,6 +45,7 @@ const Profile: React.FC = () => {
       setFormData({
         name: userData.name || "",
         surname: userData.surname || "",
+        telegram_username: userData.telegram_username || "",
         mother_tongue: userData.mother_tongue || "",
         timezone: userData.timezone || "UTC",
         password: "",
@@ -80,6 +83,7 @@ const Profile: React.FC = () => {
       const updateData: Record<string, string | null> = {
         name: formData.name || null,
         surname: formData.surname || null,
+        telegram_username: formData.telegram_username || null,
         mother_tongue: formData.mother_tongue || null,
         timezone: formData.timezone,
       };
@@ -173,6 +177,14 @@ const Profile: React.FC = () => {
         name="surname"
         value={formData.surname}
         onChange={(e) => handleChange("surname", e.target.value)}
+      />
+
+      <AuthTextField
+        label="Telegram Username"
+        name="telegram_username"
+        value={formData.telegram_username}
+        onChange={(e) => handleChange("telegram_username", e.target.value)}
+        helperText="Use your Telegram @username so RuneRecall can link /start to your account."
       />
 
       <LanguageAutocomplete

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -16,6 +16,7 @@ interface RegisterData extends LoginCredentials {
 interface UpdateProfileData {
   name?: string | null;
   surname?: string | null;
+  telegram_username?: string | null;
   timezone?: string;
   password?: string;
   email?: string;

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -4,6 +4,7 @@ export interface UserData {
   email: string;
   name: string | null;
   surname: string | null;
+  telegram_username?: string | null;
   mother_tongue?: string | null;
   timezone: string | null;
   pages_recognised_count: number;

--- a/recall_main.py
+++ b/recall_main.py
@@ -21,6 +21,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 from runestone.config import settings
 from runestone.core.logging_config import setup_logging
 from runestone.db.database import SessionLocal, setup_database
+from runestone.db.user_repository import UserRepository
 from runestone.db.vocabulary_repository import VocabularyRepository
 from runestone.services.rune_recall_service import RuneRecallService
 from runestone.services.telegram_command_service import TelegramCommandService
@@ -32,8 +33,9 @@ async def process_updates_job(state_manager: StateManager) -> None:
     async with SessionLocal() as db:
         try:
             vocabulary_repository = VocabularyRepository(db)
+            user_repository = UserRepository(db)
             recall_service = RuneRecallService(vocabulary_repository, state_manager, settings)
-            telegram_service = TelegramCommandService(state_manager, recall_service)
+            telegram_service = TelegramCommandService(state_manager, recall_service, user_repository)
             await telegram_service.process_updates()
         except Exception:
             logging.getLogger(__name__).exception("Error in process_updates_job")

--- a/src/runestone/api/schemas.py
+++ b/src/runestone/api/schemas.py
@@ -16,6 +16,7 @@ from runestone.constants import VOCABULARY_PRIORITY_DEFAULT, VOCABULARY_PRIORITY
 from runestone.core.prompt_builder.types import ImprovementMode
 from runestone.schemas.analysis import ContentAnalysis, GrammarFocus, VocabularyItem
 from runestone.schemas.ocr import OCRResult, RecognitionStatistics
+from runestone.utils.telegram import normalize_telegram_username
 
 # Define the public API contract
 __all__ = [
@@ -174,6 +175,7 @@ class UserProfileResponse(BaseModel):
     email: str
     name: str
     surname: Optional[str] = None
+    telegram_username: Optional[str] = None
     mother_tongue: Optional[str] = None
     timezone: str
     pages_recognised_count: int
@@ -190,6 +192,7 @@ class UserProfileUpdate(BaseModel):
 
     name: Optional[str] = None
     surname: Optional[str] = None
+    telegram_username: Optional[str] = None
     mother_tongue: Optional[str] = None
     timezone: Optional[str] = None
     password: Optional[str] = None
@@ -198,6 +201,12 @@ class UserProfileUpdate(BaseModel):
     personal_info: Optional[dict[str, Any] | str] = None
     areas_to_improve: Optional[dict[str, Any] | str] = None
     knowledge_strengths: Optional[dict[str, Any] | str] = None
+
+    @field_validator("telegram_username", mode="before")
+    @classmethod
+    def normalize_telegram_username_field(cls, v: Optional[str]) -> Optional[str]:
+        """Store Telegram usernames in the canonical lookup format."""
+        return normalize_telegram_username(v)
 
     @field_validator("personal_info", "areas_to_improve", "knowledge_strengths", mode="before")
     @classmethod

--- a/src/runestone/db/models.py
+++ b/src/runestone/db/models.py
@@ -37,6 +37,7 @@ class User(Base):
     hashed_password = Column(String, nullable=False)
     name = Column(String, nullable=False)
     surname = Column(String, nullable=True)
+    telegram_username = Column(String, unique=True, nullable=True, index=True)
     timezone = Column(String, default="UTC", nullable=False)
     pages_recognised_count = Column(Integer, default=0, nullable=False)
     mother_tongue = Column(String, nullable=True)  # User's preferred language

--- a/src/runestone/db/user_repository.py
+++ b/src/runestone/db/user_repository.py
@@ -28,6 +28,15 @@ class UserRepository:
         result = await self.db.execute(stmt)
         return result.scalars().first()
 
+    async def find_by_telegram_username(self, username: str | None) -> list[User]:
+        """Find users linked to a canonical Telegram username."""
+        if username is None:
+            return []
+
+        stmt = select(User).filter(User.telegram_username == username)
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())
+
     async def create(self, user: User) -> User:
         """Create a new user."""
         self.db.add(user)

--- a/src/runestone/services/telegram_command_service.py
+++ b/src/runestone/services/telegram_command_service.py
@@ -187,13 +187,7 @@ class TelegramCommandService:
         if user_data:
             return username, user_data
 
-        normalized_username = normalize_telegram_username(username)
-        if normalized_username and normalized_username != username:
-            user_data = self.state_manager.get_user(normalized_username)
-            if user_data:
-                return normalized_username, user_data
-
-        return normalized_username or username, None
+        return self.state_manager.get_user_by_normalized_telegram_username(username)
 
     async def _try_link_user_from_profile(self, username: str, chat_id: int) -> bool:
         """Link an active DB user into state.json when /start arrives first."""

--- a/src/runestone/services/telegram_command_service.py
+++ b/src/runestone/services/telegram_command_service.py
@@ -6,16 +6,25 @@ import httpx
 
 from runestone.config import settings
 from runestone.core.exceptions import VocabularyOperationError, WordNotFoundError, WordNotInSelectionError
+from runestone.db.user_repository import UserRepository
 from runestone.services.rune_recall_service import RuneRecallService
 from runestone.state.state_manager import StateManager
+from runestone.state.state_types import UserData
+from runestone.utils.telegram import normalize_telegram_username
 
 logger = logging.getLogger(__name__)
 
 
 class TelegramCommandService:
-    def __init__(self, state_manager: StateManager, rune_recall_service: RuneRecallService):
+    def __init__(
+        self,
+        state_manager: StateManager,
+        rune_recall_service: RuneRecallService,
+        user_repository: UserRepository | None = None,
+    ):
         self.state_manager = state_manager
         self.rune_recall_service = rune_recall_service
+        self.user_repository = user_repository
         self.bot_token = settings.telegram_bot_token
         if not self.bot_token:
             raise ValueError("Telegram bot token is required")
@@ -145,7 +154,7 @@ class TelegramCommandService:
         logger.info(f"Processing bot command '{text}' from {username} in chat {chat_id}")
 
         try:
-            user_data = self.state_manager.get_user(username)
+            state_username, user_data = self._get_state_user(username)
         except Exception as e:
             logger.error(f"Failed to get user data for {username}: {e}")
             return
@@ -153,7 +162,7 @@ class TelegramCommandService:
         if user_data:
             # Authorized user - process commands
             try:
-                await self._handle_authorized_user_command(text, message, username, user_data, chat_id)
+                await self._handle_authorized_user_command(text, message, state_username, user_data, chat_id)
             except Exception as e:
                 logger.error(f"Error processing command '{text}' for user {username}: {e}")
                 # Attempt to notify user of the error
@@ -162,12 +171,68 @@ class TelegramCommandService:
                 except Exception as send_error:
                     logger.error(f"Failed to send error message to user {username}: {send_error}")
         else:
+            if text == "/start" and await self._try_link_user_from_profile(username, chat_id):
+                return
+
             # Unauthorized user
             logger.warning(f"Unauthorized user {username} tried to access the bot")
             try:
                 await self._send_message(chat_id, "Sorry, you are not authorized to use this bot.")
             except Exception as e:
                 logger.error(f"Failed to send unauthorized message to {username}: {e}")
+
+    def _get_state_user(self, username: str) -> tuple[str, UserData | None]:
+        """Return user state by exact key, then by normalized Telegram username."""
+        user_data = self.state_manager.get_user(username)
+        if user_data:
+            return username, user_data
+
+        normalized_username = normalize_telegram_username(username)
+        if normalized_username and normalized_username != username:
+            user_data = self.state_manager.get_user(normalized_username)
+            if user_data:
+                return normalized_username, user_data
+
+        return normalized_username or username, None
+
+    async def _try_link_user_from_profile(self, username: str, chat_id: int) -> bool:
+        """Link an active DB user into state.json when /start arrives first."""
+        normalized_username = normalize_telegram_username(username)
+        if not normalized_username:
+            logger.warning("Cannot link Telegram user %s because no username was found in message", username)
+            return False
+
+        if self.user_repository is None:
+            logger.warning("Cannot link Telegram user %s because no user repository is configured", username)
+            return False
+
+        users = await self.user_repository.find_by_telegram_username(normalized_username)
+        if not users:
+            await self._send_message(
+                chat_id,
+                "I couldn't find a Runestone account linked to this Telegram username. "
+                "Add your Telegram username in Profile, then send /start again.",
+            )
+            return True
+
+        if len(users) > 1:
+            await self._send_message(
+                chat_id,
+                "This Telegram username is linked to multiple Runestone accounts. Please contact an administrator.",
+            )
+            logger.error("Telegram username %s matched multiple DB users", normalized_username)
+            return True
+
+        user = users[0]
+        if not user.active:
+            await self._send_message(chat_id, "Your Runestone account is not active. Please contact an administrator.")
+            return True
+
+        user_data = UserData(db_user_id=user.id, chat_id=chat_id, is_active=True, daily_selection=[], next_word_index=0)
+        self.state_manager.create_user(normalized_username, user_data)
+        await self._send_message(chat_id, "Bot started! You will receive daily vocabulary words.")
+        logger.info("Linked Telegram user %s to Runestone user %s", normalized_username, user.id)
+        return True
 
     async def _handle_authorized_user_command(
         self, text: str, message: dict, username: str, user_data, chat_id: int

--- a/src/runestone/services/user_service.py
+++ b/src/runestone/services/user_service.py
@@ -78,6 +78,7 @@ class UserService:
             email=user.email,
             name=user.name,
             surname=user.surname,
+            telegram_username=user.telegram_username,
             mother_tongue=user.mother_tongue,
             timezone=user.timezone,
             pages_recognised_count=user.pages_recognised_count,
@@ -101,6 +102,11 @@ class UserService:
             if existing_user is not None and existing_user.id != user.id:
                 raise ValueError("Email address is already registered by another user")
 
+        if update_data.telegram_username is not None and update_data.telegram_username != user.telegram_username:
+            existing_users = await self.user_repo.find_by_telegram_username(update_data.telegram_username)
+            if any(existing_user.id != user.id for existing_user in existing_users):
+                raise ValueError("Telegram username is already linked to another account")
+
         # Update user fields
         update_dict = update_data.model_dump(exclude_unset=True)
 
@@ -120,6 +126,12 @@ class UserService:
             error_str = str(e)
             if "users_email_key" in error_str or "UNIQUE constraint failed: users.email" in error_str:
                 raise ValueError("Email address is already registered by another user") from e
+            if (
+                "users_telegram_username_key" in error_str
+                or "ix_users_telegram_username" in error_str
+                or "UNIQUE constraint failed: users.telegram_username" in error_str
+            ):
+                raise ValueError("Telegram username is already linked to another account") from e
             raise
 
         return await self.get_user_profile(updated_user)

--- a/src/runestone/state/state_manager.py
+++ b/src/runestone/state/state_manager.py
@@ -163,6 +163,23 @@ class StateManager:
             logger.error(f"Failed to update user '{username}': {e}")
             raise
 
+    @with_lock
+    def create_user(self, username: str, user_data: UserData):
+        """Create a new user state entry for an already authorized account."""
+        try:
+            state = self._get_state()
+
+            if username in state.users:
+                raise ValueError(f"User '{username}' already exists.")
+
+            state.users[username] = user_data
+            self.save_state_to_file()
+            logger.debug(f"Created user state for '{username}'")
+
+        except Exception as e:
+            logger.error(f"Failed to create user state for '{username}': {e}")
+            raise
+
     def get_active_users(self) -> Dict[str, UserData]:
         """Get dictionary of active users (username -> UserData)."""
         try:

--- a/src/runestone/state/state_manager.py
+++ b/src/runestone/state/state_manager.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Optional
 
 from src.runestone.core.exceptions import UserNotAuthorised
 
+from ..utils.telegram import normalize_telegram_username
 from .state_config import StateManagerConfig
 from .state_exceptions import StateAccessError, StateCorruptionError
 from .state_types import StateData, UserData
@@ -136,6 +137,24 @@ class StateManager:
             return state.users.get(username)
         except Exception as e:
             logger.error(f"Failed to get user '{username}': {e}")
+            raise
+
+    @with_lock
+    def get_user_by_normalized_telegram_username(self, username: str) -> tuple[str, Optional[UserData]]:
+        """Get user data whose stored state key normalizes to the given Telegram username."""
+        try:
+            normalized_username = normalize_telegram_username(username)
+            if not normalized_username:
+                return username, None
+
+            state = self._get_state()
+            for state_username, user_data in state.users.items():
+                if normalize_telegram_username(state_username) == normalized_username:
+                    return state_username, user_data
+
+            return normalized_username, None
+        except Exception as e:
+            logger.error(f"Failed to get user by normalized Telegram username '{username}': {e}")
             raise
 
     @with_lock

--- a/src/runestone/utils/telegram.py
+++ b/src/runestone/utils/telegram.py
@@ -6,8 +6,5 @@ def normalize_telegram_username(username: str | None) -> str | None:
     if username is None:
         return None
 
-    normalized = username.strip()
-    if normalized.startswith("@"):
-        normalized = normalized[1:]
-    normalized = normalized.strip().lower()
+    normalized = username.strip().lstrip("@").strip().lower()
     return normalized or None

--- a/src/runestone/utils/telegram.py
+++ b/src/runestone/utils/telegram.py
@@ -1,0 +1,13 @@
+"""Helpers for Telegram integration."""
+
+
+def normalize_telegram_username(username: str | None) -> str | None:
+    """Return the canonical Telegram username used for account linking."""
+    if username is None:
+        return None
+
+    normalized = username.strip()
+    if normalized.startswith("@"):
+        normalized = normalized[1:]
+    normalized = normalized.strip().lower()
+    return normalized or None

--- a/tests/api/test_user_endpoints.py
+++ b/tests/api/test_user_endpoints.py
@@ -24,6 +24,7 @@ class TestUserProfileEndpoints:
         assert "test-" in data["email"] and "@example.com" in data["email"]
         assert data["name"] == "Test User"
         assert data["surname"] == "Testsson"
+        assert data["telegram_username"] is None
         assert data["timezone"] == "UTC"
         assert data["pages_recognised_count"] == 0
         assert "created_at" in data
@@ -226,6 +227,32 @@ class TestUserProfileEndpoints:
 
         # Verify email remains the same
         assert data["email"] == current_email
+
+    async def test_update_user_profile_telegram_username_success(self, client):
+        """Test successful normalized Telegram username update."""
+        update_payload = {
+            "telegram_username": " @SomeUser ",
+        }
+
+        response = await client.put("/api/me", json=update_payload)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["telegram_username"] == "someuser"
+
+    async def test_update_user_profile_telegram_username_duplicate(self, client, user_factory):
+        """Test user Telegram username update with duplicate username should fail."""
+        await user_factory(telegram_username="someuser")
+
+        update_payload = {
+            "telegram_username": "@SomeUser",
+        }
+
+        response = await client.put("/api/me", json=update_payload)
+
+        assert response.status_code == 400
+        data = response.json()
+        assert "Telegram username is already linked to another account" in data["detail"]
 
 
 class TestPageRecognitionCounter:

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -20,6 +20,7 @@ def mock_user_repo():
     mock = Mock()
     mock.get_by_id = AsyncMock()
     mock.get_by_email = AsyncMock()
+    mock.find_by_telegram_username = AsyncMock(return_value=[])
     mock.update = AsyncMock()
     mock.increment_pages_recognised_count = AsyncMock()
     mock.clear_user_memory = AsyncMock()
@@ -61,6 +62,7 @@ def user():
         hashed_password="hashedpassword",
         name="Test User",
         surname="Testsson",
+        telegram_username=None,
         timezone="UTC",
         pages_recognised_count=0,
         created_at=datetime.utcnow(),
@@ -79,6 +81,9 @@ def temp_state_file():
     import json
 
     with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        offset_file = os.path.join(os.path.dirname(f.name), "offset.txt")
+        if os.path.exists(offset_file):
+            os.unlink(offset_file)
         default_state = {
             "update_offset": 0,
             "users": {
@@ -90,3 +95,5 @@ def temp_state_file():
         f.flush()
         yield f.name
     os.unlink(f.name)
+    if os.path.exists(offset_file):
+        os.unlink(offset_file)

--- a/tests/services/test_state_manager.py
+++ b/tests/services/test_state_manager.py
@@ -13,6 +13,9 @@ from src.runestone.state.state_types import UserData, WordOfDay
 @pytest.fixture
 def temp_state_file():
     with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        offset_file = os.path.join(os.path.dirname(f.name), "offset.txt")
+        if os.path.exists(offset_file):
+            os.unlink(offset_file)
         default_state = {
             "users": {
                 "user1": {"db_user_id": 1, "chat_id": 123, "is_active": True, "daily_selection": [[1, "test"]]},
@@ -23,6 +26,8 @@ def temp_state_file():
         f.flush()
         yield f.name
     os.unlink(f.name)
+    if os.path.exists(offset_file):
+        os.unlink(offset_file)
 
 
 @pytest.fixture

--- a/tests/services/test_telegram_command_service.py
+++ b/tests/services/test_telegram_command_service.py
@@ -11,7 +11,7 @@ from runestone.db.models import User
 from runestone.services.rune_recall_service import RuneRecallService
 from runestone.services.telegram_command_service import TelegramCommandService
 from runestone.state.state_manager import StateManager
-from runestone.state.state_types import WordOfDay
+from runestone.state.state_types import UserData, WordOfDay
 from runestone.utils.markdown import escape_markdown
 
 
@@ -310,6 +310,52 @@ async def test_process_updates_unknown_start_links_active_profile_user(
     assert user_data.chat_id == 789
     assert user_data.is_active is True
     mock_user_repository.find_by_telegram_username.assert_awaited_once_with("someuser")
+    mock_client.post.assert_called_once_with(
+        "https://api.telegram.org/bottest_token/sendMessage",
+        json={"chat_id": 789, "text": "Bot started! You will receive daily vocabulary words."},
+    )
+
+
+@patch("runestone.services.telegram_command_service.httpx.AsyncClient")
+async def test_process_updates_uses_legacy_mixed_case_state_key(
+    mock_client_class, telegram_service_with_user_repo, state_manager, mock_user_repository
+):
+    state_manager.create_user(
+        "SomeUser",
+        UserData(db_user_id=7, chat_id=None, is_active=False, daily_selection=[]),
+    )
+    mock_client = MagicMock()
+
+    mock_get_response = MagicMock()
+    mock_get_response.json.return_value = {
+        "ok": True,
+        "result": [
+            {
+                "update_id": 4,
+                "message": {
+                    "message_id": 4,
+                    "from": {"username": "someuser"},
+                    "chat": {"id": 789},
+                    "text": "/start",
+                    "entities": [{"offset": 0, "length": 6, "type": "bot_command"}],
+                },
+            }
+        ],
+    }
+    mock_get_response.raise_for_status.return_value = None
+    mock_client.get = AsyncMock(return_value=mock_get_response)
+    mock_post_response = MagicMock()
+    mock_post_response.raise_for_status.return_value = None
+    mock_client.post = AsyncMock(return_value=mock_post_response)
+    mock_client_class.return_value.__aenter__.return_value = mock_client
+
+    await telegram_service_with_user_repo.process_updates()
+
+    user_data = state_manager.get_user("SomeUser")
+    assert user_data.chat_id == 789
+    assert user_data.is_active is True
+    assert state_manager.get_user("someuser") is None
+    mock_user_repository.find_by_telegram_username.assert_not_awaited()
     mock_client.post.assert_called_once_with(
         "https://api.telegram.org/bottest_token/sendMessage",
         json={"chat_id": 789, "text": "Bot started! You will receive daily vocabulary words."},

--- a/tests/services/test_telegram_command_service.py
+++ b/tests/services/test_telegram_command_service.py
@@ -7,6 +7,7 @@ import httpx
 import pytest
 
 from runestone.core.exceptions import WordNotFoundError, WordNotInSelectionError
+from runestone.db.models import User
 from runestone.services.rune_recall_service import RuneRecallService
 from runestone.services.telegram_command_service import TelegramCommandService
 from runestone.state.state_manager import StateManager
@@ -17,6 +18,9 @@ from runestone.utils.markdown import escape_markdown
 @pytest.fixture
 def temp_state_file():
     with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        offset_file = os.path.join(os.path.dirname(f.name), "offset.txt")
+        if os.path.exists(offset_file):
+            os.unlink(offset_file)
         default_state = {
             "users": {"authorized_user": {"db_user_id": 1, "chat_id": None, "is_active": False, "daily_selection": []}},
         }
@@ -24,6 +28,8 @@ def temp_state_file():
         f.flush()
         yield f.name
     os.unlink(f.name)
+    if os.path.exists(offset_file):
+        os.unlink(offset_file)
 
 
 @pytest.fixture
@@ -45,6 +51,13 @@ def mock_rune_recall_service():
 
 
 @pytest.fixture
+def mock_user_repository():
+    repo = MagicMock()
+    repo.find_by_telegram_username = AsyncMock(return_value=[])
+    return repo
+
+
+@pytest.fixture
 def telegram_service(state_manager, mock_rune_recall_service):
     with patch("runestone.services.telegram_command_service.settings") as mock_settings:
         mock_settings.telegram_bot_token = "test_token"
@@ -58,6 +71,17 @@ def telegram_service_with_deps(state_manager, mock_rune_recall_service):
         return TelegramCommandService(
             state_manager,
             rune_recall_service=mock_rune_recall_service,
+        )
+
+
+@pytest.fixture
+def telegram_service_with_user_repo(state_manager, mock_rune_recall_service, mock_user_repository):
+    with patch("runestone.services.telegram_command_service.settings") as mock_settings:
+        mock_settings.telegram_bot_token = "test_token"
+        return TelegramCommandService(
+            state_manager,
+            rune_recall_service=mock_rune_recall_service,
+            user_repository=mock_user_repository,
         )
 
 
@@ -245,6 +269,209 @@ async def test_process_updates_unauthorized(mock_client_class, telegram_service)
     mock_client.post.assert_called_once_with(
         "https://api.telegram.org/bottest_token/sendMessage",
         json={"chat_id": 456, "text": "Sorry, you are not authorized to use this bot."},
+    )
+
+
+@patch("runestone.services.telegram_command_service.httpx.AsyncClient")
+async def test_process_updates_unknown_start_links_active_profile_user(
+    mock_client_class, telegram_service_with_user_repo, state_manager, mock_user_repository
+):
+    db_user = User(id=7, email="linked@example.com", hashed_password="hash", name="Linked", active=True)
+    mock_user_repository.find_by_telegram_username.return_value = [db_user]
+    mock_client = MagicMock()
+
+    mock_get_response = MagicMock()
+    mock_get_response.json.return_value = {
+        "ok": True,
+        "result": [
+            {
+                "update_id": 4,
+                "message": {
+                    "message_id": 4,
+                    "from": {"username": "SomeUser"},
+                    "chat": {"id": 789},
+                    "text": "/start",
+                    "entities": [{"offset": 0, "length": 6, "type": "bot_command"}],
+                },
+            }
+        ],
+    }
+    mock_get_response.raise_for_status.return_value = None
+    mock_client.get = AsyncMock(return_value=mock_get_response)
+    mock_post_response = MagicMock()
+    mock_post_response.raise_for_status.return_value = None
+    mock_client.post = AsyncMock(return_value=mock_post_response)
+    mock_client_class.return_value.__aenter__.return_value = mock_client
+
+    await telegram_service_with_user_repo.process_updates()
+
+    user_data = state_manager.get_user("someuser")
+    assert user_data.db_user_id == 7
+    assert user_data.chat_id == 789
+    assert user_data.is_active is True
+    mock_user_repository.find_by_telegram_username.assert_awaited_once_with("someuser")
+    mock_client.post.assert_called_once_with(
+        "https://api.telegram.org/bottest_token/sendMessage",
+        json={"chat_id": 789, "text": "Bot started! You will receive daily vocabulary words."},
+    )
+
+
+@patch("runestone.services.telegram_command_service.httpx.AsyncClient")
+async def test_process_updates_unknown_start_without_profile_link(
+    mock_client_class, telegram_service_with_user_repo, mock_user_repository
+):
+    mock_user_repository.find_by_telegram_username.return_value = []
+    mock_client = MagicMock()
+
+    mock_get_response = MagicMock()
+    mock_get_response.json.return_value = {
+        "ok": True,
+        "result": [
+            {
+                "update_id": 5,
+                "message": {
+                    "message_id": 5,
+                    "from": {"username": "missing_user"},
+                    "chat": {"id": 790},
+                    "text": "/start",
+                    "entities": [{"offset": 0, "length": 6, "type": "bot_command"}],
+                },
+            }
+        ],
+    }
+    mock_get_response.raise_for_status.return_value = None
+    mock_client.get = AsyncMock(return_value=mock_get_response)
+    mock_post_response = MagicMock()
+    mock_post_response.raise_for_status.return_value = None
+    mock_client.post = AsyncMock(return_value=mock_post_response)
+    mock_client_class.return_value.__aenter__.return_value = mock_client
+
+    await telegram_service_with_user_repo.process_updates()
+
+    call_args = mock_client.post.call_args[1]["json"]
+    assert call_args["chat_id"] == 790
+    assert "Add your Telegram username in Profile" in call_args["text"]
+
+
+@patch("runestone.services.telegram_command_service.httpx.AsyncClient")
+async def test_process_updates_unknown_start_inactive_profile_user(
+    mock_client_class, telegram_service_with_user_repo, mock_user_repository
+):
+    db_user = User(id=8, email="inactive@example.com", hashed_password="hash", name="Inactive", active=False)
+    mock_user_repository.find_by_telegram_username.return_value = [db_user]
+    mock_client = MagicMock()
+
+    mock_get_response = MagicMock()
+    mock_get_response.json.return_value = {
+        "ok": True,
+        "result": [
+            {
+                "update_id": 6,
+                "message": {
+                    "message_id": 6,
+                    "from": {"username": "inactive_user"},
+                    "chat": {"id": 791},
+                    "text": "/start",
+                    "entities": [{"offset": 0, "length": 6, "type": "bot_command"}],
+                },
+            }
+        ],
+    }
+    mock_get_response.raise_for_status.return_value = None
+    mock_client.get = AsyncMock(return_value=mock_get_response)
+    mock_post_response = MagicMock()
+    mock_post_response.raise_for_status.return_value = None
+    mock_client.post = AsyncMock(return_value=mock_post_response)
+    mock_client_class.return_value.__aenter__.return_value = mock_client
+
+    await telegram_service_with_user_repo.process_updates()
+
+    mock_client.post.assert_called_once_with(
+        "https://api.telegram.org/bottest_token/sendMessage",
+        json={"chat_id": 791, "text": "Your Runestone account is not active. Please contact an administrator."},
+    )
+
+
+@patch("runestone.services.telegram_command_service.httpx.AsyncClient")
+async def test_process_updates_unknown_start_duplicate_profile_link(
+    mock_client_class, telegram_service_with_user_repo, mock_user_repository
+):
+    users = [
+        User(id=9, email="first@example.com", hashed_password="hash", name="First", active=True),
+        User(id=10, email="second@example.com", hashed_password="hash", name="Second", active=True),
+    ]
+    mock_user_repository.find_by_telegram_username.return_value = users
+    mock_client = MagicMock()
+
+    mock_get_response = MagicMock()
+    mock_get_response.json.return_value = {
+        "ok": True,
+        "result": [
+            {
+                "update_id": 8,
+                "message": {
+                    "message_id": 8,
+                    "from": {"username": "duplicate_user"},
+                    "chat": {"id": 793},
+                    "text": "/start",
+                    "entities": [{"offset": 0, "length": 6, "type": "bot_command"}],
+                },
+            }
+        ],
+    }
+    mock_get_response.raise_for_status.return_value = None
+    mock_client.get = AsyncMock(return_value=mock_get_response)
+    mock_post_response = MagicMock()
+    mock_post_response.raise_for_status.return_value = None
+    mock_client.post = AsyncMock(return_value=mock_post_response)
+    mock_client_class.return_value.__aenter__.return_value = mock_client
+
+    await telegram_service_with_user_repo.process_updates()
+
+    mock_client.post.assert_called_once_with(
+        "https://api.telegram.org/bottest_token/sendMessage",
+        json={
+            "chat_id": 793,
+            "text": "This Telegram username is linked to multiple Runestone accounts. "
+            "Please contact an administrator.",
+        },
+    )
+
+
+@patch("runestone.services.telegram_command_service.httpx.AsyncClient")
+async def test_process_updates_unknown_command_does_not_run_profile_fallback(
+    mock_client_class, telegram_service_with_user_repo, mock_user_repository
+):
+    mock_client = MagicMock()
+    mock_get_response = MagicMock()
+    mock_get_response.json.return_value = {
+        "ok": True,
+        "result": [
+            {
+                "update_id": 7,
+                "message": {
+                    "message_id": 7,
+                    "from": {"username": "unknown_user"},
+                    "chat": {"id": 792},
+                    "text": "/state",
+                    "entities": [{"offset": 0, "length": 6, "type": "bot_command"}],
+                },
+            }
+        ],
+    }
+    mock_get_response.raise_for_status.return_value = None
+    mock_client.get = AsyncMock(return_value=mock_get_response)
+    mock_post_response = MagicMock()
+    mock_post_response.raise_for_status.return_value = None
+    mock_client.post = AsyncMock(return_value=mock_post_response)
+    mock_client_class.return_value.__aenter__.return_value = mock_client
+
+    await telegram_service_with_user_repo.process_updates()
+
+    mock_user_repository.find_by_telegram_username.assert_not_awaited()
+    mock_client.post.assert_called_once_with(
+        "https://api.telegram.org/bottest_token/sendMessage",
+        json={"chat_id": 792, "text": "Sorry, you are not authorized to use this bot."},
     )
 
 

--- a/tests/services/test_user_service.py
+++ b/tests/services/test_user_service.py
@@ -284,3 +284,74 @@ class TestUserService:
         # Verify user attribute was updated
         assert user.mother_tongue == "Spanish"
         mock_user_repo.update.assert_called()
+
+    @pytest.mark.anyio
+    async def test_update_user_profile_normalizes_telegram_username(
+        self, user_service, mock_user_repo, mock_vocab_repo, user
+    ):
+        """Test updating Telegram username stores the canonical format."""
+        from runestone.api.schemas import UserProfileUpdate
+
+        mock_user_repo.find_by_telegram_username.return_value = []
+        mock_user_repo.update.return_value = user
+
+        update_data = UserProfileUpdate(telegram_username=" @SomeUser ")
+        await user_service.update_user_profile(user, update_data)
+
+        assert user.telegram_username == "someuser"
+        mock_user_repo.find_by_telegram_username.assert_called_once_with("someuser")
+        mock_user_repo.update.assert_called()
+
+    @pytest.mark.anyio
+    async def test_update_user_profile_clears_telegram_username(
+        self, user_service, mock_user_repo, mock_vocab_repo, user
+    ):
+        """Test clearing Telegram username."""
+        from runestone.api.schemas import UserProfileUpdate
+
+        user.telegram_username = "someuser"
+        mock_user_repo.update.return_value = user
+
+        update_data = UserProfileUpdate(telegram_username="")
+        await user_service.update_user_profile(user, update_data)
+
+        assert user.telegram_username is None
+        mock_user_repo.find_by_telegram_username.assert_not_called()
+        mock_user_repo.update.assert_called()
+
+    @pytest.mark.anyio
+    async def test_update_user_profile_duplicate_telegram_username(
+        self, user_service, mock_user_repo, mock_vocab_repo, user
+    ):
+        """Test duplicate Telegram username validation."""
+        from datetime import datetime
+
+        from runestone.api.schemas import UserProfileUpdate
+        from runestone.db.models import User
+
+        existing_user = User(
+            id=2,
+            email="existing@example.com",
+            hashed_password="hash",
+            name="Existing User",
+            surname="Test",
+            telegram_username="someuser",
+            timezone="UTC",
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+        )
+        mock_user_repo.find_by_telegram_username.return_value = [existing_user]
+
+        update_data = UserProfileUpdate(telegram_username="@SomeUser")
+
+        with pytest.raises(ValueError, match="Telegram username is already linked to another account"):
+            await user_service.update_user_profile(user, update_data)
+
+    @pytest.mark.anyio
+    async def test_get_user_profile_includes_telegram_username(self, user_service, mock_user_repo, user):
+        """Test user profile response includes Telegram username."""
+        user.telegram_username = "someuser"
+
+        profile = await user_service.get_user_profile(user)
+
+        assert profile.telegram_username == "someuser"

--- a/tests/services/test_user_service.py
+++ b/tests/services/test_user_service.py
@@ -295,7 +295,7 @@ class TestUserService:
         mock_user_repo.find_by_telegram_username.return_value = []
         mock_user_repo.update.return_value = user
 
-        update_data = UserProfileUpdate(telegram_username=" @SomeUser ")
+        update_data = UserProfileUpdate(telegram_username=" @@SomeUser ")
         await user_service.update_user_profile(user, update_data)
 
         assert user.telegram_username == "someuser"

--- a/tests/test_recall_main.py
+++ b/tests/test_recall_main.py
@@ -208,6 +208,7 @@ class TestRecallMain:
         mock_conn.run_sync.assert_called_once()
 
     @patch("recall_main.SessionLocal")
+    @patch("recall_main.UserRepository")
     @patch("recall_main.VocabularyRepository")
     @patch("recall_main.RuneRecallService")
     @patch("recall_main.TelegramCommandService")
@@ -217,6 +218,7 @@ class TestRecallMain:
         mock_telegram_service,
         mock_recall_service,
         mock_vocabulary_repository,
+        mock_user_repository,
         mock_session_local,
     ):
         """Test process_updates_job wrapper function."""
@@ -238,6 +240,7 @@ class TestRecallMain:
 
         # Verify services were created with fresh session
         mock_vocabulary_repository.assert_called_once_with(mock_db)
+        mock_user_repository.assert_called_once_with(mock_db)
         mock_recall_service.assert_called_once()
         mock_telegram_service.assert_called_once()
 


### PR DESCRIPTION
## Summary
- add unique nullable telegram_username on users with migration
- expose and normalize Telegram username in profile API and frontend profile form
- add start-command fallback linking for unknown Telegram users based on normalized DB username
- create missing state entry for active linked users and keep non-start unauthorized behavior
- add backend/api/frontend tests for normalization, duplicate handling, and fallback flow

## Validation
- make lint-check
- make backend-test
- make frontend-test
- cd frontend && npm run build
