### PR TITLE
[codex] Fix adverb cheatsheet typo

### DIFF
--- a/cheatsheets/adverbs/adjektiv_vs_adverb.md
+++ b/cheatsheets/adverbs/adjektiv_vs_adverb.md
@@ -8,7 +8,7 @@
 
 **adjektiv + t = adverb**
 
-`snabb → snabbt` · `tyst → tystt` · `lugn → lugnt`
+`snabb → snabbt` · `tyst → tyst` · `lugn → lugnt`
 
 ---
 

--- a/cheatsheets/adverbs/adjektiv_vs_adverb.md
+++ b/cheatsheets/adverbs/adjektiv_vs_adverb.md
@@ -8,7 +8,7 @@
 
 **adjektiv + t = adverb**
 
-`snabb → snabbt` · `tyst → tyst` · `lugn → lugnt`
+`snabb → snabbt` · `pigg → piggt` · `lugn → lugnt`
 
 ---
 


### PR DESCRIPTION
## Summary
- fix the incorrect `tyst -> tystt` example in the new adjective-vs-adverb cheatsheet

## Why
Commit `3bb3544` added [`/Users/40min/.codex/worktrees/a555/runestone/cheatsheets/adverbs/adjektiv_vs_adverb.md`](/Users/40min/.codex/worktrees/a555/runestone/cheatsheets/adverbs/adjektiv_vs_adverb.md), but the golden-rule example showed the wrong Swedish adverb form for `tyst`.

## Impact
This removes a user-facing grammar error from the referenced cheatsheet without changing any code paths.

## Validation
- `rg -n "tystt|tyst → tyst" cheatsheets/adverbs/adjektiv_vs_adverb.md`
- commit-time pre-commit hooks passed (`trim trailing whitespace`, `fix end of files`, merge-conflict and large-file checks)
