### PR TITLE
fix: prevent misspelled-word memory pollution

### DIFF
--- a/src/runestone/agents/coordinator.py
+++ b/src/runestone/agents/coordinator.py
@@ -120,6 +120,8 @@ COORDINATOR_POST_RESPONSE_PROMPT = (
 - The request existed only in older `history` rather than the current student `message`.
 - The teacher response is routine praise, a normal correction, a drill prompt, or a generic explanation
   without an explicit durable signal.
+- The teacher only says a student-written word is misspelled, invalid, nonexistent, or should be replaced
+  by another vocabulary item. That is a vocabulary correction, not a durable memory update.
 - The plan would rely on inferred intent rather than explicit wording in the current turn.
 
 Examples that SHOULD route:
@@ -133,6 +135,7 @@ Examples that should NOT route:
 - Student: "We talked about this before."
 - Teacher: "Good job."
 - Teacher: "Write one more sentence with these words."
+- Teacher: "There is no such word as 'varen'; use 'våren' for spring."
 
 ### word_keeper (post)
 
@@ -141,11 +144,13 @@ Examples that should NOT route:
   (e.g. "the key words here are…", "good words to memorize",
   "let's keep these words in mind").
 - The teacher clearly presents a vocabulary-saving moment, not just vocabulary usage inside a drill.
+- The teacher explicitly corrects a misspelled, invalid, or nonexistent student-written word and provides
+  the corrected Swedish vocabulary item. Route so WordKeeper can prioritize the corrected item, not the error.
 
 **Do NOT route when:**
 - The teacher is only asking the student to practice, answer, or write another sentence using words.
-- Words are merely bolded, translated, corrected, or reused in an exercise prompt without an explicit
-  memory/save signal.
+- Words are merely bolded, translated, grammatically corrected, or reused in an exercise prompt without
+  an explicit memory/save signal or a corrected Swedish vocabulary item.
 - The teacher gives an example sentence using words but does not say they are important to memorize or save.
 - The response is an ordinary exercise, correction, explanation, or drill rather than a vocabulary-saving moment.
 

--- a/src/runestone/agents/coordinator.py
+++ b/src/runestone/agents/coordinator.py
@@ -147,6 +147,9 @@ Examples that should NOT route:
 - The teacher explicitly corrects a misspelled, invalid, or nonexistent student-written word and provides
   the corrected Swedish vocabulary item. Route so WordKeeper can prioritize the corrected item, not the error.
 
+Examples that SHOULD route:
+- Teacher: "There is no such word as 'varen'; use 'våren' for spring."
+
 **Do NOT route when:**
 - The teacher is only asking the student to practice, answer, or write another sentence using words.
 - Words are merely bolded, translated, grammatically corrected, or reused in an exercise prompt without

--- a/src/runestone/agents/specialists/memory_keeper.py
+++ b/src/runestone/agents/specialists/memory_keeper.py
@@ -59,6 +59,11 @@ If no trigger is detected → return `no_action` immediately. Do not call any to
 - Prefer updating an existing item over creating a duplicate (that's what Step 1 is for).
 - Never call `read_memory` without filters unless a broad inspection is explicitly required.
 - Never call `read_memory` as a standalone action — it is always a precursor to a write.
+- Treat spelling corrections, nonexistent-word feedback, and one-off wrong vocabulary forms as
+  vocabulary events, not durable memory. Do not create `area_to_improve` items for misspelled
+  or invalid word forms such as "no such word", "that word is wrong", or "use X instead of Y".
+- Only act on spelling or vocabulary mistakes when the Teacher explicitly names a broader durable
+  pattern to remember, such as repeated spelling confusion or recurring word-choice trouble.
 
 ## Category Rules
 
@@ -107,6 +112,8 @@ Return valid JSON matching this exact shape and nothing else:
 - Student expressing frustration → emotional signal, not a memory change request
 - Student re-mentioning an earlier fact → restatement, not a correction
 - Teacher giving feedback mid-lesson → instructional output, not a persistence directive
+- Teacher saying a student-written word is misspelled, invalid, nonexistent, or should be replaced
+  by another word → vocabulary correction; leave it to WordKeeper unless a recurring durable pattern is named
 """
 
 

--- a/src/runestone/agents/specialists/word_keeper.py
+++ b/src/runestone/agents/specialists/word_keeper.py
@@ -47,6 +47,9 @@ Never invent candidates simply because a Swedish word appears in the conversatio
   - Named vocabulary sections (e.g. "подсказка по лексике", "key vocabulary", "useful words").
   - Structured word–translation lists or bullet pairs regardless of the header label.
   - Explicit save phrasing (e.g. "the key words here are", "good words to memorize").
+- Save the corrected Swedish vocabulary item when the teacher explicitly says the student's form is
+  misspelled, invalid, nonexistent, or should be replaced by a specific corrected Swedish word.
+  Never save the student's erroneous form in this case.
 - Do NOT treat ordinary exercise wording as a save signal, even if words are bolded or repeated.
 - Do NOT save words from prompts like "use X or Y in a sentence", "try another sentence with X",
   or other drill wording unless the teacher also explicitly says the words are worth remembering.
@@ -55,7 +58,9 @@ Never invent candidates simply because a Swedish word appears in the conversatio
 
 ## What NOT to Save
 - Words the student merely reused in their message.
-- Words that appear only in correction or example sentences without a save signal.
+- Words that appear only in grammar corrections or example sentences without a save signal.
+- Misspelled, invalid, or nonexistent student-written word forms. If a correction should be saved,
+  save only the corrected Swedish item supplied by the teacher.
 - Words introduced in earlier turns unless the student explicitly references them.
 - Words that are only mentioned as options in a practice prompt or writing exercise.
 - Bolded words that are emphasized for an exercise but not presented as vocabulary to memorize.

--- a/tests/agents/specialists/test_memory_keeper.py
+++ b/tests/agents/specialists/test_memory_keeper.py
@@ -143,3 +143,9 @@ async def test_memory_keeper_parses_fenced_json_output(specialist, mock_user):
 def test_memory_keeper_prompt_requires_mastered_state_before_promotion():
     assert "confirm via `read_memory` that the target item is already" in MEMORY_KEEPER_SYSTEM_PROMPT
     assert "first call `update_memory_status` to set it to `mastered`" in MEMORY_KEEPER_SYSTEM_PROMPT
+
+
+def test_memory_keeper_prompt_rejects_misspelled_word_pollution():
+    assert "Treat spelling corrections, nonexistent-word feedback" in MEMORY_KEEPER_SYSTEM_PROMPT
+    assert "Do not create `area_to_improve` items for misspelled" in MEMORY_KEEPER_SYSTEM_PROMPT
+    assert "leave it to WordKeeper unless a recurring durable pattern is named" in MEMORY_KEEPER_SYSTEM_PROMPT

--- a/tests/agents/specialists/test_word_keeper.py
+++ b/tests/agents/specialists/test_word_keeper.py
@@ -131,6 +131,12 @@ def test_word_keeper_prompt_rejects_exercise_wording_as_save_signal():
     )
 
 
+def test_word_keeper_prompt_saves_corrected_word_not_misspelling():
+    assert "Save the corrected Swedish vocabulary item" in WORDKEEPER_SYSTEM_PROMPT
+    assert "Never save the student's erroneous form in this case." in WORDKEEPER_SYSTEM_PROMPT
+    assert "save only the corrected Swedish item supplied by the teacher" in WORDKEEPER_SYSTEM_PROMPT
+
+
 def test_word_keeper_extraction_schema_is_key_only():
     fields = WordSaveCandidate.model_fields
     assert set(fields) == {"word_phrase", "source_form"}

--- a/tests/agents/test_coordinator.py
+++ b/tests/agents/test_coordinator.py
@@ -87,6 +87,8 @@ def test_memory_keeper_prompt_mentions_student_driven_memory_requests():
     assert "older `history`" in COORDINATOR_POST_RESPONSE_PROMPT
     assert 'Student: "Forget my old goal."' in COORDINATOR_POST_RESPONSE_PROMPT
     assert 'Teacher: "You have now clearly mastered this tense."' in COORDINATOR_POST_RESPONSE_PROMPT
+    assert "misspelled, invalid, nonexistent" in COORDINATOR_POST_RESPONSE_PROMPT
+    assert "That is a vocabulary correction, not a durable memory update." in COORDINATOR_POST_RESPONSE_PROMPT
 
 
 def test_news_prompt_requires_known_topic():
@@ -124,6 +126,7 @@ def test_word_keeper_prompt_does_not_allow_anticipatory_post_routing():
     assert "The teacher is only asking the student to practice, answer, or write another sentence using words." in (
         COORDINATOR_POST_RESPONSE_PROMPT
     )
+    assert "provides\n  the corrected Swedish vocabulary item" in COORDINATOR_POST_RESPONSE_PROMPT
 
 
 def test_word_keeper_prompt_limits_pre_stage_to_explicit_save_requests():


### PR DESCRIPTION
## Summary
- prevent post-response MemoryKeeper routing from treating misspelled/nonexistent student word forms as durable memory updates
- route explicit teacher word corrections to WordKeeper so corrected vocabulary can be prioritized instead of persisting erroneous forms
- add regression tests for coordinator, MemoryKeeper prompt rules, and WordKeeper prompt rules

## Validation
- make check-readiness
  - backend: 834 passed
  - frontend: 457 passed
  - frontend build dry-run passed

## Task
- jLNKrqEwCJTE