### PR TITLE
[codex] fix grammar search URL test expectation

### DIFF
--- a/frontend/src/hooks/useGrammar.test.ts
+++ b/frontend/src/hooks/useGrammar.test.ts
@@ -132,7 +132,7 @@ describe('useGrammar', () => {
     });
 
     expect(mockFetch).toHaveBeenLastCalledWith(
-      'http://localhost:8010/api/grammar/search?query=adjective+comparison&top_k=3'
+      '/api/grammar/search?query=adjective+comparison&top_k=3'
     );
     expect(result.current.searchResults).toEqual(mockResults);
     expect(result.current.searchError).toBeNull();


### PR DESCRIPTION
## Summary

- Align the new grammar search hook test with the repo's relative API base URL contract.
- Keep the product code unchanged; the failing evidence was a stale test expectation.

## Root cause

`frontend/src/config.ts` uses `import.meta.env.VITE_API_BASE_URL || ''`, so grammar search fetches `/api/grammar/search?...` when no explicit API base URL is configured. The new test added in the recent grammar-search commits expected `http://localhost:8010/api/...` instead.

## Validation

- `cd frontend && npm run test:run -- src/hooks/useGrammar.test.ts src/components/GrammarView.test.tsx src/components/ui/SearchInput.test.tsx`
- `./.venv/bin/pytest tests/api/test_grammar_endpoints.py tests/services/test_grammar_service.py tests/rag/test_loader.py tests/rag/test_index.py tests/agents/test_grammar_tools.py -q`
