### PR TITLE
Adjust chat bubble collapse behavior and preserve response time labels

### DIFF
--- a/frontend/src/components/ui/ChatMessageBubble.test.tsx
+++ b/frontend/src/components/ui/ChatMessageBubble.test.tsx
@@ -154,10 +154,10 @@ describe("ChatMessageBubble", () => {
 
   it("collapses long messages and toggles via button", async () => {
     const user = userEvent.setup();
-    const longText = "a".repeat(301);
+    const longText = "a".repeat(451);
     render(<ChatMessageBubble role="user" content={longText} />);
 
-    expect(screen.getByText("a".repeat(300))).toBeInTheDocument();
+    expect(screen.getByText("a".repeat(450))).toBeInTheDocument();
     expect(screen.getByText("...")).toBeInTheDocument();
     expect(screen.queryByText(longText)).not.toBeInTheDocument();
 
@@ -170,12 +170,12 @@ describe("ChatMessageBubble", () => {
     const showLessBtn = screen.getByRole("button", { name: /show less/i });
     await user.click(showLessBtn);
 
-    expect(screen.getByText("a".repeat(300))).toBeInTheDocument();
+    expect(screen.getByText("a".repeat(450))).toBeInTheDocument();
     expect(screen.getByText("...")).toBeInTheDocument();
   });
 
   it("does not collapse long messages if isLast is true", () => {
-    const longText = "a".repeat(301);
+    const longText = "a".repeat(451);
     render(
       <ChatMessageBubble role="user" content={longText} isLast={true} />,
     );
@@ -185,21 +185,44 @@ describe("ChatMessageBubble", () => {
   });
 
   it("collapses long assistant teaching messages", () => {
-    const longText = "a".repeat(320);
+    const longText = "a".repeat(470);
     render(<ChatMessageBubble role="assistant" content={longText} />);
 
-    expect(screen.getByText("a".repeat(300))).toBeInTheDocument();
+    expect(screen.getByText("a".repeat(450))).toBeInTheDocument();
     expect(screen.getByText("...")).toBeInTheDocument();
   });
 
   it("does not collapse long messages when latest by role", () => {
-    const longText = "a".repeat(301);
+    const longText = "a".repeat(451);
     render(
       <ChatMessageBubble role="assistant" content={longText} isLatestByRole={true} />,
     );
 
-    expect(screen.getByText("a".repeat(301))).toBeInTheDocument();
+    expect(screen.getByText("a".repeat(451))).toBeInTheDocument();
     expect(screen.queryByText("...")).not.toBeInTheDocument();
+  });
+
+  it("includes sources in collapse limit and hides them while collapsed", async () => {
+    const user = userEvent.setup();
+    render(
+      <ChatMessageBubble
+        role="assistant"
+        content={"a".repeat(440)}
+        sources={[
+          {
+            title: "T".repeat(20),
+            url: "https://example.com/news",
+            date: "2026-02-05",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.queryByText("Sources")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /show more/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /show more/i }));
+    expect(screen.getByText("Sources")).toBeInTheDocument();
   });
 
   it("renders assistant response time as visible copy", () => {

--- a/frontend/src/components/ui/ChatMessageBubble.tsx
+++ b/frontend/src/components/ui/ChatMessageBubble.tsx
@@ -58,12 +58,20 @@ export const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = ({
   onReplayAudio,
   studentAvatarLabel = "You",
 }) => {
-  const maxCollapsedChars = 300;
-  const isLongMessage = content.length > maxCollapsedChars;
+  const maxCollapsedChars = 450;
   const [isExpanded, setIsExpanded] = useState(false);
+  const hasSources = role === "assistant" && sources && sources.length > 0;
+  const sourcesLength = hasSources
+    ? sources.reduce(
+        (total, source) =>
+          total + source.title.length + source.url.length + source.date.length,
+        0,
+      )
+    : 0;
+  const isLongMessage = content.length + sourcesLength > maxCollapsedChars;
   const shouldKeepExpanded = isLast || isLatestByRole;
   const isCollapsed = !shouldKeepExpanded && isLongMessage && !isExpanded;
-  const hasSources = role === "assistant" && sources && sources.length > 0;
+  const shouldShowSources = hasSources && !isCollapsed;
   const messageTime = formatMessageTime(createdAt);
   const showResponseTime =
     role === "assistant" &&
@@ -236,26 +244,6 @@ export const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = ({
           </Typography>
         )}
 
-        {!shouldKeepExpanded && isLongMessage && (
-          <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
-            <IconButton
-              onClick={() => setIsExpanded(!isExpanded)}
-              size="small"
-              aria-label={isExpanded ? "Show less" : "Show more"}
-              sx={{
-                color: "var(--primary-color)",
-                mt: 0.5,
-                backgroundColor: "rgba(56, 224, 123, 0.08)",
-                borderRadius: "6px",
-                "&:hover": {
-                  backgroundColor: "rgba(56, 224, 123, 0.14)",
-                },
-              }}
-            >
-              {isExpanded ? <ChevronUp size={18} /> : <ChevronDown size={18} />}
-            </IconButton>
-          </Box>
-        )}
         {role === "assistant" && showAudioControls && (
           <Box
             sx={{
@@ -313,7 +301,7 @@ export const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = ({
             </Button>
           </Box>
         )}
-        {hasSources && (
+        {shouldShowSources && (
           <Box sx={{ mt: 1.5 }}>
             <Typography
               sx={(theme) => ({
@@ -382,6 +370,25 @@ export const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = ({
                 </Box>
               ))}
             </Box>
+          </Box>
+        )}
+        {!shouldKeepExpanded && isLongMessage && (
+          <Box sx={{ display: "flex", justifyContent: "flex-end", mt: 1 }}>
+            <IconButton
+              onClick={() => setIsExpanded(!isExpanded)}
+              size="small"
+              aria-label={isExpanded ? "Show less" : "Show more"}
+              sx={{
+                color: "var(--primary-color)",
+                backgroundColor: "rgba(56, 224, 123, 0.08)",
+                borderRadius: "6px",
+                "&:hover": {
+                  backgroundColor: "rgba(56, 224, 123, 0.14)",
+                },
+              }}
+            >
+              {isExpanded ? <ChevronUp size={18} /> : <ChevronDown size={18} />}
+            </IconButton>
           </Box>
         )}
         {(responseTimeLabel || messageTime) && (

--- a/frontend/src/components/ui/ChatMessageBubble.tsx
+++ b/frontend/src/components/ui/ChatMessageBubble.tsx
@@ -64,7 +64,7 @@ export const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = ({
   const sourcesLength = hasSources
     ? sources.reduce(
         (total, source) =>
-          total + source.title.length + source.url.length + source.date.length,
+          total + (source.title?.length ?? 0) + (source.url?.length ?? 0) + (source.date?.length ?? 0),
         0,
       )
     : 0;

--- a/frontend/src/hooks/useChat.test.ts
+++ b/frontend/src/hooks/useChat.test.ts
@@ -190,6 +190,54 @@ describe('useChat', () => {
     });
   });
 
+  it('should derive assistant response time from history timestamps', async () => {
+    mockFetch.mockImplementation((url, options) => {
+      if (options?.method === 'GET' || !options?.method) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve(
+              buildHistoryPayload(
+                [
+                  {
+                    id: 1,
+                    role: 'user',
+                    content: 'Hej',
+                    created_at: '2026-04-30T09:00:00.000Z',
+                  },
+                  {
+                    id: 2,
+                    role: 'assistant',
+                    content: 'Hej! Hur mår du?',
+                    created_at: '2026-04-30T09:00:01.420Z',
+                  },
+                ],
+                'chat-1',
+                2
+              )
+            ),
+        });
+      }
+
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ message: 'Response' }),
+      });
+    });
+
+    const { result } = renderHook(() => useChat());
+
+    await waitFor(() => {
+      const assistant = result.current.messages.find((message) => message.role === 'assistant');
+      expect(assistant).toEqual(
+        expect.objectContaining({
+          content: 'Hej! Hur mår du?',
+          responseTimeMs: 1420,
+        })
+      );
+    });
+  });
+
   it('should preserve optimistic assistant message id after history synchronization', async () => {
     mockNow.mockReturnValueOnce(1000).mockReturnValueOnce(1500);
     let historyCallCount = 0;

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -70,7 +70,7 @@ const deriveResponseTimesFromTimestamps = (messages: ChatMessage[]): ChatMessage
     const hasValidTimestamp = Number.isFinite(messageTimestampMs);
 
     if (message.role === 'user') {
-      latestUserTimestampMs = hasValidTimestamp ? messageTimestampMs : latestUserTimestampMs;
+      latestUserTimestampMs = hasValidTimestamp ? messageTimestampMs : null;
       return message;
     }
 

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -62,6 +62,34 @@ const MAX_POLL_INTERVAL_MS = 60000;
 const HISTORY_LIMIT = 200;
 const INITIAL_HISTORY_ERROR = 'Failed to load chat history. Starting fresh.';
 
+const deriveResponseTimesFromTimestamps = (messages: ChatMessage[]): ChatMessage[] => {
+  let latestUserTimestampMs: number | null = null;
+
+  return messages.map((message) => {
+    const messageTimestampMs = message.createdAt ? new Date(message.createdAt).getTime() : Number.NaN;
+    const hasValidTimestamp = Number.isFinite(messageTimestampMs);
+
+    if (message.role === 'user') {
+      latestUserTimestampMs = hasValidTimestamp ? messageTimestampMs : latestUserTimestampMs;
+      return message;
+    }
+
+    if (typeof message.responseTimeMs === 'number') {
+      return message;
+    }
+
+    if (!hasValidTimestamp || latestUserTimestampMs === null) {
+      return message;
+    }
+
+    const computedResponseTime = Math.max(0, Math.round(messageTimestampMs - latestUserTimestampMs));
+    return {
+      ...message,
+      responseTimeMs: computedResponseTime,
+    };
+  });
+};
+
 export const useChat = (): UseChatReturn => {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -188,10 +216,10 @@ export const useChat = (): UseChatReturn => {
         if (chatChanged) {
           currentChatIdRef.current = data.chat_id;
           lastMessageIdRef.current = maxIncomingId ?? 0;
-          setMessages(serverMessages);
+          setMessages(deriveResponseTimesFromTimestamps(serverMessages));
           setHistorySyncNotice(data.history_truncated ? 'Some older messages are no longer available.' : null);
         } else {
-          setMessages(prev => mergeServerMessages(prev, serverMessages));
+          setMessages((prev) => deriveResponseTimesFromTimestamps(mergeServerMessages(prev, serverMessages)));
           if (typeof maxIncomingId === 'number' && maxIncomingId > lastMessageIdRef.current) {
             lastMessageIdRef.current = maxIncomingId;
           }


### PR DESCRIPTION
Summary

Increase chat collapse threshold to 450 chars.
Include assistant sources in collapse-size calculation.
Keep collapse toggle directly above timestamp row, including when sources are present.
Derive responseTimeMs for history-loaded assistant messages from timestamps when explicit value is missing.
Expand frontend tests for collapse + response-time behavior.
Changed files

frontend/src/components/ui/ChatMessageBubble.tsx
frontend/src/components/ui/ChatMessageBubble.test.tsx
frontend/src/hooks/useChat.ts
frontend/src/hooks/useChat.test.ts
Validation

make frontend-test ✅ (37 files, 460 tests)

tests/agents/test_teacher.py::test_build_agent
assertion mismatch in teacher system prompt string (at most 2 grammar material URLs)
Re-ran directly: uv run pytest tests/agents/test_teacher.py::test_build_agent -v ❌ (same failure)
If you want, I can also give you a 1-line “Why this change” summary tuned for reviewers.