### PR TITLE
feat: order vocabulary by updated time and expose updated field

### DIFF
--- a/frontend/src/components/VocabularyView.test.tsx
+++ b/frontend/src/components/VocabularyView.test.tsx
@@ -477,6 +477,7 @@ describe("VocabularyView", () => {
         learned_times: 5,
         created_at: "2023-10-27T10:00:00Z",
         updated_at: "2023-10-27T10:00:00Z",
+        updated: "2023-10-27T10:00:00Z",
       },
       {
         id: 2,
@@ -491,6 +492,7 @@ describe("VocabularyView", () => {
         learned_times: 0,
         created_at: "2023-10-28T10:05:00Z",
         updated_at: "2023-10-28T10:05:00Z",
+        updated: "2023-10-28T10:05:00Z",
       },
     ];
 
@@ -520,7 +522,7 @@ describe("VocabularyView", () => {
     expect(screen.getByText("In Learning")).toBeInTheDocument();
     expect(screen.getByText("Priority")).toBeInTheDocument();
     expect(screen.getByText("Last Learned")).toBeInTheDocument();
-    expect(screen.getByText("Saved")).toBeInTheDocument();
+    expect(screen.getByText("Updated")).toBeInTheDocument();
 
     // Check vocabulary data
     expect(screen.getByText("hej")).toBeInTheDocument();

--- a/frontend/src/components/VocabularyView.tsx
+++ b/frontend/src/components/VocabularyView.tsx
@@ -357,10 +357,13 @@ const VocabularyView: React.FC = () => {
                 ),
               },
               {
-                key: "created_at",
-                label: "Saved",
-                render: (value) =>
-                  new Date(value as string).toLocaleDateString(),
+                key: "updated",
+                label: "Updated",
+                render: (value, row) => {
+                  const item = row as unknown as (typeof recentVocabulary)[0];
+                  const updated = value || item.updated_at;
+                  return updated ? new Date(updated as string).toLocaleDateString() : "—";
+                },
               },
             ]}
             data={

--- a/frontend/src/hooks/useVocabulary.test.ts
+++ b/frontend/src/hooks/useVocabulary.test.ts
@@ -573,6 +573,11 @@ describe('useRecentVocabulary', () => {
       ok: true,
       json: () => Promise.resolve(updatedItem),
     });
+    // Mock refetch response after update
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve([updatedItem]),
+    });
 
     const { result } = renderHook(() => useRecentVocabulary());
 
@@ -605,7 +610,7 @@ describe('useRecentVocabulary', () => {
       })
     );
 
-    // Verify state was updated directly with the updated item
+    // Verify state was updated from refetched list after update
     await waitFor(() => {
       expect(result.current.recentVocabulary).toEqual([updatedItem]);
     });

