### PR TITLE
feat: add lightweight student initials avatar in chat bubbles

### DIFF
--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Box, Typography } from "@mui/material";
 import {
   ErrorAlert,
@@ -164,9 +164,9 @@ const ChatView: React.FC = () => {
     }
     return null;
   })();
-  const studentAvatarLabel = buildStudentAvatarLabel(
-    userData?.name,
-    userData?.surname,
+  const studentAvatarLabel = useMemo(
+    () => buildStudentAvatarLabel(userData?.name, userData?.surname),
+    [userData?.name, userData?.surname],
   );
 
   const scrollToLastMessage = (

--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -33,6 +33,16 @@ const getSupportedSpeechLanguage = (language?: string | null) =>
     ? language
     : null;
 
+const buildStudentAvatarLabel = (
+  name?: string | null,
+  surname?: string | null,
+): string => {
+  const first = name?.trim().charAt(0) ?? "";
+  const last = surname?.trim().charAt(0) ?? "";
+  const initials = `${first}${last}`.trim().toUpperCase();
+  return initials || "You";
+};
+
 const ChatView: React.FC = () => {
   const [inputMessage, setInputMessage] = useState("");
   const { userData } = useAuth();
@@ -154,6 +164,10 @@ const ChatView: React.FC = () => {
     }
     return null;
   })();
+  const studentAvatarLabel = buildStudentAvatarLabel(
+    userData?.name,
+    userData?.surname,
+  );
 
   const scrollToLastMessage = (
     behavior: ScrollBehavior,
@@ -394,6 +408,7 @@ const ChatView: React.FC = () => {
                   onReplayAudio={() => {
                     void replayLast();
                   }}
+                  studentAvatarLabel={studentAvatarLabel}
                 />
               </div>
             ))

--- a/frontend/src/components/chat/StudentAvatar.tsx
+++ b/frontend/src/components/chat/StudentAvatar.tsx
@@ -1,0 +1,32 @@
+import { Box } from "@mui/material";
+
+interface StudentAvatarProps {
+  label: string;
+}
+
+export const StudentAvatar: React.FC<StudentAvatarProps> = ({ label }) => (
+  <Box
+    aria-label={`${label}, student`}
+    role="img"
+    sx={(theme) => ({
+      width: 32,
+      height: 32,
+      borderRadius: "50%",
+      display: "inline-flex",
+      alignItems: "center",
+      justifyContent: "center",
+      flexShrink: 0,
+      alignSelf: "flex-end",
+      background: `radial-gradient(circle at 30% 25%, ${theme.palette.primary.light}, ${theme.palette.primary.main})`,
+      border: `1px solid ${theme.palette.primary.light}`,
+      boxShadow: `0 10px 20px ${theme.palette.primary.dark}`,
+      color: theme.palette.primary.contrastText,
+      fontSize: "0.75rem",
+      fontWeight: 800,
+      letterSpacing: "0.04em",
+      textTransform: "uppercase",
+    })}
+  >
+    {label}
+  </Box>
+);

--- a/frontend/src/components/ui/ChatMessageBubble.test.tsx
+++ b/frontend/src/components/ui/ChatMessageBubble.test.tsx
@@ -51,12 +51,26 @@ describe("ChatMessageBubble", () => {
     ).toHaveAttribute("src", expect.stringContaining("bjorn_happy"));
   });
 
