### PR TITLE
feat: show red chat status dot when backend is unavailable

### DIFF
--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -46,6 +46,7 @@ const ChatView: React.FC = () => {
     isLoading,
     isSyncingHistory,
     historySyncNotice,
+    isBackendAvailable,
     error,
     sendMessage,
     startNewChat,
@@ -355,6 +356,7 @@ const ChatView: React.FC = () => {
           onOpenMemory={() => setIsMemoryModalOpen(true)}
           isLoading={isAnyProcessing}
           hasMessages={messages.length > 0}
+          isBackendAvailable={isBackendAvailable}
           teacherEmotion={latestTeacherEmotion}
         />
 

--- a/frontend/src/components/chat/ChatHeader.tsx
+++ b/frontend/src/components/chat/ChatHeader.tsx
@@ -10,6 +10,7 @@ interface ChatHeaderProps {
   onOpenMemory: () => void;
   isLoading: boolean;
   hasMessages: boolean;
+  isBackendAvailable?: boolean;
   teacherEmotion?: TeacherEmotion | string | null;
 }
 
@@ -18,6 +19,7 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
   onOpenMemory,
   isLoading,
   hasMessages,
+  isBackendAvailable = true,
   teacherEmotion,
 }) => {
   return (
@@ -38,6 +40,7 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
         <TeacherAvatar
           size={73}
           showStatus
+          isBackendAvailable={isBackendAvailable}
           emotion={isLoading ? "thinking" : teacherEmotion}
         />
         <Box>

--- a/frontend/src/components/chat/TeacherAvatar.tsx
+++ b/frontend/src/components/chat/TeacherAvatar.tsx
@@ -20,6 +20,7 @@ interface TeacherAvatarProps {
   emotion?: TeacherEmotion | string | null;
   alt?: string;
   showStatus?: boolean;
+  isBackendAvailable?: boolean;
 }
 
 const emotionAvatars: Record<TeacherEmotion, string> = {
@@ -91,6 +92,7 @@ export const TeacherAvatar: React.FC<TeacherAvatarProps> = ({
   emotion,
   alt = "Björn, your Swedish teacher",
   showStatus = false,
+  isBackendAvailable = true,
 }) => {
   const CROSSFADE_MS = 1800;
   const CROSSFADE_EASING = "cubic-bezier(0.22, 1, 0.36, 1)";
@@ -264,8 +266,11 @@ export const TeacherAvatar: React.FC<TeacherAvatarProps> = ({
             width: Math.max(9, Math.floor(size * 0.22)),
             height: Math.max(9, Math.floor(size * 0.22)),
             borderRadius: "50%",
-            backgroundColor: "var(--primary-color)",
+            backgroundColor: isBackendAvailable ? "var(--primary-color)" : "#ef4444",
             border: "2px solid #1a102b",
+            boxShadow: isBackendAvailable
+              ? "0 0 0 1px rgba(56, 224, 123, 0.28)"
+              : "0 0 0 1px rgba(239, 68, 68, 0.25)",
           }}
         />
       )}

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -6,6 +6,7 @@ import {
   normalizeTeacherEmotion,
   type TeacherEmotion,
 } from '../types/teacherEmotion';
+import { API_BASE_URL } from '../config';
 
 interface NewsSource {
   title: string;
@@ -48,6 +49,7 @@ interface UseChatReturn {
   isFetchingHistory: boolean;
   isSyncingHistory: boolean;
   historySyncNotice: string | null;
+  isBackendAvailable: boolean;
   error: string | null;
   sendMessage: (message: string, ttsExpected?: boolean, speed?: number) => Promise<string | null>;
   startNewChat: () => Promise<void>;
@@ -60,6 +62,7 @@ const INITIAL_POLL_INTERVAL_MS = 5000;
 const MAX_POLL_INTERVAL_MS = 60000;
 const HISTORY_LIMIT = 200;
 const INITIAL_HISTORY_ERROR = 'Failed to load chat history. Starting fresh.';
+const SHOULD_POLL_BACKEND_HEALTH = import.meta.env.MODE !== 'test';
 
 export const useChat = (): UseChatReturn => {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -67,6 +70,7 @@ export const useChat = (): UseChatReturn => {
   const [isFetchingHistory, setIsFetchingHistory] = useState(false);
   const [isSyncingHistory, setIsSyncingHistory] = useState(false);
   const [historySyncNotice, setHistorySyncNotice] = useState<string | null>(null);
+  const [isBackendAvailable, setIsBackendAvailable] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const { get, post, delete: apiDelete } = useApi();
   const { token } = useAuth();
@@ -213,14 +217,15 @@ export const useChat = (): UseChatReturn => {
 
         page += 1;
       }
-
       if (!syncingOlderPages) {
         setIsSyncingHistory(false);
       }
+      setIsBackendAvailable(true);
 
       return receivedUpdates;
     } catch (err) {
       console.error('Failed to fetch chat history:', err);
+      setIsBackendAvailable(false);
       if (!hasLoadedHistoryRef.current) {
         setError(INITIAL_HISTORY_ERROR);
         setMessages([]);
@@ -237,6 +242,16 @@ export const useChat = (): UseChatReturn => {
       fetchInProgressRef.current = false;
     }
   }, [get, getMaxServerId, isLoading, mapServerMessage, mergeServerMessages, token]);
+
+  const checkBackendHealth = useCallback(async () => {
+    const base = API_BASE_URL.replace(/\/+$/, '');
+    try {
+      const response = await fetch(`${base}/api/health`, { method: 'GET' });
+      setIsBackendAvailable(response.ok);
+    } catch {
+      setIsBackendAvailable(false);
+    }
+  }, []);
 
   // Initial fetch
   useEffect(() => {
@@ -325,6 +340,21 @@ export const useChat = (): UseChatReturn => {
     };
   }, [fetchHistory, resetPollingInterval]);
 
+  useEffect(() => {
+    if (!SHOULD_POLL_BACKEND_HEALTH) {
+      return;
+    }
+
+    void checkBackendHealth();
+    const intervalId = window.setInterval(() => {
+      void checkBackendHealth();
+    }, 15000);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [checkBackendHealth]);
+
   const broadcastChange = useCallback(() => {
     if (channelRef.current) {
       channelRef.current.postMessage({ type: 'CHAT_UPDATED', sender: CLIENT_ID });
@@ -370,6 +400,7 @@ export const useChat = (): UseChatReturn => {
         };
 
         setMessages((prev) => [...prev, assistantMessage]);
+        setIsBackendAvailable(true);
         resetPollingInterval();
         broadcastChange();
         void fetchHistory(true);
@@ -377,6 +408,7 @@ export const useChat = (): UseChatReturn => {
       } catch (err) {
         const errorMessage =
           err instanceof Error ? err.message : 'An error occurred';
+        setIsBackendAvailable(false);
         setError(errorMessage);
         console.error('Chat error:', err);
         return null;
@@ -392,6 +424,7 @@ export const useChat = (): UseChatReturn => {
     setError(null);
     try {
       await apiDelete('/api/chat/history');
+      setIsBackendAvailable(true);
       setMessages([]);
       setHistorySyncNotice(null);
       currentChatIdRef.current = null;
@@ -400,6 +433,7 @@ export const useChat = (): UseChatReturn => {
       broadcastChange();
     } catch (err) {
       console.error('Failed to clear chat history:', err);
+      setIsBackendAvailable(false);
       setError('Failed to start a new chat. Please try again.');
     } finally {
       setIsLoading(false);
@@ -421,6 +455,7 @@ export const useChat = (): UseChatReturn => {
     isFetchingHistory,
     isSyncingHistory,
     historySyncNotice,
+    isBackendAvailable,
     error,
     sendMessage,
     startNewChat,

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -6,7 +6,6 @@ import {
   normalizeTeacherEmotion,
   type TeacherEmotion,
 } from '../types/teacherEmotion';
-import { API_BASE_URL } from '../config';
 
 interface NewsSource {
   title: string;
@@ -62,7 +61,6 @@ const INITIAL_POLL_INTERVAL_MS = 5000;
 const MAX_POLL_INTERVAL_MS = 60000;
 const HISTORY_LIMIT = 200;
 const INITIAL_HISTORY_ERROR = 'Failed to load chat history. Starting fresh.';
-const SHOULD_POLL_BACKEND_HEALTH = import.meta.env.MODE !== 'test';
 
 export const useChat = (): UseChatReturn => {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -243,16 +241,6 @@ export const useChat = (): UseChatReturn => {
     }
   }, [get, getMaxServerId, isLoading, mapServerMessage, mergeServerMessages, token]);
 
-  const checkBackendHealth = useCallback(async () => {
-    const base = API_BASE_URL.replace(/\/+$/, '');
-    try {
-      const response = await fetch(`${base}/api/health`, { method: 'GET' });
-      setIsBackendAvailable(response.ok);
-    } catch {
-      setIsBackendAvailable(false);
-    }
-  }, []);
-
   // Initial fetch
   useEffect(() => {
     void fetchHistory();
@@ -339,21 +327,6 @@ export const useChat = (): UseChatReturn => {
       channelRef.current = null;
     };
   }, [fetchHistory, resetPollingInterval]);
-
-  useEffect(() => {
-    if (!SHOULD_POLL_BACKEND_HEALTH) {
-      return;
-    }
-
-    void checkBackendHealth();
-    const intervalId = window.setInterval(() => {
-      void checkBackendHealth();
-    }, 15000);
-
-    return () => {
-      window.clearInterval(intervalId);
-    };
-  }, [checkBackendHealth]);
 
   const broadcastChange = useCallback(() => {
     if (channelRef.current) {


### PR DESCRIPTION
## Summary
- add backend availability tracking in chat state
- wire availability to the header avatar status dot
- render the dot red when backend requests fail, green when healthy

## Testing
- make frontend-test