--- a/frontend/src/hooks/useVocabulary.ts
+++ b/frontend/src/hooks/useVocabulary.ts
@@ -15,6 +15,7 @@ interface SavedVocabularyItem {
   learned_times: number;
   created_at: string;
   updated_at: string;
+  updated?: string | null;
 }
 
 export interface VocabularyStats {

--- a/frontend/src/hooks/useVocabulary.ts
+++ b/frontend/src/hooks/useVocabulary.ts
@@ -188,16 +188,11 @@ export const useRecentVocabulary = (
 
   const updateVocabularyItem = useCallback(
     async (id: number, updates: Partial<SavedVocabularyItem>) => {
-      const updatedItem: SavedVocabularyItem = await put<SavedVocabularyItem>(
-        `/api/vocabulary/${id}`,
-        updates
-      );
-      setRecentVocabulary((prev) =>
-        prev.map((item) => (item.id === id ? updatedItem : item))
-      );
+      await put<SavedVocabularyItem>(`/api/vocabulary/${id}`, updates);
+      await fetchRecentVocabulary();
       closeEditModal();
     },
-    [closeEditModal, put]
+    [closeEditModal, fetchRecentVocabulary, put]
   );
 
   const createVocabularyItem = useCallback(

--- a/src/runestone/api/schemas.py
+++ b/src/runestone/api/schemas.py
@@ -130,6 +130,7 @@ class Vocabulary(BaseModel):
     learned_times: int = 0
     created_at: str
     updated_at: str
+    updated: Optional[str] = None
 
 
 class VocabularyImproveRequest(BaseModel):

--- a/src/runestone/db/vocabulary_repository.py
+++ b/src/runestone/db/vocabulary_repository.py
@@ -321,7 +321,9 @@ class VocabularyRepository:
                 # Use ilike with escape character for case-insensitive matching
                 stmt = stmt.filter(Vocabulary.word_phrase.ilike(search_pattern, escape="\\"))
 
-        stmt = stmt.order_by(Vocabulary.updated_at.desc(), Vocabulary.id.desc()).limit(limit)
+        stmt = stmt.order_by(
+            func.coalesce(Vocabulary.updated_at, Vocabulary.created_at).desc(), Vocabulary.id.desc()
+        ).limit(limit)
         result = await self.db.execute(stmt)
         return list(result.scalars().all())
 

--- a/src/runestone/db/vocabulary_repository.py
+++ b/src/runestone/db/vocabulary_repository.py
@@ -321,7 +321,7 @@ class VocabularyRepository:
                 # Use ilike with escape character for case-insensitive matching
                 stmt = stmt.filter(Vocabulary.word_phrase.ilike(search_pattern, escape="\\"))
 
-        stmt = stmt.order_by(Vocabulary.created_at.desc(), Vocabulary.id.desc()).limit(limit)
+        stmt = stmt.order_by(Vocabulary.updated_at.desc(), Vocabulary.id.desc()).limit(limit)
         result = await self.db.execute(stmt)
         return list(result.scalars().all())
 

--- a/src/runestone/services/vocabulary_service.py
+++ b/src/runestone/services/vocabulary_service.py
@@ -91,6 +91,7 @@ class VocabularyService:
             last_learned=vocab.last_learned.isoformat() if vocab.last_learned else None,
             created_at=vocab.created_at.isoformat() if vocab.created_at else None,
             updated_at=vocab.updated_at.isoformat() if vocab.updated_at else None,
+            updated=vocab.updated_at.isoformat() if vocab.updated_at else None,
         )
 
     async def get_vocabulary(
@@ -114,6 +115,7 @@ class VocabularyService:
                     learned_times=vocab.learned_times or 0,
                     created_at=vocab.created_at.isoformat() if vocab.created_at else None,
                     updated_at=vocab.updated_at.isoformat() if vocab.updated_at else None,
+                    updated=vocab.updated_at.isoformat() if vocab.updated_at else None,
                 )
             )
         return result
@@ -153,6 +155,7 @@ class VocabularyService:
             learned_times=updated_vocab.learned_times or 0,
             created_at=updated_vocab.created_at.isoformat() if updated_vocab.created_at else None,
             updated_at=updated_vocab.updated_at.isoformat() if updated_vocab.updated_at else None,
+            updated=updated_vocab.updated_at.isoformat() if updated_vocab.updated_at else None,
         )
 
     async def load_vocab_from_csv(

--- a/tests/api/test_endpoints.py
+++ b/tests/api/test_endpoints.py
@@ -257,6 +257,7 @@ class TestVocabularyEndpoints:
         assert "id" in vocab
         assert "created_at" in vocab
         assert "updated_at" in vocab
+        assert vocab["updated"] == vocab["updated_at"]
 
     async def test_save_vocabulary_item_success(self, client):
         """Test successful saving of a single vocabulary item."""
@@ -402,7 +403,7 @@ class TestVocabularyEndpoints:
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 2
-        # Should be ordered by created_at descending
+        # Should be ordered by updated_at descending, with id as a tie-breaker
         assert data[0]["word_phrase"] == "ett päron"  # Most recent
         assert data[1]["word_phrase"] == "ett äpple"
 

--- a/tests/db/test_db_repository.py
+++ b/tests/db/test_db_repository.py
@@ -7,7 +7,7 @@ This module contains tests for the vocabulary repository.
 from datetime import datetime, timedelta, timezone
 
 import pytest
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 
 from runestone.api.schemas import VocabularyItemCreate
 from runestone.db.models import User
@@ -388,6 +388,51 @@ class TestVocabularyRepository:
         result_user2 = await repo.get_vocabulary(limit=20, user_id=2)
         assert len(result_user2) == 1
         assert result_user2[0].word_phrase == "en kiwi"
+
+    async def test_get_vocabulary_recent_with_null_updated_at(self, repo, db_session):
+        """Test recent ordering falls back to created_at when updated_at is null."""
+        vocab1 = VocabularyModel(
+            user_id=1,
+            word_phrase="ett äpple",
+            translation="an apple",
+            created_at=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            in_learn=True,
+            last_learned=None,
+        )
+        vocab2 = VocabularyModel(
+            user_id=1,
+            word_phrase="en banan",
+            translation="a banana",
+            created_at=datetime(2023, 1, 3, tzinfo=timezone.utc),
+            updated_at=datetime(2023, 1, 3, tzinfo=timezone.utc),
+            in_learn=True,
+            last_learned=None,
+        )
+        vocab3 = VocabularyModel(
+            user_id=1,
+            word_phrase="ett päron",
+            translation="a pear",
+            created_at=datetime(2023, 1, 2, tzinfo=timezone.utc),
+            updated_at=datetime(2023, 1, 4, tzinfo=timezone.utc),
+            in_learn=True,
+            last_learned=None,
+        )
+
+        db_session.add_all([vocab1, vocab2, vocab3])
+        await db_session.commit()
+        await db_session.execute(
+            update(VocabularyModel).where(VocabularyModel.id.in_([vocab1.id, vocab2.id])).values(updated_at=None)
+        )
+        await db_session.commit()
+
+        result = await repo.get_vocabulary(limit=20, user_id=1)
+        assert len(result) == 3
+        # coalesce(updated_at, created_at) descending:
+        # päron -> updated_at(2023-01-04), banan -> created_at(2023-01-03), äpple -> created_at(2023-01-01)
+        assert result[0].word_phrase == "ett päron"
+        assert result[1].word_phrase == "en banan"
+        assert result[2].word_phrase == "ett äpple"
 
     async def test_get_vocabulary_with_search(self, repo, db_session, basic_vocab_items):
         """Test retrieving vocabulary items filtered by search query."""

--- a/tests/db/test_db_repository.py
+++ b/tests/db/test_db_repository.py
@@ -327,13 +327,14 @@ class TestVocabularyRepository:
         """Test retrieving the most recent vocabulary items."""
         from datetime import datetime, timezone
 
-        # Add test data with different creation times
+        # Add test data with different update times
         vocab1 = VocabularyModel(
             user_id=1,
             word_phrase="ett äpple",
             translation="an apple",
             example_phrase="Jag äter ett äpple varje dag.",
             created_at=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2023, 1, 1, tzinfo=timezone.utc),
             in_learn=True,
             last_learned=None,
         )