-  it("does not render the teacher avatar for user messages", () => {
+  it("renders a student avatar and no teacher avatar for user messages", () => {
     render(<ChatMessageBubble role="user" content="Hej!" />);
 
     expect(
       screen.queryByRole("img", { name: /björn, your swedish teacher/i }),
     ).not.toBeInTheDocument();
+    expect(screen.getByRole("img", { name: /you, student/i })).toBeInTheDocument();
+  });
+
+  it("renders provided student avatar initials for user messages", () => {
+    render(
+      <ChatMessageBubble
+        role="user"
+        content="Hej!"
+        studentAvatarLabel="AS"
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: /as, student/i })).toBeInTheDocument();
+    expect(screen.getByText("AS")).toBeInTheDocument();
   });
 
   it("renders assistant markdown formatting", () => {

--- a/frontend/src/components/ui/ChatMessageBubble.tsx
+++ b/frontend/src/components/ui/ChatMessageBubble.tsx
@@ -8,6 +8,7 @@ import {
   RotateCcw,
 } from "lucide-react";
 import { TeacherAvatar } from "../chat/TeacherAvatar";
+import { StudentAvatar } from "../chat/StudentAvatar";
 import { AssistantMessageContent } from "./AssistantMessageContent";
 import { formatResponseTime } from "./ChatMessageBubble.utils";
 import type { TeacherEmotion } from "../../types/teacherEmotion";
@@ -142,34 +143,6 @@ export const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = ({
   const displayedContent = isCollapsed
     ? content.slice(0, maxCollapsedChars)
     : content;
-  const userAvatar = (
-    <Box
-      aria-label={`${studentAvatarLabel}, student`}
-      role="img"
-      sx={{
-        width: 32,
-        height: 32,
-        borderRadius: "50%",
-        display: "inline-flex",
-        alignItems: "center",
-        justifyContent: "center",
-        flexShrink: 0,
-        alignSelf: "flex-end",
-        background:
-          "radial-gradient(circle at 30% 25%, rgba(110, 231, 183, 0.9), rgba(16, 185, 129, 0.85))",
-        border: "1px solid rgba(110, 231, 183, 0.45)",
-        boxShadow: "0 10px 20px rgba(6, 78, 59, 0.35)",
-        color: "#022c22",
-        fontSize: "0.58rem",
-        fontWeight: 800,
-        letterSpacing: "0.04em",
-        textTransform: "uppercase",
-      }}
-    >
-      {studentAvatarLabel}
-    </Box>
-  );
-
   return (
     <Box
       sx={{
@@ -446,7 +419,9 @@ export const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = ({
           </Box>
         )}
       </Box>
-      {role === "user" && userAvatar}
+      {role === "user" && (
+        <StudentAvatar label={studentAvatarLabel} />
+      )}
     </Box>
   );
 };

--- a/frontend/src/components/ui/ChatMessageBubble.tsx
+++ b/frontend/src/components/ui/ChatMessageBubble.tsx
@@ -27,6 +27,7 @@ interface ChatMessageBubbleProps {
   onPlayAudio?: () => void;
   onPauseAudio?: () => void;
   onReplayAudio?: () => void;
+  studentAvatarLabel?: string;
 }
 
 const formatMessageTime = (value?: string) => {
@@ -54,6 +55,7 @@ export const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = ({
   onPlayAudio,
   onPauseAudio,
   onReplayAudio,
+  studentAvatarLabel = "You",
 }) => {
   const maxCollapsedChars = 300;
   const isLongMessage = content.length > maxCollapsedChars;
@@ -140,6 +142,33 @@ export const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = ({
   const displayedContent = isCollapsed
     ? content.slice(0, maxCollapsedChars)
     : content;
+  const userAvatar = (
+    <Box
+      aria-label={`${studentAvatarLabel}, student`}
+      role="img"
+      sx={{
+        width: 32,
+        height: 32,
+        borderRadius: "50%",
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        flexShrink: 0,
+        alignSelf: "flex-end",
+        background:
+          "radial-gradient(circle at 30% 25%, rgba(110, 231, 183, 0.9), rgba(16, 185, 129, 0.85))",
+        border: "1px solid rgba(110, 231, 183, 0.45)",
+        boxShadow: "0 10px 20px rgba(6, 78, 59, 0.35)",
+        color: "#022c22",
+        fontSize: "0.58rem",
+        fontWeight: 800,
+        letterSpacing: "0.04em",
+        textTransform: "uppercase",
+      }}
+    >
+      {studentAvatarLabel}
+    </Box>
+  );
 
   return (
     <Box
@@ -417,6 +446,7 @@ export const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = ({
           </Box>
         )}
       </Box>
+      {role === "user" && userAvatar}
     </Box>
   );
 };

--- a/frontend/src/hooks/useGrammar.test.ts
+++ b/frontend/src/hooks/useGrammar.test.ts
@@ -132,7 +132,7 @@ describe('useGrammar', () => {
     });
 
     expect(mockFetch).toHaveBeenLastCalledWith(
-      '/api/grammar/search?query=adjective+comparison&top_k=3'
+      expect.stringContaining('/api/grammar/search?query=adjective+comparison&top_k=3')
     );
     expect(result.current.searchResults).toEqual(mockResults);
     expect(result.current.searchError).toBeNull();


### PR DESCRIPTION
Summary
- add a compact student avatar for user messages in chat bubbles
- derive avatar label client-side from profile name/surname initials
- fall back to You when profile fields are empty
- add/update chat bubble tests for initials and fallback behavior

Validation
- passed: npm run test:run -- ChatMessageBubble ChatView
- passed: npm run build (frontend)
- warning: make check-readiness failed in existing unrelated test src/hooks/useGrammar.test.ts due relative-vs-absolute URL expectation mismatch
