### PR TITLE
[codex] Add vocabulary lookup modal flow

### DIFF
--- a/frontend/src/components/AddEditVocabularyModal.test.tsx
+++ b/frontend/src/components/AddEditVocabularyModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import AddEditVocabularyModal from "./AddEditVocabularyModal";
 import { VOCABULARY_IMPROVEMENT_MODES } from "../constants";
@@ -29,6 +29,8 @@ describe("AddEditVocabularyModal", () => {
   const mockOnClose = vi.fn();
   const mockOnSave = vi.fn();
   const mockOnDelete = vi.fn();
+  const mockOnLookup = vi.fn();
+  const mockOnLookupFound = vi.fn();
 
   const defaultProps = {
     open: true,
@@ -36,6 +38,8 @@ describe("AddEditVocabularyModal", () => {
     onClose: mockOnClose,
     onSave: mockOnSave,
     onDelete: mockOnDelete,
+    onLookup: mockOnLookup,
+    onLookupFound: mockOnLookupFound,
   };
 
   const renderWithAuthProvider = (component: React.ReactElement) => {
@@ -50,6 +54,8 @@ describe("AddEditVocabularyModal", () => {
     mockOnClose.mockClear();
     mockOnSave.mockClear();
     mockOnDelete.mockClear();
+    mockOnLookup.mockClear();
+    mockOnLookupFound.mockClear();
     mockImproveVocabularyItem.mockClear();
   });
 
@@ -107,6 +113,112 @@ describe("AddEditVocabularyModal", () => {
     await user.click(cancelButton);
 
     expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+
+  it("disables lookup button when word phrase is empty", () => {
+    renderWithAuthProvider(<AddEditVocabularyModal {...defaultProps} />);
+
+    expect(screen.getByTitle("Look up existing word")).toBeDisabled();
+  });
+
+  it("looks up the trimmed word and shows a found notification", async () => {
+    const user = userEvent.setup();
+    mockOnLookup.mockResolvedValue({
+      id: 7,
+      user_id: 1,
+      word_phrase: "hej",
+      translation: "hello",
+      example_phrase: "Hej!",
+      extra_info: "interjection",
+      in_learn: true,
+      priority_learn: 3,
+      last_learned: null,
+      created_at: "2023-10-27T10:00:00Z",
+    });
+
+    renderWithAuthProvider(<AddEditVocabularyModal {...defaultProps} />);
+
+    await user.type(screen.getByLabelText("Swedish Word/Phrase"), "  hej  ");
+    await user.click(screen.getByTitle("Look up existing word"));
+
+    await waitFor(() => {
+      expect(mockOnLookup).toHaveBeenCalledWith("hej");
+      expect(
+        screen.getByText("Found existing word: hej. Editing saved entry.")
+      ).toBeInTheDocument();
+      expect(mockOnLookupFound).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 7, word_phrase: "hej" })
+      );
+    });
+  });
+
+
+
+  it("ignores a lookup result after the modal is closed", async () => {
+    const user = userEvent.setup();
+    let resolveLookup: (item: unknown) => void = () => {};
+    mockOnLookup.mockReturnValue(
+      new Promise((resolve) => {
+        resolveLookup = resolve;
+      })
+    );
+
+    renderWithAuthProvider(<AddEditVocabularyModal {...defaultProps} />);
+
+    await user.type(screen.getByLabelText("Swedish Word/Phrase"), "hej");
+    await user.click(screen.getByTitle("Look up existing word"));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await act(async () => {
+      resolveLookup({
+        id: 7,
+        user_id: 1,
+        word_phrase: "hej",
+        translation: "hello",
+        example_phrase: "Hej!",
+        extra_info: null,
+        in_learn: true,
+        priority_learn: 3,
+        last_learned: null,
+        created_at: "2023-10-27T10:00:00Z",
+      });
+    });
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByText("Found existing word: hej. Editing saved entry.")
+    ).not.toBeInTheDocument();
+    expect(mockOnLookupFound).not.toHaveBeenCalled();
+  });
+
+  it("keeps add mode and shows a not-found notification when lookup misses", async () => {
+    const user = userEvent.setup();
+    mockOnLookup.mockResolvedValue(null);
+
+    renderWithAuthProvider(<AddEditVocabularyModal {...defaultProps} />);
+
+    await user.type(screen.getByLabelText("Swedish Word/Phrase"), "nytt");
+    await user.click(screen.getByTitle("Look up existing word"));
+
+    await waitFor(() => {
+      expect(screen.getByText("No existing word found.")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Add Vocabulary Item")).toBeInTheDocument();
+  });
+
+  it("shows an inline error when lookup fails", async () => {
+    const user = userEvent.setup();
+    mockOnLookup.mockRejectedValue(new Error("Lookup failed"));
+
+    renderWithAuthProvider(<AddEditVocabularyModal {...defaultProps} />);
+
+    await user.type(screen.getByLabelText("Swedish Word/Phrase"), "hej");
+    await user.click(screen.getByTitle("Look up existing word"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Lookup failed")).toBeInTheDocument();
+    });
   });
 
   it("fills all fields when Fill All icon button is clicked", async () => {

--- a/frontend/src/components/AddEditVocabularyModal.tsx
+++ b/frontend/src/components/AddEditVocabularyModal.tsx
@@ -1,24 +1,27 @@
-import React, { useState, useEffect } from "react";
-import { Modal, Box, TextField, Typography, IconButton, FormControl, InputLabel, Select, MenuItem } from "@mui/material";
+import React, { useState, useEffect, useRef } from "react";
+import {
+  Modal,
+  Box,
+  TextField,
+  Typography,
+  IconButton,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  CircularProgress,
+} from "@mui/material";
 import AutoFixNormal from "@mui/icons-material/AutoFixNormal";
 import AutoFixHigh from "@mui/icons-material/AutoFixHigh";
-import { CustomButton, StyledCheckbox } from "./ui";
-import { improveVocabularyItem } from "../hooks/useVocabulary";
+import Search from "@mui/icons-material/Search";
+import { CustomButton, StyledCheckbox, Snackbar } from "./ui";
+import {
+  improveVocabularyItem,
+  type SavedVocabularyItem,
+} from "../hooks/useVocabulary";
 import { useApi } from "../utils/api";
 import { VOCABULARY_IMPROVEMENT_MODES, type VocabularyImprovementMode } from "../constants";
 
-interface SavedVocabularyItem {
-  id: number;
-  user_id: number;
-  word_phrase: string;
-  translation: string;
-  example_phrase: string | null;
-  extra_info: string | null;
-  in_learn: boolean;
-  priority_learn: number;
-  last_learned: string | null;
-  created_at: string;
-}
 
 interface AddEditVocabularyModalProps {
   open: boolean;
@@ -26,6 +29,8 @@ interface AddEditVocabularyModalProps {
   onClose: () => void;
   onSave: (updatedItem: Partial<SavedVocabularyItem>) => Promise<void>;
   onDelete?: () => Promise<void>;
+  onLookup?: (wordPhrase: string) => Promise<SavedVocabularyItem | null>;
+  onLookupFound?: (item: SavedVocabularyItem) => void;
 }
 
 const textFieldStyles = {
@@ -57,6 +62,8 @@ const AddEditVocabularyModal: React.FC<AddEditVocabularyModalProps> = ({
   onClose,
   onSave,
   onDelete,
+  onLookup,
+  onLookupFound,
 }) => {
   const [wordPhrase, setWordPhrase] = useState("");
   const [translation, setTranslation] = useState("");
@@ -65,6 +72,12 @@ const AddEditVocabularyModal: React.FC<AddEditVocabularyModalProps> = ({
   const [inLearn, setInLearn] = useState(false);
   const [priorityLearn, setPriorityLearn] = useState(DEFAULT_PRIORITY_LEARN);
   const [isImproving, setIsImproving] = useState(false);
+  const [isLookingUp, setIsLookingUp] = useState(false);
+  const [lookupMessage, setLookupMessage] = useState<string | null>(null);
+  const [lookupSeverity, setLookupSeverity] = useState<"success" | "info">(
+    "info"
+  );
+  const lookupRequestIdRef = useRef(0);
   const [error, setError] = useState<string | null>(null);
 
   // Get authenticated API client
@@ -72,6 +85,7 @@ const AddEditVocabularyModal: React.FC<AddEditVocabularyModalProps> = ({
 
   useEffect(() => {
     setError(null);
+    setLookupMessage(null);
     if (item) {
       setWordPhrase(item.word_phrase);
       setTranslation(item.translation);
@@ -111,6 +125,9 @@ const AddEditVocabularyModal: React.FC<AddEditVocabularyModalProps> = ({
   };
 
   const handleClose = () => {
+    lookupRequestIdRef.current += 1;
+    setIsLookingUp(false);
+    setLookupMessage(null);
     onClose();
   };
 
@@ -141,6 +158,43 @@ const AddEditVocabularyModal: React.FC<AddEditVocabularyModalProps> = ({
     }
   };
 
+  const handleLookupVocabulary = async () => {
+    const trimmedWordPhrase = wordPhrase.trim();
+    if (!trimmedWordPhrase || !onLookup) return;
+
+    const requestId = lookupRequestIdRef.current + 1;
+    lookupRequestIdRef.current = requestId;
+
+    setError(null);
+    setIsLookingUp(true);
+    try {
+      const foundItem = await onLookup(trimmedWordPhrase);
+      if (requestId !== lookupRequestIdRef.current) return;
+      if (foundItem) {
+        setLookupSeverity("success");
+        setLookupMessage(
+          `Found existing word: ${foundItem.word_phrase}. Editing saved entry.`
+        );
+        onLookupFound?.(foundItem);
+      } else {
+        setLookupSeverity("info");
+        setLookupMessage("No existing word found.");
+      }
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error
+          ? err.message
+          : "Failed to look up vocabulary item";
+      if (requestId === lookupRequestIdRef.current) {
+        setError(errorMessage);
+      }
+    } finally {
+      if (requestId === lookupRequestIdRef.current) {
+        setIsLookingUp(false);
+      }
+    }
+  };
+
   const handleFillAll = () => handleImproveVocabulary(VOCABULARY_IMPROVEMENT_MODES.ALL_FIELDS);
 
   const handleFillExample = () => handleImproveVocabulary(VOCABULARY_IMPROVEMENT_MODES.EXAMPLE_ONLY);
@@ -152,7 +206,8 @@ const AddEditVocabularyModal: React.FC<AddEditVocabularyModalProps> = ({
       aria-labelledby="edit-vocabulary-modal"
       aria-describedby="edit-vocabulary-modal-description"
     >
-      <Box
+      <Box>
+        <Box
         sx={{
           position: "absolute",
           top: "50%",
@@ -187,14 +242,45 @@ const AddEditVocabularyModal: React.FC<AddEditVocabularyModalProps> = ({
         </Box>
 
         <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-          <TextField
-            label="Swedish Word/Phrase"
-            value={wordPhrase}
-            onChange={(e) => setWordPhrase(e.target.value)}
-            fullWidth
-            variant="outlined"
-            sx={textFieldStyles}
-          />
+          <Box sx={{ position: "relative" }}>
+            <TextField
+              label="Swedish Word/Phrase"
+              value={wordPhrase}
+              onChange={(e) => setWordPhrase(e.target.value)}
+              fullWidth
+              variant="outlined"
+              sx={{
+                ...textFieldStyles,
+                "& .MuiOutlinedInput-input": {
+                  pr: 5,
+                },
+              }}
+            />
+            <IconButton
+              aria-label="Look up vocabulary word"
+              onClick={handleLookupVocabulary}
+              disabled={!wordPhrase.trim() || isLookingUp || !onLookup}
+              sx={{
+                position: "absolute",
+                top: 8,
+                right: 8,
+                color: "var(--primary-color)",
+                "&:hover": {
+                  backgroundColor: "rgba(59, 130, 246, 0.1)",
+                },
+                "&:disabled": {
+                  color: "#6b7280",
+                },
+              }}
+              title="Look up existing word"
+            >
+              {isLookingUp ? (
+                <CircularProgress size={20} color="inherit" />
+              ) : (
+                <Search />
+              )}
+            </IconButton>
+          </Box>
 
           <TextField
             label="English Translation"
@@ -376,6 +462,14 @@ const AddEditVocabularyModal: React.FC<AddEditVocabularyModalProps> = ({
             </Box>
           </Box>
         </Box>
+      </Box>
+        <Snackbar
+          open={Boolean(lookupMessage)}
+          message={lookupMessage || ""}
+          severity={lookupSeverity}
+          autoHideDuration={3500}
+          onClose={() => setLookupMessage(null)}
+        />
       </Box>
     </Modal>
   );

--- a/frontend/src/components/VocabularyView.test.tsx
+++ b/frontend/src/components/VocabularyView.test.tsx
@@ -32,6 +32,7 @@ vi.mock('../hooks/useVocabulary', () => ({
     updateVocabularyItem: vi.fn(),
     createVocabularyItem: vi.fn(),
     deleteVocabularyItem: vi.fn(),
+    lookupVocabularyItem: vi.fn(),
   })),
 }));
 
@@ -103,6 +104,7 @@ describe("VocabularyView", () => {
       updateVocabularyItem: vi.fn(),
       createVocabularyItem: vi.fn(),
       deleteVocabularyItem: vi.fn(),
+      lookupVocabularyItem: vi.fn(),
     });
 
     renderWithAuthProvider(<VocabularyView />);
@@ -124,6 +126,7 @@ describe("VocabularyView", () => {
       updateVocabularyItem: vi.fn(),
       createVocabularyItem: vi.fn(),
       deleteVocabularyItem: vi.fn(),
+      lookupVocabularyItem: vi.fn(),
     });
 
     const { rerender } = renderWithAuthProvider(<VocabularyView />);
@@ -157,6 +160,7 @@ describe("VocabularyView", () => {
       updateVocabularyItem: vi.fn(),
       createVocabularyItem: vi.fn(),
       deleteVocabularyItem: vi.fn(),
+      lookupVocabularyItem: vi.fn(),
     });
 
     rerender(<VocabularyView />);
@@ -192,6 +196,7 @@ describe("VocabularyView", () => {
       updateVocabularyItem: vi.fn(),
       createVocabularyItem: vi.fn(),
       deleteVocabularyItem: vi.fn(),
+      lookupVocabularyItem: vi.fn(),
     });
 
     rerender(<VocabularyView />);
@@ -319,6 +324,7 @@ describe("VocabularyView", () => {
       updateVocabularyItem: vi.fn(),
       createVocabularyItem: vi.fn(),
       deleteVocabularyItem: vi.fn(),
+      lookupVocabularyItem: vi.fn(),
     });
 
     renderWithAuthProvider(<VocabularyView />);
@@ -379,6 +385,7 @@ describe("VocabularyView", () => {
       updateVocabularyItem: vi.fn(),
       createVocabularyItem: vi.fn(),
       deleteVocabularyItem: vi.fn(),
+      lookupVocabularyItem: vi.fn(),
     });
 
     renderWithAuthProvider(<VocabularyView />);
@@ -415,6 +422,7 @@ describe("VocabularyView", () => {
       updateVocabularyItem: vi.fn(),
       createVocabularyItem: vi.fn(),
       deleteVocabularyItem: vi.fn(),
+      lookupVocabularyItem: vi.fn(),
     });
 
     renderWithAuthProvider(<VocabularyView />);
@@ -436,6 +444,7 @@ describe("VocabularyView", () => {
       updateVocabularyItem: vi.fn(),
       createVocabularyItem: vi.fn(),
       deleteVocabularyItem: vi.fn(),
+      lookupVocabularyItem: vi.fn(),
     });
 
     renderWithAuthProvider(<VocabularyView />);
@@ -457,6 +466,7 @@ describe("VocabularyView", () => {
       updateVocabularyItem: vi.fn(),
       createVocabularyItem: vi.fn(),
       deleteVocabularyItem: vi.fn(),
+      lookupVocabularyItem: vi.fn(),
     });
 
     renderWithAuthProvider(<VocabularyView />);
@@ -478,6 +488,7 @@ describe("VocabularyView", () => {
       updateVocabularyItem: vi.fn(),
       createVocabularyItem: vi.fn(),
       deleteVocabularyItem: vi.fn(),
+      lookupVocabularyItem: vi.fn(),
     });
 
     renderWithAuthProvider(<VocabularyView />);
@@ -504,6 +515,7 @@ describe("VocabularyView", () => {
       updateVocabularyItem: vi.fn(),
       createVocabularyItem: vi.fn(),
       deleteVocabularyItem: vi.fn(),
+      lookupVocabularyItem: vi.fn(),
     };
 
     mockUseRecentVocabulary.mockReturnValue(mockHookReturn);
@@ -534,6 +546,7 @@ describe("VocabularyView", () => {
       updateVocabularyItem: vi.fn(),
       createVocabularyItem: vi.fn(),
       deleteVocabularyItem: vi.fn(),
+      lookupVocabularyItem: vi.fn(),
     });
 
     renderWithAuthProvider(<VocabularyView />);
@@ -560,6 +573,7 @@ describe("VocabularyView", () => {
       updateVocabularyItem: vi.fn(),
       createVocabularyItem: vi.fn(),
       deleteVocabularyItem: vi.fn(),
+      lookupVocabularyItem: vi.fn(),
     });
 
     renderWithAuthProvider(<VocabularyView />);
@@ -592,6 +606,7 @@ describe("VocabularyView", () => {
       updateVocabularyItem: vi.fn(),
       createVocabularyItem: vi.fn(),
       deleteVocabularyItem: vi.fn(),
+      lookupVocabularyItem: vi.fn(),
     });
 
     renderWithAuthProvider(<VocabularyView />);
@@ -653,6 +668,7 @@ describe("VocabularyView", () => {
       updateVocabularyItem: vi.fn(),
       createVocabularyItem: vi.fn(),
       deleteVocabularyItem: vi.fn(),
+      lookupVocabularyItem: vi.fn(),
     });
 
     renderWithAuthProvider(<VocabularyView />);
@@ -716,6 +732,7 @@ describe("VocabularyView", () => {
       updateVocabularyItem: vi.fn(),
       createVocabularyItem: vi.fn(),
       deleteVocabularyItem: vi.fn(),
+      lookupVocabularyItem: vi.fn(),
     });
 
     renderWithAuthProvider(<VocabularyView />);
@@ -768,6 +785,7 @@ describe("VocabularyView", () => {
       updateVocabularyItem,
       createVocabularyItem: vi.fn(),
       deleteVocabularyItem: vi.fn(),
+      lookupVocabularyItem: vi.fn(),
     });
 
     renderWithAuthProvider(<VocabularyView />);
@@ -810,6 +828,7 @@ describe("VocabularyView", () => {
       updateVocabularyItem,
       createVocabularyItem: vi.fn(),
       deleteVocabularyItem: vi.fn(),
+      lookupVocabularyItem: vi.fn(),
     });
 
     renderWithAuthProvider(<VocabularyView />);
@@ -867,6 +886,7 @@ describe("VocabularyView", () => {
       updateVocabularyItem,
       createVocabularyItem: vi.fn(),
       deleteVocabularyItem: vi.fn(),
+      lookupVocabularyItem: vi.fn(),
     });
 
     renderWithAuthProvider(<VocabularyView />);
@@ -930,6 +950,7 @@ describe("VocabularyView", () => {
       updateVocabularyItem,
       createVocabularyItem: vi.fn(),
       deleteVocabularyItem: vi.fn(),
+      lookupVocabularyItem: vi.fn(),
     });
 
     renderWithAuthProvider(<VocabularyView />);
@@ -983,6 +1004,7 @@ describe("VocabularyView", () => {
       updateVocabularyItem,
       createVocabularyItem: vi.fn(),
       deleteVocabularyItem,
+      lookupVocabularyItem: vi.fn(),
     });
 
     return { deleteVocabularyItem, refetchStats, updateVocabularyItem };

--- a/frontend/src/components/VocabularyView.tsx
+++ b/frontend/src/components/VocabularyView.tsx
@@ -50,6 +50,7 @@ const VocabularyView: React.FC = () => {
     updateVocabularyItem,
     createVocabularyItem,
     deleteVocabularyItem,
+    lookupVocabularyItem,
   } = useRecentVocabulary(activeSearchTerm, preciseSearch);
   const loadMoreSentinelRef = useRef<HTMLDivElement | null>(null);
 
@@ -430,6 +431,8 @@ const VocabularyView: React.FC = () => {
         onClose={closeEditModal}
         onSave={handleSaveEdit}
         onDelete={handleDelete}
+        onLookup={lookupVocabularyItem}
+        onLookupFound={openEditModal}
       />
     </Box>
   );

--- a/frontend/src/hooks/useVocabulary.test.ts
+++ b/frontend/src/hooks/useVocabulary.test.ts
@@ -668,6 +668,85 @@ describe('useRecentVocabulary', () => {
     });
   });
 
+
+  it('should look up vocabulary item with precise case-insensitive search and set editing item when found', async () => {
+    const foundItem = {
+      id: 7,
+      user_id: 1,
+      word_phrase: 'hej',
+      translation: 'hello',
+      example_phrase: 'Hej!',
+      extra_info: null,
+      in_learn: true,
+      priority_learn: 3,
+      last_learned: null,
+      learned_times: 0,
+      created_at: '2023-10-27T10:00:00Z',
+      updated_at: '2023-10-27T10:00:00Z',
+    };
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve([]),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve([foundItem]),
+      });
+
+    const { result } = renderHook(() => useRecentVocabulary());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    let lookupResult: unknown = null;
+    await act(async () => {
+      lookupResult = await result.current.lookupVocabularyItem('  hej  ');
+    });
+
+    expect(lookupResult).toEqual(foundItem);
+    expect(result.current.editingItem).toBeNull();
+    expect(result.current.isEditModalOpen).toBe(false);
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      'http://localhost:8010/api/vocabulary?search_query=hej&limit=1&precise=true',
+      expect.objectContaining({
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+    );
+  });
+
+  it('should keep add mode when vocabulary lookup has no match', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve([]),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+
+    const { result } = renderHook(() => useRecentVocabulary());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    let lookupResult: unknown = 'not-called';
+    await act(async () => {
+      lookupResult = await result.current.lookupVocabularyItem('nytt');
+    });
+
+    expect(lookupResult).toBeNull();
+    expect(result.current.editingItem).toBeNull();
+    expect(result.current.isEditModalOpen).toBe(false);
+  });
+
   it('should create vocabulary item successfully', async () => {
     const mockCreatedItem = {
       id: 3,

--- a/frontend/src/hooks/useVocabulary.ts
+++ b/frontend/src/hooks/useVocabulary.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useApi } from "../utils/api";
 import type { VocabularyImprovementMode } from "../constants";
 
-interface SavedVocabularyItem {
+export interface SavedVocabularyItem {
   id: number;
   user_id: number;
   word_phrase: string;
@@ -50,6 +50,7 @@ interface UseRecentVocabularyReturn {
   ) => Promise<void>;
   createVocabularyItem: (item: Partial<SavedVocabularyItem>) => Promise<void>;
   deleteVocabularyItem: (id: number) => Promise<void>;
+  lookupVocabularyItem: (wordPhrase: string) => Promise<SavedVocabularyItem | null>;
 }
 
 interface UseVocabularyStatsReturn {
@@ -278,6 +279,26 @@ export const useRecentVocabulary = (
     [closeEditModal, apiDelete]
   );
 
+  const lookupVocabularyItem = useCallback(
+    async (wordPhrase: string) => {
+      const trimmedWordPhrase = wordPhrase.trim();
+      if (!trimmedWordPhrase) {
+        return null;
+      }
+
+      const params = new URLSearchParams({
+        search_query: trimmedWordPhrase,
+        limit: "1",
+        precise: "true",
+      });
+      const data = await get<SavedVocabularyItem[]>(
+        `/api/vocabulary?${params.toString()}`
+      );
+      return data[0] ?? null;
+    },
+    [get]
+  );
+
   useEffect(() => {
     fetchRecentVocabulary();
   }, [searchQuery, preciseSearch, fetchRecentVocabulary]);
@@ -297,6 +318,7 @@ export const useRecentVocabulary = (
     updateVocabularyItem,
     createVocabularyItem,
     deleteVocabularyItem,
+    lookupVocabularyItem,
   };
 };
 


### PR DESCRIPTION
## Summary
- add a lookup button to the add/edit vocabulary modal word field
- reuse precise vocabulary search to find existing entries by trimmed word
- switch fresh lookup hits into the existing edit flow and show snackbar feedback
- guard against stale lookup results after cancel/close

## Validation
- npm test -- AddEditVocabularyModal VocabularyView useVocabulary
- npm run lint
- npm run build
- uv run pytest tests/api/test_endpoints.py tests/db/test_vocabulary_repository.py tests/services/test_services_vocabulary_service.py -k 'precise' -q

## Review
- Ran independent GPT-5.5 code review; fixed the requested stale lookup response issue.