@@ -343,6 +344,7 @@ class TestVocabularyRepository:
             translation="a banana",
             example_phrase=None,
             created_at=datetime(2023, 1, 2, tzinfo=timezone.utc),
+            updated_at=datetime(2023, 1, 2, tzinfo=timezone.utc),
             in_learn=True,
             last_learned=None,
         )
@@ -351,6 +353,7 @@ class TestVocabularyRepository:
             word_phrase="ett päron",
             translation="a pear",
             created_at=datetime(2023, 1, 3, tzinfo=timezone.utc),
+            updated_at=datetime(2023, 1, 3, tzinfo=timezone.utc),
             in_learn=True,
             last_learned=None,
         )
@@ -359,6 +362,7 @@ class TestVocabularyRepository:
             word_phrase="en kiwi",
             translation="a kiwi",
             created_at=datetime(2023, 1, 4, tzinfo=timezone.utc),
+            updated_at=datetime(2023, 1, 4, tzinfo=timezone.utc),
             in_learn=True,
             last_learned=None,
         )
@@ -369,7 +373,7 @@ class TestVocabularyRepository:
         # Get recent for user 1 (should return 3 items, most recent first)
         result = await repo.get_vocabulary(limit=20, user_id=1)
         assert len(result) == 3
-        # Should be ordered by created_at descending
+        # Should be ordered by updated_at descending
         assert result[0].word_phrase == "ett päron"  # Most recent
         assert result[1].word_phrase == "en banan"
         assert result[2].word_phrase == "ett äpple"  # Oldest

