### PR TITLE
[codex] test grammar direct link loading

### DIFF
--- a/frontend/src/components/GrammarView.test.tsx
+++ b/frontend/src/components/GrammarView.test.tsx
@@ -584,6 +584,72 @@ describe("GrammarView", () => {
     expect(window.location.search).toContain("cheatsheet=verbs%2Fverb-forms");
   });
 
+  it("loads a direct categorized cheatsheet link after cheatsheets arrive", async () => {
+    const mockFetchCheatsheetContent = vi.fn().mockResolvedValue(undefined);
+    window.history.replaceState(
+      {},
+      "",
+      "/?view=grammar&cheatsheet=adjectives/adjectiv-komparation"
+    );
+
+    mockUseGrammar
+      .mockReturnValueOnce({
+        cheatsheets: [],
+        selectedCheatsheet: null,
+        searchResults: [],
+        loading: true,
+        error: null,
+        searchLoading: false,
+        searchError: null,
+        fetchCheatsheets: vi.fn(),
+        fetchCheatsheetContent: mockFetchCheatsheetContent,
+        searchGrammar: vi.fn(),
+        clearSearch: vi.fn(),
+      })
+      .mockReturnValue({
+        cheatsheets: [
+          {
+            filename: "adjectives/adjectiv-komparation.md",
+            title: "Adjectiv Komparation",
+            category: "adjectives",
+          },
+        ],
+        selectedCheatsheet: { content: "# Adjectiv Komparation" },
+        searchResults: [],
+        loading: false,
+        error: null,
+        searchLoading: false,
+        searchError: null,
+        fetchCheatsheets: vi.fn(),
+        fetchCheatsheetContent: mockFetchCheatsheetContent,
+        searchGrammar: vi.fn(),
+        clearSearch: vi.fn(),
+      });
+
+    const { rerender } = render(<GrammarView />);
+    expect(mockFetchCheatsheetContent).not.toHaveBeenCalled();
+
+    rerender(<GrammarView />);
+
+    await waitFor(() => {
+      expect(mockFetchCheatsheetContent).toHaveBeenCalledWith(
+        "adjectives/adjectiv-komparation.md"
+      );
+    });
+
+    await waitFor(() => {
+      const selectedCheatsheet = screen.getByRole("button", {
+        name: "Adjectiv Komparation",
+      });
+      expect(selectedCheatsheet.closest(".MuiCollapse-root")).not.toHaveStyle({
+        height: "0px",
+      });
+    });
+    expect(
+      await screen.findByRole("heading", { name: "Adjectiv Komparation" })
+    ).toBeInTheDocument();
+  });
+
   it("reacts to browser back by returning to grammar start page", async () => {
     const mockFetchCheatsheetContent = vi.fn().mockResolvedValue(undefined);
     window.history.replaceState({}, "", "/?view=grammar");

--- a/frontend/src/hooks/useGrammar.test.ts
+++ b/frontend/src/hooks/useGrammar.test.ts
@@ -132,7 +132,7 @@ describe('useGrammar', () => {
     });
 
     expect(mockFetch).toHaveBeenLastCalledWith(
-      'http://localhost:8010/api/grammar/search?query=adjective+comparison&top_k=3'
+      '/api/grammar/search?query=adjective+comparison&top_k=3'
     );
     expect(result.current.searchResults).toEqual(mockResults);
     expect(result.current.searchError).toBeNull();


### PR DESCRIPTION
## Summary
- Add focused coverage for loading a direct categorized grammar cheatsheet URL after the cheatsheet list arrives.
- Assert the deferred fetch, expanded category, and rendered markdown heading.
- Update the grammar search hook test to expect the current relative API base URL.

## Validation
- make frontend-test
- make frontend-lint
- git diff --check