### PR TITLE
[codex] fix teacher grammar source citations

### DIFF
--- a/src/runestone/agents/manager.py
+++ b/src/runestone/agents/manager.py
@@ -574,7 +574,8 @@ class AgentsManager:
         specialist_sources = self._extract_pre_result_sources(pre_results or [])
         merged_sources: list[dict[str, str]] = specialist_sources[:] if specialist_sources else []
         seen_urls = {source["url"] for source in merged_sources}
-        grammar_sources = self._extract_grammar_sources(grammar_source_urls or [], seen_urls)
+        grammar_result_urls = self._extract_search_grammar_result_urls(messages or [])
+        grammar_sources = self._extract_grammar_sources(grammar_source_urls or [], grammar_result_urls, seen_urls)
         merged_sources.extend(grammar_sources)
 
         for msg in reversed(messages or []):
@@ -614,18 +615,47 @@ class AgentsManager:
     def _extract_grammar_sources(
         self,
         grammar_source_urls: list[str],
+        allowed_urls: set[str],
         seen_urls: set[str],
     ) -> list[dict[str, str]]:
         """Return grammar references explicitly selected by the Teacher response."""
         sources: list[dict[str, str]] = []
         for url in grammar_source_urls:
-            if not self._is_safe_url(url) or url in seen_urls:
+            if url not in allowed_urls:
+                logger.info("[agents:manager] Rejected grammar source URL (not returned by search_grammar): %s", url)
+                continue
+            if url in seen_urls:
+                logger.info("[agents:manager] Rejected grammar source URL (duplicate): %s", url)
+                continue
+            if not self._is_safe_url(url):
+                logger.info("[agents:manager] Rejected grammar source URL (unsafe): %s", url)
                 continue
             sources.append({"title": self._format_grammar_source_title(url), "url": url, "date": ""})
             seen_urls.add(url)
             if len(sources) == MAX_TEACHER_GRAMMAR_SOURCE_LINKS:
                 break
         return sources
+
+    def _extract_search_grammar_result_urls(self, messages) -> set[str]:
+        """Return exact grammar URLs produced by search_grammar during this teacher turn."""
+        urls: set[str] = set()
+        for msg in messages or []:
+            if not isinstance(msg, ToolMessage):
+                continue
+            payload = self._safe_json_loads(msg.content)
+            tool_name = payload.get("tool") if isinstance(payload, dict) else None
+            if tool_name != "search_grammar":
+                continue
+            results = payload.get("results")
+            if not isinstance(results, list):
+                continue
+            for item in results:
+                if not isinstance(item, dict):
+                    continue
+                raw_url = item.get("url")
+                if isinstance(raw_url, str) and raw_url:
+                    urls.add(raw_url)
+        return urls
 
     @staticmethod
     def _format_grammar_source_title(url: str) -> str:

--- a/src/runestone/agents/specialists/teacher.py
+++ b/src/runestone/agents/specialists/teacher.py
@@ -154,6 +154,8 @@ Rules:
 - Never write the emotion label, JSON envelope, or any avatar instructions inside the student-facing `message`.
 - `grammar_source_urls` must contain at most {MAX_TEACHER_GRAMMAR_SOURCE_LINKS}
   grammar material URLs that are genuinely helpful for this reply.
+- `grammar_source_urls` may contain only exact `url` values returned by the `search_grammar` tool in this same turn.
+- Never invent, guess, reconstruct, or reuse grammar source URLs from memory, chat history, or prior turns.
 - Leave `grammar_source_urls` empty when no grammar material is clearly relevant enough to show.
 - Pick the emotion that best matches the teaching moment:
   - `happy` for praise, celebration, and warm encouragement.