--- a/tests/services/test_services_vocabulary_service.py
+++ b/tests/services/test_services_vocabulary_service.py
@@ -194,14 +194,15 @@ class TestVocabularyService:
         assert stats.words_prioritized_count == 1
 
     async def test_get_vocabulary_recent(self, service, db_session):
-        """Test retrieving vocabulary items sorted by creation date (most recent first)."""
-        # Add test data with specific creation dates
+        """Test retrieving vocabulary items sorted by update date (most recent first)."""
+        # Add test data with specific update dates
         vocab1 = VocabularyModel(
             user_id=1,
             word_phrase="ett äpple",
             translation="an apple",
             example_phrase="Jag äter ett äpple varje dag.",
             created_at=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2023, 1, 1, tzinfo=timezone.utc),
             in_learn=True,
             last_learned=None,
         )
@@ -211,6 +212,7 @@ class TestVocabularyService:
             translation="a banana",
             example_phrase=None,
             created_at=datetime(2023, 1, 2, tzinfo=timezone.utc),
+            updated_at=datetime(2023, 1, 2, tzinfo=timezone.utc),
             in_learn=True,
             last_learned=None,
         )
@@ -219,6 +221,7 @@ class TestVocabularyService:
             word_phrase="ett päron",
             translation="a pear",
             created_at=datetime(2023, 1, 3, tzinfo=timezone.utc),
+            updated_at=datetime(2023, 1, 3, tzinfo=timezone.utc),
             in_learn=True,
             last_learned=None,
         )
@@ -227,6 +230,7 @@ class TestVocabularyService:
             word_phrase="en kiwi",
             translation="a kiwi",
             created_at=datetime(2023, 1, 4, tzinfo=timezone.utc),
+            updated_at=datetime(2023, 1, 4, tzinfo=timezone.utc),
             in_learn=True,
             last_learned=None,
         )
@@ -238,10 +242,11 @@ class TestVocabularyService:
         result = await service.get_vocabulary(limit=20, user_id=1)
         assert len(result) == 3
         assert isinstance(result[0], VocabularySchema)
-        # Should be ordered by created_at descending
+        # Should be ordered by updated_at descending
         assert result[0].word_phrase == "ett päron"  # Most recent
         assert result[1].word_phrase == "en banan"
         assert result[2].word_phrase == "ett äpple"  # Oldest
+        assert result[0].updated == result[0].updated_at
 
         # Test with limit
         result_limited = await service.get_vocabulary(limit=2, user_id=1)


### PR DESCRIPTION
## Summary
- order vocabulary retrieval by updated_at descending (with id tie-breaker)
- include updated in vocabulary API responses while keeping updated_at for compatibility
- switch Vocabulary table date column to Updated and keep a frontend fallback to updated_at
- update backend/API/frontend tests to cover ordering and response shape

## Validation
- uv run pytest tests/db/test_db_repository.py::TestVocabularyRepository::test_get_vocabulary_recent tests/services/test_services_vocabulary_service.py::TestVocabularyService::test_get_vocabulary_recent tests/api/test_endpoints.py::TestVocabularyEndpoints::test_get_vocabulary_with_data tests/api/test_endpoints.py::TestVocabularyEndpoints::test_get_vocabulary_with_search -q
- npm run test -- --run src/components/VocabularyView.test.tsx
- make lint-check

Task: vArQX4lPHcu9