### PR TITLE
docs: refresh agent workflow commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,10 @@ Prefer the Makefile targets over spelling out raw tool commands; the Makefile al
 - Use `make check-readiness` before commit-sized changes. It runs lint checks, backend and frontend tests, then a frontend build dry-run.
 - Use scoped checks while iterating: `make backend-test`, `make frontend-test`, `make lint-check`, or targeted `uv run pytest tests/path -v` for backend tests.
 - Bootstrap a fresh worktree with `make setup` or `make install-dev`; use `make install-backend` and `make install-frontend` when only one side of the stack needs dependency refreshes.
+- Use `make run IMAGE_PATH=... GEMINI_API_KEY=...` for the CLI image-processing flow and `make load-vocab CSV_PATH=...` for vocabulary imports instead of calling the package entry points directly.
 - Start services with `make run-backend` (applies Alembic migrations, serves FastAPI on port 8010), `make run-frontend` (Vite on port 5173), or `make run-dev` for both.
-- When touching the Telegram recall worker or containerized dev stack, use `make run-recall`, `make docker-up`, `make docker-down`, and `make docker-build` instead of ad hoc commands.
-- Manage schema changes through Alembic targets: `make db-migrate MESSAGE="..."`, `make db-upgrade`, `make db-current`, and `make db-history`.
+- When touching the Telegram recall worker or containerized dev stack, use `make run-recall`, `make docker-up`, `make docker-down`, and `make docker-build`; when refreshing running containers, prefer `make restart-recall`, `make rebuild-restart-recall`, `make rebuild-restart-all`, or `make rebuild-container NAMES="..."` over ad hoc Docker commands.
+- Manage schema changes through Alembic targets: `make db-init`, `make db-migrate MESSAGE="..."`, `make db-upgrade`, `make db-downgrade REVISION=...`, `make db-current`, and `make db-history`.
 - Use prompt and RAG smoke targets when touching prompt construction or grammar retrieval: `make test-prompts-ocr`, `make test-prompts-analysis TEXT="..."`, `make test-prompts-vocabulary WORD="..."`, and `make test-grammar-search QUERY="..."`.
 
 For LangChain `@tool` tests, use `.ainvoke()` for tools without `ToolRuntime`; use `.coroutine(runtime, ...)` with a manually constructed runtime for tools that depend on `ToolRuntime` context.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,11 +11,9 @@ Prefer the Makefile targets over spelling out raw tool commands; the Makefile al
 - Use `make check-readiness` before commit-sized changes. It runs lint checks, backend and frontend tests, then a frontend build dry-run.
 - Use scoped checks while iterating: `make backend-test`, `make frontend-test`, `make lint-check`, or targeted `uv run pytest tests/path -v` for backend tests.
 - Bootstrap a fresh worktree with `make setup` or `make install-dev`; use `make install-backend` and `make install-frontend` when only one side of the stack needs dependency refreshes.
-- Use `make run IMAGE_PATH=... GEMINI_API_KEY=...` for the CLI image-processing flow and `make load-vocab CSV_PATH=...` for vocabulary imports instead of calling the package entry points directly.
 - Start services with `make run-backend` (applies Alembic migrations, serves FastAPI on port 8010), `make run-frontend` (Vite on port 5173), or `make run-dev` for both.
-- When touching the Telegram recall worker or containerized dev stack, use `make run-recall`, `make docker-up`, `make docker-down`, and `make docker-build`; when refreshing running containers, prefer `make restart-recall`, `make rebuild-restart-recall`, `make rebuild-restart-all`, or `make rebuild-container NAMES="..."` over ad hoc Docker commands.
+- When touching the Telegram recall worker or containerized dev stack, use `make run-recall`, `make docker-up`, `make docker-down`, and `make docker-build`; when refreshing running containers, prefer `make restart-recall`, `make rebuild-restart-recall`, or `make rebuild-restart-all` over ad hoc Docker commands.
 - Manage schema changes through Alembic targets: `make db-init`, `make db-migrate MESSAGE="..."`, `make db-upgrade`, `make db-downgrade REVISION=...`, `make db-current`, and `make db-history`.
-- Use prompt and RAG smoke targets when touching prompt construction or grammar retrieval: `make test-prompts-ocr`, `make test-prompts-analysis TEXT="..."`, `make test-prompts-vocabulary WORD="..."`, and `make test-grammar-search QUERY="..."`.
 
 For LangChain `@tool` tests, use `.ainvoke()` for tools without `ToolRuntime`; use `.coroutine(runtime, ...)` with a manually constructed runtime for tools that depend on `ToolRuntime` context.
 


### PR DESCRIPTION
## Summary
- add the Makefile wrappers for CLI image processing and vocabulary imports to `AGENTS.md`
- document the Docker container refresh targets used when updating recall/containerized dev flows
- include the Alembic init and downgrade targets alongside the existing migration commands

## Testing
- not run (documentation-only change)