@@ -257,8 +259,10 @@ when the student asks about or it is good moment to refer to it (after some erro
 
 If you are uncertain whether a document is relevant, use `read_grammar_page(path)`
 to read its contents before deciding.
-- Only include a grammar link in `grammar_source_urls` if it clearly helps this exact reply.
+- Only include a grammar link in `grammar_source_urls` if it clearly helps this exact reply and was copied
+  verbatim from the latest `search_grammar` results in this turn.
 - If the search results feel off-topic, partial, or weakly relevant, keep `grammar_source_urls` empty.
+- If you did not call `search_grammar` in this turn, `grammar_source_urls` must be empty.
 
 """
 

--- a/tests/agents/test_manager.py
+++ b/tests/agents/test_manager.py
@@ -546,7 +546,26 @@ async def test_generate_teacher_response_filters_unsafe_urls(mock_settings, mock
 
 
 @pytest.mark.anyio
-async def test_generate_teacher_response_caps_grammar_sources_without_selection(mock_settings, mock_user):
+async def test_generate_teacher_response_requires_search_grammar_result_for_grammar_sources(mock_settings, mock_user):
+    manager = AgentsManager(mock_settings)
+    manager.teacher = AsyncMock()
+    manager.teacher.generate_response.return_value = TeacherGenerationResult(
+        message="Grammatik",
+        grammar_source_urls=[
+            "https://localhost:5173/?view=grammar&cheatsheet=verbs/presens",
+        ],
+        final_messages=[],
+    )
+
+    _response, sources, _teacher_emotion = await manager.generate_teacher_response(
+        message="Grammatik", history=[], user=mock_user, pre_results=[], starter_memory="", recent_side_effects=[]
+    )
+
+    assert sources is None
+
+
+@pytest.mark.anyio
+async def test_generate_teacher_response_caps_search_grammar_selected_sources(mock_settings, mock_user):
     manager = AgentsManager(mock_settings)
     manager.teacher = AsyncMock()
     manager.teacher.generate_response.return_value = TeacherGenerationResult(
@@ -556,7 +575,19 @@ async def test_generate_teacher_response_caps_grammar_sources_without_selection(
             "https://localhost:5173/?view=grammar&cheatsheet=adjectives/adjectiv-komparation",
             "https://localhost:5173/?view=grammar&cheatsheet=word_order/bisatser",
         ],
-        final_messages=[],
+        final_messages=[
+            ToolMessage(
+                content=(
+                    '{"tool":"search_grammar","results":['
+                    '{"title":"Presens","url":"https://localhost:5173/?view=grammar&cheatsheet=verbs/presens"},'
+                    '{"title":"Adjectives",'
+                    '"url":"https://localhost:5173/?view=grammar&cheatsheet=adjectives/adjectiv-komparation"},'
+                    '{"title":"Bisatser","url":"https://localhost:5173/?view=grammar&cheatsheet=word_order/bisatser"}'
+                    "]}"
+                ),
+                tool_call_id="tool-call-grammar-1",
+            )
+        ],
     )
 
     _response, sources, _teacher_emotion = await manager.generate_teacher_response(
@@ -587,7 +618,18 @@ async def test_generate_teacher_response_uses_selected_grammar_sources(mock_sett
             "https://localhost:5173/?view=grammar&cheatsheet=pronouns/possessiva-pronomen",
             "https://localhost:5173/?view=grammar&cheatsheet=word_order/huvudsats",
         ],
-        final_messages=[],
+        final_messages=[
+            ToolMessage(
+                content=(
+                    '{"tool":"search_grammar","results":['
+                    '{"title":"Possessiva pronomen",'
+                    '"url":"https://localhost:5173/?view=grammar&cheatsheet=pronouns/possessiva-pronomen"},'
+                    '{"title":"Huvudsats","url":"https://localhost:5173/?view=grammar&cheatsheet=word_order/huvudsats"}'
+                    "]}"
+                ),
+                tool_call_id="tool-call-grammar-2",
+            )
+        ],
     )
 
     _response, sources, _teacher_emotion = await manager.generate_teacher_response(
@@ -606,6 +648,124 @@ async def test_generate_teacher_response_uses_selected_grammar_sources(mock_sett
             "date": "",
         },
     ]
+
+
+@pytest.mark.anyio
+async def test_generate_teacher_response_rejects_grammar_sources_not_returned_by_search(mock_settings, mock_user):
+    manager = AgentsManager(mock_settings)
+    manager.teacher = AsyncMock()
+    manager.teacher.generate_response.return_value = TeacherGenerationResult(
+        message="Grammatik",
+        grammar_source_urls=[
+            "https://vaxxa.dyndns.org/?view=grammar&cheatsheet=tenses/futurum",
+            "https://localhost:5173/?view=grammar&cheatsheet=tenses/futurum",
+        ],
+        final_messages=[
+            ToolMessage(
+                content=(
+                    '{"tool":"search_grammar","results":['
+                    '{"title":"Futurum","url":"https://localhost:5173/?view=grammar&cheatsheet=tenses/futurum"}'
+                    "]}"
+                ),
+                tool_call_id="tool-call-grammar-3",
+            )
+        ],
+    )
+
+    _response, sources, _teacher_emotion = await manager.generate_teacher_response(
+        message="Grammatik", history=[], user=mock_user, pre_results=[], starter_memory="", recent_side_effects=[]
+    )
+
+    assert sources == [
+        {
+            "title": "Tenses / Futurum",
+            "url": "https://localhost:5173/?view=grammar&cheatsheet=tenses/futurum",
+            "date": "",
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_generate_teacher_response_rejects_same_host_invented_grammar_sources(mock_settings, mock_user):
+    manager = AgentsManager(mock_settings)
+    manager.teacher = AsyncMock()
+    manager.teacher.generate_response.return_value = TeacherGenerationResult(
+        message="Grammatik",
+        grammar_source_urls=[
+            "https://localhost:5173/?view=grammar&cheatsheet=tenses/futurum",
+            "https://localhost:5173/?view=grammar&cheatsheet=tenses/not-from-search",
+        ],
+        final_messages=[
+            ToolMessage(
+                content=(
+                    '{"tool":"search_grammar","results":['
+                    '{"title":"Futurum","url":"https://localhost:5173/?view=grammar&cheatsheet=tenses/futurum"}'
+                    "]}"
+                ),
+                tool_call_id="tool-call-grammar-4",
+            )
+        ],
+    )
+
+    _response, sources, _teacher_emotion = await manager.generate_teacher_response(
+        message="Grammatik", history=[], user=mock_user, pre_results=[], starter_memory="", recent_side_effects=[]
+    )
+
+    assert sources == [
+        {
+            "title": "Tenses / Futurum",
+            "url": "https://localhost:5173/?view=grammar&cheatsheet=tenses/futurum",
+            "date": "",
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_generate_teacher_response_rejects_unsafe_search_grammar_source(mock_settings, mock_user):
+    manager = AgentsManager(mock_settings)
+    manager.teacher = AsyncMock()
+    manager.teacher.generate_response.return_value = TeacherGenerationResult(
+        message="Grammatik",
+        grammar_source_urls=["javascript:alert(1)"],
+        final_messages=[
+            ToolMessage(
+                content='{"tool":"search_grammar","results":[{"title":"Unsafe","url":"javascript:alert(1)"}]}',
+                tool_call_id="tool-call-grammar-5",
+            )
+        ],
+    )
+
+    _response, sources, _teacher_emotion = await manager.generate_teacher_response(
+        message="Grammatik", history=[], user=mock_user, pre_results=[], starter_memory="", recent_side_effects=[]
+    )
+
+    assert sources is None
+
+
+@pytest.mark.anyio
+async def test_generate_teacher_response_rejects_disallowed_port_search_grammar_source(mock_settings, mock_user):
+    manager = AgentsManager(mock_settings)
+    manager.teacher = AsyncMock()
+    manager.teacher.generate_response.return_value = TeacherGenerationResult(
+        message="Grammatik",
+        grammar_source_urls=["http://localhost:8080/?view=grammar&cheatsheet=tenses/futurum"],
+        final_messages=[
+            ToolMessage(
+                content=(
+                    '{"tool":"search_grammar","results":['
+                    '{"title":"Futurum","url":"http://localhost:8080/?view=grammar&cheatsheet=tenses/futurum"}'
+                    "]}"
+                ),
+                tool_call_id="tool-call-grammar-6",
+            )
+        ],
+    )
+
+    _response, sources, _teacher_emotion = await manager.generate_teacher_response(
+        message="Grammatik", history=[], user=mock_user, pre_results=[], starter_memory="", recent_side_effects=[]
+    )
+
+    assert sources is None
 
 
 @pytest.mark.anyio

--- a/tests/agents/test_teacher.py
+++ b/tests/agents/test_teacher.py
@@ -124,7 +124,11 @@ def test_build_agent(mock_settings, mock_chat_model):
             assert "grammar_source_urls" in call_kwargs["system_prompt"]
             assert f"at most {MAX_TEACHER_GRAMMAR_SOURCE_LINKS}" in call_kwargs["system_prompt"]
             assert "grammar material URLs" in call_kwargs["system_prompt"]
+            assert "only exact `url` values returned by the `search_grammar` tool" in call_kwargs["system_prompt"]
+            assert "Never invent, guess, reconstruct, or reuse grammar source URLs" in call_kwargs["system_prompt"]
             assert f"top_k=1..{MAX_TEACHER_GRAMMAR_SOURCE_LINKS}" in call_kwargs["system_prompt"]
+            assert "copied\n  verbatim from the latest `search_grammar` results" in call_kwargs["system_prompt"]
+            assert "If you did not call `search_grammar` in this turn" in call_kwargs["system_prompt"]
             assert "keep `grammar_source_urls` empty" in call_kwargs["system_prompt"]
 
 


### PR DESCRIPTION
## Summary
- constrain Teacher grammar citations to exact URLs returned by same-turn search_grammar tool calls
- harden the Teacher prompt so grammar_source_urls must be copied from search_grammar results only
- log rejected grammar source URLs by reason and cover hallucinated/unsafe cases in tests

## Root cause
The structured Teacher output had a free-form grammar_source_urls field, but the prompt did not explicitly tie it to search_grammar results. After the recent explicit grammar source link change, hallucinated or history-derived URLs could be surfaced as chat sources.

## Validation
- make lint-check
- uv run pytest tests/agents/test_manager.py tests/agents/test_teacher.py -q
- independent code review gate: approved; reviewer also ran .venv/bin/pytest tests/agents/test_manager.py tests/agents/test_teacher.py tests/agents/test_grammar_tools.py -q with 75 passed