### PR TITLE
fix: decode escaped unicode in WordKeeper save flow

### DIFF
--- a/src/runestone/agents/specialists/word_keeper.py
+++ b/src/runestone/agents/specialists/word_keeper.py
@@ -10,14 +10,19 @@ from typing import Literal
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.messages import HumanMessage, SystemMessage
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from runestone.agents.llm import build_chat_model
 from runestone.agents.service_providers import provide_vocabulary_service
 from runestone.agents.specialists.base import BaseSpecialist, SpecialistAction, SpecialistContext, SpecialistResult
 from runestone.config import Settings
 from runestone.core.observability import elapsed_ms_since
-from runestone.schemas.vocabulary_save import PriorityWordSaveItem, VocabularyPrioritizationAction, WordSaveCandidate
+from runestone.schemas.vocabulary_save import (
+    PriorityWordSaveItem,
+    VocabularyPrioritizationAction,
+    WordSaveCandidate,
+    decode_unicode_escapes,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -132,6 +137,12 @@ class WordEnrichmentItem(BaseModel):
     translation: str | None = Field(None, description="Concise translation of the word_phrase")
     example_phrase: str | None = Field(None, description="Natural Swedish example sentence")
     extra_info: str | None = Field(None, description="Compact grammar or usage note when useful")
+
+    @field_validator("candidate_id", "word_phrase", "translation", "example_phrase", "extra_info", mode="before")
+    @classmethod
+    def decode_enrichment_unicode_escapes(cls, value: str | None) -> str | None:
+        """Normalize double-escaped unicode before matching or saving enrichment payloads."""
+        return decode_unicode_escapes(value)
 
 
 class WordKeeperEnrichment(BaseModel):

--- a/src/runestone/schemas/vocabulary_save.py
+++ b/src/runestone/schemas/vocabulary_save.py
@@ -18,11 +18,27 @@ def priority_word_action_name(action: object, *, default: PriorityWordAction = "
     return default
 
 
+def decode_unicode_escapes(value: str | None) -> str | None:
+    """Decode double-escaped unicode text that some model payloads still emit."""
+    if isinstance(value, str) and "\\u" in value:
+        try:
+            return value.encode("utf-8").decode("unicode_escape")
+        except Exception:
+            return value
+    return value
+
+
 class WordSaveCandidate(BaseModel):
     """Canonical vocabulary candidate extracted before enrichment or persistence."""
 
     word_phrase: str = Field(..., description="Swedish word or phrase to save")
     source_form: str | None = Field(None, description="Original context form when it differs from word_phrase")
+
+    @field_validator("word_phrase", "source_form", mode="before")
+    @classmethod
+    def decode_candidate_unicode_escapes(cls, value: str | None) -> str | None:
+        """Normalize double-escaped unicode before candidate dedupe or persistence planning."""
+        return decode_unicode_escapes(value)
 
 
 class PriorityWordSaveItem(BaseModel):

--- a/src/runestone/schemas/vocabulary_save.py
+++ b/src/runestone/schemas/vocabulary_save.py
@@ -20,9 +20,9 @@ def priority_word_action_name(action: object, *, default: PriorityWordAction = "
 
 def decode_unicode_escapes(value: str | None) -> str | None:
     """Decode double-escaped unicode text that some model payloads still emit."""
-    if isinstance(value, str) and "\\u" in value:
+    if isinstance(value, str) and ("\\u" in value or "\\U" in value):
         try:
-            return value.encode("utf-8").decode("unicode_escape")
+            return value.encode("latin-1", "backslashreplace").decode("unicode_escape")
         except Exception:
             return value
     return value

--- a/tests/agents/specialists/test_word_keeper.py
+++ b/tests/agents/specialists/test_word_keeper.py
@@ -163,6 +163,38 @@ def test_word_keeper_models_decode_double_escaped_unicode():
     assert enrichment.extra_info == "adjective; common/neuter/plural: avgörande"
 
 
+def test_word_keeper_models_preserve_existing_unicode_when_decoding_escapes():
+    candidate = WordSaveCandidate(word_phrase="Här \\u00f6ver", source_form="Här \\u00f6ver")
+    enrichment = WordEnrichmentItem(
+        candidate_id="0",
+        word_phrase="Här \\u00f6ver",
+        translation="over here",
+        example_phrase="Här \\u00f6ver finns svaret.",
+        extra_info="phrase; mixed decoded and escaped unicode",
+    )
+
+    assert candidate.word_phrase == "Här över"
+    assert candidate.source_form == "Här över"
+    assert enrichment.word_phrase == "Här över"
+    assert enrichment.example_phrase == "Här över finns svaret."
+
+
+def test_word_keeper_models_decode_double_escaped_non_bmp_unicode():
+    candidate = WordSaveCandidate(word_phrase="glad \\U0001f600", source_form="glad \\U0001f600")
+    enrichment = WordEnrichmentItem(
+        candidate_id="0",
+        word_phrase="glad \\U0001f600",
+        translation="happy",
+        example_phrase="Hon blev glad \\U0001f600.",
+        extra_info="adjective; handles non-BMP escapes",
+    )
+
+    assert candidate.word_phrase == "glad 😀"
+    assert candidate.source_form == "glad 😀"
+    assert enrichment.word_phrase == "glad 😀"
+    assert enrichment.example_phrase == "Hon blev glad 😀."
+
+
 @pytest.mark.anyio
 async def test_word_keeper_prioritizes_existing_without_enrichment(specialist, mock_chat_model, mock_user):
     mock_chat_model.extraction_model.ainvoke.return_value = WordKeeperExtraction(

--- a/tests/agents/specialists/test_word_keeper.py
+++ b/tests/agents/specialists/test_word_keeper.py
@@ -146,6 +146,23 @@ def test_word_keeper_enrichment_prompt_owns_full_save_fields():
     assert "If unsure, leave `extra_info` empty rather than guess." in WORDKEEPER_ENRICHMENT_PROMPT
 
 
+def test_word_keeper_models_decode_double_escaped_unicode():
+    candidate = WordSaveCandidate(word_phrase="avg\\u00f6rande", source_form="avg\\u00f6rande")
+    enrichment = WordEnrichmentItem(
+        candidate_id="0",
+        word_phrase="avg\\u00f6rande",
+        translation="decisive",
+        example_phrase="Det var ett avg\\u00f6rande beslut.",
+        extra_info="adjective; common/neuter/plural: avg\\u00f6rande",
+    )
+
+    assert candidate.word_phrase == "avgörande"
+    assert candidate.source_form == "avgörande"
+    assert enrichment.word_phrase == "avgörande"
+    assert enrichment.example_phrase == "Det var ett avgörande beslut."
+    assert enrichment.extra_info == "adjective; common/neuter/plural: avgörande"
+
+
 @pytest.mark.anyio
 async def test_word_keeper_prioritizes_existing_without_enrichment(specialist, mock_chat_model, mock_user):
     mock_chat_model.extraction_model.ainvoke.return_value = WordKeeperExtraction(


### PR DESCRIPTION
## Summary
- restore double-escaped unicode decoding at the WordKeeper LLM output boundaries
- keep the sanitization scoped to model-facing schemas instead of internal save payloads
- add a regression test covering escaped Swedish characters

## Validation
- make check-readiness
