### PR TITLE
Refactor teacher vocabulary candidate routing and WordKeeper flow

### DIFF
--- a/cheatsheets/adjectives/adjective_t_special.md
+++ b/cheatsheets/adjectives/adjective_t_special.md
@@ -1,0 +1,56 @@
+# Adverb #2 — Adjektiv + t: special
+
+> When there's no real noun to describe, Swedish defaults to neuter **-t**. Because *something* has to take the hit.
+
+---
+
+## Rule 1 — "Det är" + adjektiv + t
+
+`Det är` is a dummy subject — it refers to nothing specific, so the adjektiv goes neuter.
+
+| Exempel                                 | Pattern             |
+| --------------------------------------- | ------------------- |
+| Det är **nyttigt** att springa.         | "Det är" + adj**t** |
+| Det är **roligt** att lära sig svenska. | "Det är" + adj**t** |
+
+---
+
+## Rule 2 — Att-clause as subject → adjektiv + t
+
+When the subject is an **att + infinitive** or an **att-bisats** (that-clause), same deal — neuter -t.
+
+| Exempel                          | Pattern                    |
+| -------------------------------- | -------------------------- |
+| Att springa är **nyttigt**.      | att + infinitiv → adj**t** |
+| Att han springer är **nyttigt**. | att + bisats → adj**t**    |
+
+> The clause *acts* as a noun, but it has no gender. Swedish panics and picks neuter. Fair enough.
+
+---
+
+## Rule 3 — General vs Specific (the sneaky one)
+
+|                                | Exempel                         | Why                                |
+| ------------------------------ | ------------------------------- | ---------------------------------- |
+| **General** (no specific noun) | Sill är **gott**.               | No specific herring → neuter -t    |
+| **General**                    | Simning är **stort** i Sverige. | Swimming in general → neuter -t    |
+| **Specific** (a real noun)     | Den här sillen är **god**.      | *Den här sillen* = en-word → no -t |
+
+> **Sill är gott** = herring as a concept is tasty (philosophical)
+> **Den här sillen är god** = *this specific herring* is tasty (practical)
+
+---
+
+## Summary — when does -t kick in?
+
+| Trigger                                    | Form             | Exempel                                                |
+| ------------------------------------------ | ---------------- | ------------------------------------------------------ |
+| `Det är ...`                               | adj + **t**      | Det är **svårt**.                                      |
+| `Att [göra] är ...`                        | adj + **t**      | Att vänta är **tråkigt**.                              |
+| `Att [bisats] är ...`                      | adj + **t**      | Att du kom är **viktigt**.                             |
+| General noun (no article, no specific ref) | adj + **t**      | Kaffe är **gott**.                                     |
+| Specific noun                              | agrees with noun | Det här kaffet är **gott** / Den här kakan är **god**. |
+
+---
+
+*When in doubt: is there a real, specific noun? No → slap a -t on it and move on.*

--- a/cheatsheets/index.json
+++ b/cheatsheets/index.json
@@ -26,6 +26,19 @@
     "path": "adjectives/swedish_adjectives_cheatsheet.md"
   },
   {
+    "url": "{HOST}/?view=grammar&cheatsheet=adjectives%2Fadjective_t_special",
+    "tags": [
+      "adjectives",
+      "adverbs",
+      "neuter",
+      "adjective + t",
+      "det är",
+      "att-clause"
+    ],
+    "annotation": "Explains special cases where Swedish adjectives take neuter -t without a specific noun, including 'det är', att-clauses, and general noun references.",
+    "path": "adjectives/adjective_t_special.md"
+  },
+  {
     "url": "{HOST}/?view=grammar&cheatsheet=adjectives%2Futrop-med-adj",
     "tags": [
       "adjectives",

--- a/docs/agent-swarm-architecture.md
+++ b/docs/agent-swarm-architecture.md
@@ -154,9 +154,17 @@ Runs in `pre_response` when:
 
 - the student explicitly asks to save or remember words
 
-Runs in `post_response` when:
+Runs after the teacher response when:
 
-- the teacher reply explicitly highlights words worth learning
+- `TeacherOutput.vocabulary_candidates` is non-empty
+- `AgentsManager` dispatches a direct background `word_keeper` branch in parallel with
+  coordinator-owned post specialists
+
+Does not do:
+
+- mine post-stage vocabulary from teacher prose
+- inspect distant chat history to resolve vague earlier-turn save requests
+- receive post-stage routing from the post coordinator
 
 #### MemoryKeeper
 
@@ -373,11 +381,10 @@ Decision:
 
 - handle in pre stage
 
-Teacher-highlighted vocabulary examples:
+Teacher-emitted vocabulary candidate examples:
 
-- "these are key words"
-- "these are good words to memorize"
-- "let's keep these words in mind"
+- `TeacherOutput.vocabulary_candidates = [{"word_phrase": "begripa", "context_phrase": "Jag begriper inte."}]`
+- visible teacher wording may still highlight useful words, but the structured field is the authoritative signal
 
 Decision:
 
@@ -450,14 +457,27 @@ Input:
 Output:
 
 - final user-facing response
+- optional structured `vocabulary_candidates`
 
 ### WordKeeper Contract
 
-Input:
+Pre-response extraction input:
 
 - latest user message
-- recent relevant history
-- teacher response when running in post stage
+- `target_translation_language`
+
+Post-response save/enrichment input:
+
+- structured `vocabulary_candidates`
+- `target_translation_language`
+
+Notes:
+
+- pre-response extraction evaluates the current user message and may use the immediately
+  preceding teacher message to resolve deictic save requests
+- post-response WordKeeper does not receive chat history or teacher prose
+- `VocabularyService` normalizes, deduplicates, assigns candidate ids, and prioritizes
+  existing rows before enrichment
 
 Output artifacts:
 

--- a/docs/agent-swarm-plan.md
+++ b/docs/agent-swarm-plan.md
@@ -11,7 +11,7 @@ The following were delivered in `feat/agent-swarm-ms1` through `feat/agent-swarm
 - **MS1**: Introduced specialist interfaces, `SpecialistResult` schema, `agents/specialists/` package, `[agents:<component>]` log convention.
 - **MS2**: Split `AgentService` → `AgentsManager` + `TeacherAgent` as first specialist.
 - **MS3**: Introduced `CoordinatorAgent` for pre/post orchestration with structured `CoordinatorPlan`, concurrent specialist fan-out, and `agent_side_effects` persistence.
-- **MS4**: Extracted `WordKeeper` specialist; pre-response fast path for explicit save requests; post-response path for teacher-highlighted vocabulary.
+- **MS4**: Extracted `WordKeeper` specialist; pre-response fast path for explicit save requests; later refined so post-response saves come from structured `TeacherOutput.vocabulary_candidates`.
 
 ## Design Direction (Post-MS4)
 
@@ -85,7 +85,9 @@ If stale (`pending`/`running`/`failed`): log loudly, cancel task, mark failed, c
 ### Milestone 8: Align Specialist Routing
 
 Update coordinator prompt:
-- WordKeeper eligible for `post_response` when teacher highlights vocabulary
+- WordKeeper pre-routing stays current-message-only for explicit save requests
+- post-response teacher vocabulary is no longer coordinator-routed; Teacher emits structured
+  `vocabulary_candidates` and `AgentsManager` launches the direct WordKeeper background branch
 - News routing: known topic → pre; vague request → skip
 - Remove any grammar-specialist routing mentions
 

--- a/docs/todo/structured-intent-architecture.md
+++ b/docs/todo/structured-intent-architecture.md
@@ -73,16 +73,28 @@ Intents should declare *what needs to happen*, not carry extracted data. The Tea
 structuring word lists or memory corrections inside `intents` is the same attention problem
 in a different field.
 
-Subagents receive the full conversation context anyway — WordKeeper can find the vocabulary
-itself. That's its job. Keeping intents as pure signals means:
+In the current Runestone architecture, vocabulary saving no longer uses a pure enum-only
+intent. Teacher returns a typed response envelope with student-facing text plus optional
+structured `vocabulary_candidates`. That narrower payload works because it is a bounded,
+tested side-effect channel rather than an open-ended intent bag.
+
+Keeping most intents as pure signals still means:
 
 - The Teacher stays focused on generation and declaration only
 - Intents remain cheap to emit regardless of enum size
 - Subagents own their extraction logic, not the Teacher
 
-The one exception: a minimal disambiguation hint when the subagent genuinely can't resolve
-something from context — e.g. an explicit Teacher override. This should be rare and
-case-specific, not a default payload shape.
+The current vocabulary exception is intentional:
+
+- pre-response explicit save requests are still extracted by WordKeeper from the current user message
+- post-response saves use Teacher-owned structured `vocabulary_candidates`
+- WordKeeper no longer mines teacher prose or full chat history in post phase
+
+Possible next simplification:
+
+- remove the pre-response WordKeeper save fast path entirely
+- let Teacher own explicit save-request reactions as part of the normal reply
+- route all vocabulary persistence through post-response structured `vocabulary_candidates`
 
 ---
 

--- a/docs/todo/wordkeeper-vocabulary-save-standardization.md
+++ b/docs/todo/wordkeeper-vocabulary-save-standardization.md
@@ -72,11 +72,51 @@ If WordKeeper is unsure, it should leave `extra_info` empty rather than guess.
 WordKeeper now splits prioritization from addition so it does not generate complete
 candidate payloads before knowing whether the word already exists:
 
-1. WordKeeper extracts raw candidate word keys from the current turn.
+1. Candidate formation depends on phase:
+   - pre-response: WordKeeper extracts candidates from the current explicit save-request message
+   - post-response: Teacher emits structured `vocabulary_candidates`
 2. `VocabularyService` normalizes and deduplicates the candidate list, assigns
    stable candidate IDs, and prioritizes existing vocabulary rows.
-3. Only for genuinely new candidate IDs, ask the LLM to generate full add payload
+3. Only for genuinely new candidate IDs, ask the enrichment LLM to generate full add payload
    fields: `translation`, `example_phrase`, and optional `extra_info`.
+
+Current contract notes:
+
+- pre-response extraction reads the current user message and may use the immediately
+  preceding teacher message to resolve words referenced deictically
+- post-response saving no longer depends on parsing teacher prose
+- post-response enrichment runs from candidate artifacts plus target translation language
+
+## Future Follow-Ups
+
+### 1. Refactor WordKeeper and AgentsManager after post-phase simplification
+
+Now that post-response vocabulary saving is driven by structured `TeacherOutput.vocabulary_candidates`,
+there is still some orchestration and specialist complexity left over from the older split path.
+
+Future cleanup should revisit:
+
+- whether `WordKeeperSpecialist` should be split more explicitly into extraction-only and enrichment/persistence-only code paths
+- whether `AgentsManager` should own less vocabulary-specific filtering and branching logic
+- whether the post-phase direct WordKeeper branch can be expressed through a smaller, clearer contract
+
+The goal is to make the post-response save path easier to read, easier to test, and less coupled
+to the pre-response explicit-save flow.
+
+### 2. Remove the pre-response WordKeeper save stage
+
+The current pre-response save path still exists for explicit student save requests. A possible
+next simplification is to remove that stage entirely and let Teacher react to save requests in the
+normal reply, then emit structured `vocabulary_candidates` for post-response handling.
+
+If this is pursued, the design should ensure:
+
+- explicit student requests like "save that word" remain supported through Teacher behavior
+- WordKeeper no longer needs extraction logic for chat-time save requests
+- Coordinator no longer routes `word_keeper` in pre-response at all
+- tests cover that explicit save requests are still persisted through the Teacher-owned structured path
+
+This would further reduce branching in the swarm and make vocabulary saving fully post-response.
 
 Existing prioritized rows should not get blank `translation`, `example_phrase`, or
 `extra_info` fields auto-filled by that follow-up prioritization flow. Those fields

--- a/src/runestone/agents/coordinator.py
+++ b/src/runestone/agents/coordinator.py
@@ -35,7 +35,8 @@ Your sole job is to decide which specialist agents to route to for the current s
 - Always emit valid JSON matching the CoordinatorPlan schema. No extra text outside the JSON.
 
 ## Chat History Window
-- Set `chat_history_size` to a small even integer (e.g. 2, 4, 6) to keep specialist inputs stable and testable.
+- Set `chat_history_size` to a small non-negative integer
+  (e.g. 0, 2, 4, 6) to keep specialist inputs stable and testable.
 - Default to `2` for most specialists unless a specific routing rule below says otherwise.
 """
 
@@ -57,11 +58,13 @@ COORDINATOR_PRE_RESPONSE_PROMPT = (
 **Route when:**
 - The current student message explicitly asks to save vocabulary in this turn
   (e.g. "save this word", "remember this phrase", "add this to my list").
-- Decide this primarily from the current student message, not from earlier student messages in `history`.
+- This includes cases where the student explicitly names the words to save in the current message
+  (e.g. "save `begripa` and `noggrann`") or clearly points to words present in that same message
+  (e.g. "save these words for me: beskriva, bekräfta").
+- This also includes deictic save requests that clearly refer to words from the immediately preceding
+  teacher message (e.g. "save that word", "remember those words").
+- Decide this from the current student message only.
 - Do not treat an earlier student request to practice/save a word as an active save request for the current turn.
-- If the current student explicitly asks to save words from an earlier turn
-  (e.g. "save the words you mentioned before"), you may use `history` to identify
-  those words and increase `chat_history_size` accordingly.
 
 **Do NOT route when:**
 - The student merely reused a word without a save request.
@@ -72,7 +75,7 @@ COORDINATOR_PRE_RESPONSE_PROMPT = (
   (e.g. "next task", "let's continue", "another exercise", "I'm done").
 - Words were already saved in earlier turns — do not re-trigger on later turns.
 
-For all normal word_keeper cases, set `chat_history_size` to `2`.
+Set `chat_history_size` to `0` for `word_keeper`.
 
 ### news_agent (pre)
 **Route when:** The student's current message asks about a specific real-time or current-events topic that requires
@@ -136,28 +139,6 @@ Examples that should NOT route:
 - Teacher: "Good job."
 - Teacher: "Write one more sentence with these words."
 - Teacher: "There is no such word as 'varen'; use 'våren' for spring."
-
-### word_keeper (post)
-
-**Route when:**
-- The actual `teacher_response` explicitly marks vocabulary as worth saving
-  (e.g. "the key words here are…", "good words to memorize",
-  "let's keep these words in mind").
-- The teacher clearly presents a vocabulary-saving moment, not just vocabulary usage inside a drill.
-- The teacher explicitly corrects a misspelled, invalid, or nonexistent student-written word and provides
-  the corrected Swedish vocabulary item. Route so WordKeeper can prioritize the corrected item, not the error.
-
-Examples that SHOULD route:
-- Teacher: "There is no such word as 'varen'; use 'våren' for spring."
-
-**Do NOT route when:**
-- The teacher is only asking the student to practice, answer, or write another sentence using words.
-- Words are merely bolded, translated, grammatically corrected, or reused in an exercise prompt without
-  an explicit memory/save signal or a corrected Swedish vocabulary item.
-- The teacher gives an example sentence using words but does not say they are important to memorize or save.
-- The response is an ordinary exercise, correction, explanation, or drill rather than a vocabulary-saving moment.
-
-For all normal word_keeper cases, set `chat_history_size` to `2`.
 """
 )
 

--- a/src/runestone/agents/manager.py
+++ b/src/runestone/agents/manager.py
@@ -29,6 +29,7 @@ from runestone.core.exceptions import RunestoneError
 from runestone.core.observability import elapsed_ms_since
 from runestone.db.models import User
 from runestone.rag.index import GrammarIndex
+from runestone.schemas.vocabulary_save import WordSaveCandidate
 from runestone.services.agent_side_effect_service import AgentSideEffectService
 from runestone.services.grammar_service import GrammarService
 
@@ -43,7 +44,6 @@ class AgentsManager:
     """
 
     COORDINATOR_MAX_HISTORY_MESSAGES = 5
-    WORD_KEEPER_MAX_HISTORY_MESSAGES = 2
     POST_TASK_TIMEOUT_SECONDS = 15
     STARTER_MEMORY_PERSONAL_LIMIT = 50
     STARTER_MEMORY_AREA_LIMIT = 5
@@ -186,9 +186,9 @@ class AgentsManager:
         pre_results: list[dict],
         starter_memory: str,
         recent_side_effects: list[TeacherSideEffect],
-    ) -> tuple[str, Optional[list[dict[str, str]]], TeacherEmotion]:
+    ) -> tuple[str, Optional[list[dict[str, str]]], TeacherEmotion, list[WordSaveCandidate]]:
         """
-        Run teacher agent synchronously and return (response_text, sources, teacher_emotion).
+        Run teacher agent synchronously and return visible response data plus vocabulary candidates.
         """
         try:
             generated = await self.teacher.generate_response(
@@ -208,7 +208,7 @@ class AgentsManager:
             messages=generated.final_messages,
             grammar_source_urls=generated.grammar_source_urls,
         )
-        return generated.message, sources, generated.emotion
+        return generated.message, sources, generated.emotion, generated.vocabulary_candidates
 
     async def process_turn(
         self,
@@ -247,7 +247,7 @@ class AgentsManager:
             side_effect_service=side_effect_service,
         )
 
-        assistant_text, sources, teacher_emotion = await self.generate_teacher_response(
+        assistant_text, sources, teacher_emotion, vocabulary_candidates = await self.generate_teacher_response(
             message=message,
             history=history,
             user=user,
@@ -267,6 +267,7 @@ class AgentsManager:
             history=history,
             user=user,
             teacher_response=assistant_text,
+            vocabulary_candidates=vocabulary_candidates,
             pre_results=pre_results,
             coordinator_row_id=coordinator_row_id,
         )
@@ -280,6 +281,7 @@ class AgentsManager:
         history: list[ChatMessage],
         user: User,
         teacher_response: str,
+        vocabulary_candidates: list[WordSaveCandidate] | None,
         pre_results: list[dict],
         side_effect_service: AgentSideEffectService,
         coordinator_row_id: int,
@@ -292,32 +294,12 @@ class AgentsManager:
         await side_effect_service.mark_coordinator_running(coordinator_row_id)
 
         try:
-            coordinator_history = history[-self.COORDINATOR_MAX_HISTORY_MESSAGES :] if history else []
-            if history and len(history) > self.COORDINATOR_MAX_HISTORY_MESSAGES:
-                logger.warning(
-                    "[agents:manager] Truncated coordinator history from %s to %s messages",
-                    len(history),
-                    len(coordinator_history),
-                )
-
-            plan = await self.coordinator.plan_post_turn(
-                message=message,
-                history=coordinator_history,
-                teacher_response=teacher_response,
-                available_specialists=[name for name in self.registry.list_names() if name != "teacher"],
-            )
-            logger.info(
-                "[agents:manager] Post-phase selection: user_id=%s specialists=%s",
-                user.id,
-                ",".join([item.name for item in plan.post_response]) if plan.post_response else "none",
-            )
-
-            post_results = await self._run_specialists(
-                plan.post_response,
+            post_results, coordinator_failed = await self._run_post_branches(
                 message=message,
                 history=history,
                 user=user,
                 teacher_response=teacher_response,
+                vocabulary_candidates=vocabulary_candidates or [],
                 pre_results=pre_results,
             )
             persisted = await side_effect_service.replace_post_specialist_results(
@@ -334,6 +316,18 @@ class AgentsManager:
                     coordinator_row_id,
                 )
                 return
+            if coordinator_failed:
+                await side_effect_service.mark_coordinator_failed_if_current(
+                    row_id=coordinator_row_id,
+                    user_id=user.id,
+                    chat_id=chat_id,
+                )
+                logger.warning(
+                    "[agents:manager] Post-turn completed with coordinator failure: user_id=%s chat_id=%s",
+                    user.id,
+                    chat_id,
+                )
+                return
             await side_effect_service.mark_coordinator_done_if_current(
                 row_id=coordinator_row_id,
                 user_id=user.id,
@@ -348,6 +342,99 @@ class AgentsManager:
                 chat_id=chat_id,
             )
             raise
+
+    async def _run_post_branches(
+        self,
+        *,
+        message: str,
+        history: list[ChatMessage],
+        user: User,
+        teacher_response: str,
+        vocabulary_candidates: list[WordSaveCandidate],
+        pre_results: list[dict],
+    ) -> tuple[list[dict], bool]:
+        filtered_vocabulary_candidates = self._filter_post_vocabulary_candidates(
+            vocabulary_candidates,
+            pre_results=pre_results,
+        )
+
+        async def _coordinator_branch() -> list[dict]:
+            coordinator_history = history[-self.COORDINATOR_MAX_HISTORY_MESSAGES :] if history else []
+            if history and len(history) > self.COORDINATOR_MAX_HISTORY_MESSAGES:
+                logger.warning(
+                    "[agents:manager] Truncated coordinator history from %s to %s messages",
+                    len(history),
+                    len(coordinator_history),
+                )
+
+            plan = await self.coordinator.plan_post_turn(
+                message=message,
+                history=coordinator_history,
+                teacher_response=teacher_response,
+                available_specialists=[
+                    name for name in self.registry.list_names() if name not in {"teacher", "word_keeper"}
+                ],
+            )
+            post_items = [item for item in plan.post_response if item.name != "word_keeper"]
+            logger.info(
+                "[agents:manager] Post-phase selection: user_id=%s specialists=%s",
+                user.id,
+                ",".join([item.name for item in post_items]) if post_items else "none",
+            )
+            return await self._run_specialists(
+                post_items,
+                message=message,
+                history=history,
+                user=user,
+                teacher_response=teacher_response,
+                pre_results=pre_results,
+            )
+
+        async def _word_keeper_branch() -> list[dict]:
+            if not filtered_vocabulary_candidates:
+                return []
+            return await self._run_specialists(
+                [
+                    RoutingItem(
+                        name="word_keeper",
+                        reason="teacher emitted vocabulary_candidates",
+                        chat_history_size=0,
+                    )
+                ],
+                message=message,
+                history=history,
+                user=user,
+                teacher_response=teacher_response,
+                vocabulary_candidates=filtered_vocabulary_candidates,
+                pre_results=pre_results,
+            )
+
+        coordinator_results, word_keeper_results = await asyncio.gather(
+            _coordinator_branch(),
+            _word_keeper_branch(),
+            return_exceptions=True,
+        )
+
+        post_results: list[dict] = []
+        coordinator_failed = False
+        if isinstance(coordinator_results, Exception):
+            coordinator_failed = True
+            logger.error(
+                "[agents:manager] Coordinator post branch failed",
+                exc_info=(type(coordinator_results), coordinator_results, coordinator_results.__traceback__),
+            )
+        else:
+            post_results.extend(coordinator_results)
+
+        if isinstance(word_keeper_results, Exception):
+            logger.error(
+                "[agents:manager] Direct WordKeeper post branch failed",
+                exc_info=(type(word_keeper_results), word_keeper_results, word_keeper_results.__traceback__),
+            )
+        else:
+            post_results.extend(word_keeper_results)
+
+        return post_results, coordinator_failed
 
     # ------------------------------------------------------------------
     # Background task registry
@@ -370,6 +457,7 @@ class AgentsManager:
         history: list[ChatMessage],
         user: User,
         teacher_response: str,
+        vocabulary_candidates: list[WordSaveCandidate] | None,
         pre_results: list[dict],
         coordinator_row_id: int,
     ) -> None:
@@ -388,6 +476,7 @@ class AgentsManager:
                                 history=history,
                                 user=user,
                                 teacher_response=teacher_response,
+                                vocabulary_candidates=vocabulary_candidates or [],
                                 pre_results=pre_results,
                                 side_effect_service=background_side_effect_service,
                                 coordinator_row_id=coordinator_row_id,
@@ -471,23 +560,19 @@ class AgentsManager:
         history: list[ChatMessage],
         user: User,
         teacher_response: str | None = None,
+        vocabulary_candidates: list[WordSaveCandidate] | None = None,
         pre_results: list[dict] | None = None,
     ) -> list[dict]:
         if not routing_items:
             return []
 
+        previous_teacher_message = self._previous_teacher_message(history)
+
         async def _invoke(item, specialist):
             started = time.monotonic()
             effective_history_size = item.chat_history_size
             if item.name == "word_keeper":
-                effective_history_size = min(item.chat_history_size, self.WORD_KEEPER_MAX_HISTORY_MESSAGES)
-                if item.chat_history_size != effective_history_size:
-                    logger.warning(
-                        "[agents:manager] Capped specialist history for '%s' from %s to %s messages",
-                        item.name,
-                        item.chat_history_size,
-                        effective_history_size,
-                    )
+                effective_history_size = 0
 
             history_window = history[-effective_history_size:] if effective_history_size else []
             if effective_history_size and len(history) > effective_history_size:
@@ -501,7 +586,12 @@ class AgentsManager:
                 message=message,
                 history=history_window,
                 user=user,
-                teacher_response=teacher_response,
+                teacher_response=(
+                    None
+                    if item.name == "word_keeper" and vocabulary_candidates
+                    else previous_teacher_message if item.name == "word_keeper" else teacher_response
+                ),
+                vocabulary_candidates=vocabulary_candidates or [],
                 pre_results=pre_results or [],
                 routing_reason=item.reason,
                 chat_history_size=effective_history_size,
@@ -552,6 +642,65 @@ class AgentsManager:
 
         # Fan-out / fan-in: run specialists concurrently but preserve routing order.
         return await asyncio.gather(*tasks)
+
+    @staticmethod
+    def _previous_teacher_message(history: list[ChatMessage]) -> str | None:
+        """Return the immediately preceding assistant message only when it is adjacent."""
+        if not history:
+            return None
+        item = history[-1]
+        if item.role == "assistant" and item.content:
+            return item.content
+        return None
+
+    @classmethod
+    def _filter_post_vocabulary_candidates(
+        cls,
+        candidates: list[WordSaveCandidate],
+        *,
+        pre_results: list[dict],
+    ) -> list[WordSaveCandidate]:
+        """Drop teacher candidates that were already saved by pre-response WordKeeper this turn."""
+        if not candidates:
+            return []
+
+        previously_saved = cls._pre_saved_word_keys(pre_results)
+        if not previously_saved:
+            return candidates
+
+        return [
+            candidate
+            for candidate in candidates
+            if (dedupe_key := cls._normalize_word_key(candidate.word_phrase)) and dedupe_key not in previously_saved
+        ]
+
+    @classmethod
+    def _pre_saved_word_keys(cls, pre_results: list[dict]) -> set[str]:
+        """Collect normalized word keys already saved by pre-response WordKeeper artifacts."""
+        keys: set[str] = set()
+        for item in pre_results:
+            if item.get("name") != "word_keeper":
+                continue
+            result = item.get("result")
+            if not isinstance(result, dict):
+                continue
+            artifacts = result.get("artifacts")
+            if not isinstance(artifacts, dict):
+                continue
+
+            for word in artifacts.get("saved_words", []):
+                key = cls._normalize_word_key(word)
+                if key:
+                    keys.add(key)
+
+        return keys
+
+    @staticmethod
+    def _normalize_word_key(word_phrase: object) -> str:
+        """Mirror VocabularyService priority-candidate dedupe for manager-level routing guards."""
+        if not isinstance(word_phrase, str):
+            return ""
+        return word_phrase.strip().casefold()
 
     @staticmethod
     def _safe_json_loads(payload):

--- a/src/runestone/agents/schemas.py
+++ b/src/runestone/agents/schemas.py
@@ -12,6 +12,7 @@ from typing import Any, Literal, Optional
 from pydantic import BaseModel, Field, HttpUrl, field_validator
 
 from runestone.constants import DEFAULT_TEACHER_EMOTION, TeacherEmotion
+from runestone.schemas.vocabulary_save import WordSaveCandidate
 
 
 def normalize_teacher_emotion(value: Any) -> TeacherEmotion:
@@ -131,6 +132,10 @@ class TeacherOutput(BaseModel):
         default_factory=list,
         description="Grammar reference URLs selected by Teacher to surface alongside the reply",
     )
+    vocabulary_candidates: list[WordSaveCandidate] = Field(
+        default_factory=list,
+        description="Teacher-proposed Swedish vocabulary candidates for post-response WordKeeper handling",
+    )
 
     @field_validator("emotion", mode="before")
     @classmethod
@@ -167,6 +172,7 @@ class TeacherGenerationResult:
     message: str
     emotion: TeacherEmotion = DEFAULT_TEACHER_EMOTION
     grammar_source_urls: list[str] | None = None
+    vocabulary_candidates: list[WordSaveCandidate] = field(default_factory=list)
     final_messages: list[Any] = field(default_factory=list)
 
 

--- a/src/runestone/agents/specialists/base.py
+++ b/src/runestone/agents/specialists/base.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, Field, StringConstraints
 
 from runestone.agents.schemas import ChatMessage
+from runestone.schemas.vocabulary_save import WordSaveCandidate
 
 INFO_FOR_TEACHER_MAX_CHARS = 12000
 
@@ -15,6 +16,7 @@ class SpecialistContext(BaseModel):
     history: list[ChatMessage] = Field(default_factory=list)
     user: Any
     teacher_response: str | None = None
+    vocabulary_candidates: list[WordSaveCandidate] = Field(default_factory=list)
     pre_results: list[dict[str, Any]] = Field(default_factory=list)
     routing_reason: str = ""
     chat_history_size: int = 0

--- a/src/runestone/agents/specialists/teacher.py
+++ b/src/runestone/agents/specialists/teacher.py
@@ -189,20 +189,38 @@ Post-phase memory maintenance is handled by internal specialists.
 ### WORDKEEPER SPECIALIST
 Word-saving is handled by an internal helper specialist called `WordKeeper`, not by a tool you call directly.
 
-Use natural wording to surface candidate vocabulary when helpful, for example:
-- "The key words here are ..."
-- "These are good words to memorize ..."
-- "Let's keep these words in mind ..."
-- "These are useful words to remember ..."
+When you notice genuinely useful Swedish vocabulary worth saving from the current teaching moment, put it in the
+structured `vocabulary_candidates` field. This structured field is the authoritative signal for post-response
+word saving.
+
+Candidate rules:
+- Leave `vocabulary_candidates` empty when there are no useful words to save.
+- `word_phrase` is the canonical Swedish learning item, not a noisy slice of a sentence.
+- `context_phrase` is the Swedish sentence or phrase that introduced the word when one is available.
+- Use `source_form` only when the observed form differs from the canonical `word_phrase`.
+- Be conservative: do not invent vocabulary candidates just because Swedish words appear in the conversation.
+- Do not add words from routine drills like "write a sentence with ..." unless you explicitly want them remembered.
+- You may still naturally highlight useful vocabulary in the visible `message` when it helps the student.
+
+Normalization rules for `word_phrase`:
+- No leading articles: save `hund`, not `en hund`; save `äpple`, not `ett äpple`.
+- Allow definite or bestämd forms when the form itself is the learning target.
+- Use smart lowercase: lowercase ordinary words, but preserve acronyms, personal names, proper nouns, and fixed casing.
+- Prefer lemma or base form unless the inflected form matters.
+- Do not save bare `att` for verbs; keep `att` inside real constructions such as
+  `ha svårt att`, `komma att`, or `se till att`.
+- Preserve particles, prepositions, and reflexives that change meaning, such as
+  `tycka om`, `hälsa på`, `höra av sig`, and `se fram emot`.
+- Preserve fixed phrases exactly, minus surrounding punctuation and extra whitespace.
+- Keep Swedish characters; never ASCII-fold `å`, `ä`, or `ö`.
+- Use canonical duplicate handling so casing, articles, and punctuation do not create near-duplicates.
+- Do not save grammar-only tokens as vocabulary unless explicitly presented as learning items.
 
 Truthfulness rules:
 - Only say words were definitely saved if the internal pre-response specialist
   already confirmed that in this turn.
 - Otherwise, you may highlight useful or memorable words as candidates for
   post-response capture without claiming persistence already happened.
-- Do NOT expect WordKeeper to trigger from ordinary exercise phrasing alone.
-- Phrases like "Write a sentence with ...", "Try again using ...", routine corrections,
-  or bolded vocabulary inside drills should not be treated as save signals by themselves.
 - Keep this guidance compact in your response; do not mention `WordKeeper` or internal routing.
 
 ### MEMORYKEEPER POST-PHASE SIGNALS
@@ -347,6 +365,7 @@ to read its contents before deciding.
                 message=structured_response.message,
                 emotion=structured_response.emotion,
                 grammar_source_urls=structured_response.grammar_source_urls,
+                vocabulary_candidates=structured_response.vocabulary_candidates,
                 final_messages=final_messages,
             )
 

--- a/src/runestone/agents/specialists/word_keeper.py
+++ b/src/runestone/agents/specialists/word_keeper.py
@@ -27,7 +27,7 @@ from runestone.schemas.vocabulary_save import (
 logger = logging.getLogger(__name__)
 
 
-WORDKEEPER_SYSTEM_PROMPT = """
+WORDKEEPER_SAVE_REQUEST_EXTRACTION_PROMPT = """
 You are WordKeeper, an internal vocabulary extraction specialist for a Swedish tutoring app.
 You do not interact with the student. Your sole job is to decide whether vocabulary should be saved.
 
@@ -35,39 +35,31 @@ You do not interact with the student. Your sole job is to decide whether vocabul
 Be conservative. When in doubt, return no candidates.
 Never invent candidates simply because a Swedish word appears in the conversation.
 
-## Phase Behavior
-
-### Pre-response phase
-- Save ONLY when the student explicitly requests it (e.g. "save", "add", "remember", "keep this word").
-- Do NOT save words just because an earlier assistant message in `history` highlighted or introduced them.
-
-### Post-response phase
-- Treat `teacher_response` as the authoritative current teacher message.
-- Save vocabulary when the teacher explicitly highlights it, including:
-  - Named vocabulary sections (e.g. "подсказка по лексике", "key vocabulary", "useful words").
-  - Structured word–translation lists or bullet pairs regardless of the header label.
-  - Explicit save phrasing (e.g. "the key words here are", "good words to memorize").
-- Save the corrected Swedish vocabulary item when the teacher explicitly says the student's form is
-  misspelled, invalid, nonexistent, or should be replaced by a specific corrected Swedish word.
-  Never save the student's erroneous form in this case.
-- Do NOT treat ordinary exercise wording as a save signal, even if words are bolded or repeated.
-- Do NOT save words from prompts like "use X or Y in a sentence", "try another sentence with X",
-  or other drill wording unless the teacher also explicitly says the words are worth remembering.
-- By default, ignore older assistant messages in `history` when deciding what to save.
-- Use older history ONLY when the student explicitly asks to revisit it.
+## Request Scope
+This extractor handles explicit save requests before the teacher response.
+- Evaluate `message` as the active save request.
+- When `message` points to a word or phrase indirectly (for example "save that word"),
+  you may use `teacher_response` only to resolve the immediately preceding teacher context.
+- Return candidates only if `message` explicitly asks to save vocabulary
+  (for example: "save", "add", "remember", "keep this word").
+- Otherwise return no candidates.
 
 ## What NOT to Save
 - Words the student merely reused in their message.
 - Words that appear only in grammar corrections or example sentences without a save signal.
-- Misspelled, invalid, or nonexistent student-written word forms. If a correction should be saved,
-  save only the corrected Swedish item supplied by the teacher.
+- Misspelled, invalid, or nonexistent student-written word forms unless the student explicitly asks to save
+  the corrected target item.
 - Words introduced in earlier turns unless the student explicitly references them.
 - Words that are only mentioned as options in a practice prompt or writing exercise.
 - Bolded words that are emphasized for an exercise but not presented as vocabulary to memorize.
 
 ## Candidate Field Rules
 - `word_phrase` — the canonical Swedish learning item, not a noisy slice of the surrounding sentence.
-- `source_form` — optional original form from the current context when it differs from `word_phrase`.
+- `source_form` — optional original form from `message` when it differs from `word_phrase`.
+- `context_phrase` — a Swedish sentence or phrase that helps the learner remember the item.
+- When `message` already contains a useful Swedish sentence or phrase for the item, reuse it as `context_phrase`.
+- When `message` names bare words without a useful Swedish context, generate a short, natural Swedish
+  `context_phrase` for each saved item.
 
 ## Normalization Rules
 - No leading articles: save `hund`, not `en hund`; save `äpple`, not `ett äpple`.
@@ -84,7 +76,7 @@ Never invent candidates simply because a Swedish word appears in the conversatio
 - Do not save grammar-only tokens as vocabulary unless explicitly presented as learning items.
 
 ## Extraction Rules (apply to every candidate)
-- Return only canonical word keys and optional context source forms.
+- Return only canonical word keys, optional context source forms, and optional context phrases.
 - Do not generate translations, examples, grammar notes, or reasons.
 
 ## Output
@@ -106,9 +98,14 @@ Generate full save fields only for the requested new vocabulary items.
 - `extra_info` — an optional compact learner note with grammar or usage details.
 
 ## Context Rules
-- Prefer translations and examples already present in `teacher_response` when they fit the requested word.
-- Otherwise infer a concise translation and generate a short, natural Swedish example.
+- Prefer a provided `context_phrase` as the example phrase when it is a natural Swedish sentence that demonstrates
+  the saved item.
+- Otherwise infer a concise translation and generate a short, natural Swedish example from `word_phrase`.
 - If `source_form` differs from `word_phrase`, use it only when useful for `extra_info`.
+- `translation` and `example_phrase` should be filled whenever reasonably possible.
+- If `context_phrase` is missing, unnatural, or not useful, infer the missing fields from `word_phrase`.
+- Leave `extra_info` empty when unsure, but avoid leaving `translation` or `example_phrase` empty unless the
+  item is genuinely impossible to complete.
 
 ## Extra Info Guidance
 `extra_info` is a compact learner note, not a second translation and not a full grammar lesson.
@@ -197,7 +194,7 @@ class WordKeeperSpecialist(BaseSpecialist):
 
     async def run(self, context: SpecialistContext) -> SpecialistResult:
         started = time.monotonic()
-        extraction = await self._extract_candidates(context)
+        extraction = self._direct_candidates(context) or await self._extract_candidates(context)
         if extraction.decision == "no_action" or not extraction.candidates:
             return self._no_action_result(SaveRunState())
 
@@ -352,6 +349,12 @@ class WordKeeperSpecialist(BaseSpecialist):
             state.saved_words.append(item.word_phrase)
 
     @staticmethod
+    def _direct_candidates(context: SpecialistContext) -> WordKeeperExtraction | None:
+        if not context.vocabulary_candidates:
+            return None
+        return WordKeeperExtraction(decision="save_words", candidates=context.vocabulary_candidates)
+
+    @staticmethod
     def _error_result(state: SaveRunState) -> SpecialistResult:
         return SpecialistResult(
             status="error",
@@ -379,16 +382,13 @@ class WordKeeperSpecialist(BaseSpecialist):
         model = self.model.with_structured_output(WordKeeperExtraction)
         payload = {
             "message": context.message,
-            "history": [msg.model_dump(mode="json") for msg in context.history],
             "teacher_response": context.teacher_response,
-            "routing_reason": context.routing_reason,
-            "phase": "post_response" if context.teacher_response else "pre_response",
             "target_translation_language": self._target_translation_language(context),
         }
         try:
             return await model.ainvoke(
                 [
-                    SystemMessage(content=WORDKEEPER_SYSTEM_PROMPT),
+                    SystemMessage(content=WORDKEEPER_SAVE_REQUEST_EXTRACTION_PROMPT),
                     HumanMessage(content=json.dumps(payload, ensure_ascii=False)),
                 ]
             )
@@ -407,10 +407,6 @@ class WordKeeperSpecialist(BaseSpecialist):
         model = self.model.with_structured_output(WordKeeperEnrichment)
         payload = {
             "new_words": [candidate.as_artifact() for candidate in new_candidates],
-            "message": context.message,
-            "history": [msg.model_dump(mode="json") for msg in context.history],
-            "teacher_response": context.teacher_response,
-            "phase": "post_response" if context.teacher_response else "pre_response",
             "target_translation_language": self._target_translation_language(context),
         }
         try:

--- a/src/runestone/schemas/vocabulary_save.py
+++ b/src/runestone/schemas/vocabulary_save.py
@@ -33,8 +33,9 @@ class WordSaveCandidate(BaseModel):
 
     word_phrase: str = Field(..., description="Swedish word or phrase to save")
     source_form: str | None = Field(None, description="Original context form when it differs from word_phrase")
+    context_phrase: str | None = Field(None, description="Original Swedish sentence or phrase that introduced the item")
 
-    @field_validator("word_phrase", "source_form", mode="before")
+    @field_validator("word_phrase", "source_form", "context_phrase", mode="before")
     @classmethod
     def decode_candidate_unicode_escapes(cls, value: str | None) -> str | None:
         """Normalize double-escaped unicode before candidate dedupe or persistence planning."""
@@ -90,6 +91,7 @@ class VocabularyPrioritizationAction:
     candidate_id: str
     word_phrase: str
     source_form: str | None
+    context_phrase: str | None
     action: PriorityWordAction
     word_id: int | None
     changed: bool
@@ -99,6 +101,7 @@ class VocabularyPrioritizationAction:
             "candidate_id": self.candidate_id,
             "word_phrase": self.word_phrase,
             "source_form": self.source_form,
+            "context_phrase": self.context_phrase,
             "action": self.action,
             "word_id": self.word_id,
             "changed": self.changed,

--- a/src/runestone/services/vocabulary_service.py
+++ b/src/runestone/services/vocabulary_service.py
@@ -330,6 +330,7 @@ class VocabularyService:
                 candidate_id=str(index),
                 word_phrase=candidate.word_phrase,
                 source_form=candidate.source_form,
+                context_phrase=candidate.context_phrase,
                 action=action_result.action,
                 word_id=action_result.word_id,
                 changed=action_result.changed,
@@ -352,6 +353,7 @@ class VocabularyService:
                 WordSaveCandidate(
                     word_phrase=normalized_word_phrase,
                     source_form=(candidate.source_form or "").strip() or None,
+                    context_phrase=(candidate.context_phrase or "").strip() or None,
                 )
             )
         return normalized_candidates

--- a/tests/agents/specialists/test_word_keeper.py
+++ b/tests/agents/specialists/test_word_keeper.py
@@ -8,7 +8,7 @@ from runestone.agents.schemas import ChatMessage
 from runestone.agents.specialists.base import SpecialistContext
 from runestone.agents.specialists.word_keeper import (
     WORDKEEPER_ENRICHMENT_PROMPT,
-    WORDKEEPER_SYSTEM_PROMPT,
+    WORDKEEPER_SAVE_REQUEST_EXTRACTION_PROMPT,
     WordEnrichmentItem,
     WordKeeperEnrichment,
     WordKeeperExtraction,
@@ -89,16 +89,17 @@ def _priority_actions(*entries):
             candidate_id=str(index),
             word_phrase=word_phrase,
             source_form=source_form,
+            context_phrase=context_phrase,
             action=action,
             word_id=word_id,
             changed=changed,
         )
-        for index, (word_phrase, action, word_id, changed, source_form) in enumerate(entries)
+        for index, (word_phrase, action, word_id, changed, source_form, context_phrase) in enumerate(entries)
     ]
 
 
-def _priority_entry(word_phrase, action, word_id=1, changed=True, source_form=None):
-    return word_phrase, action, word_id, changed, source_form
+def _priority_entry(word_phrase, action, word_id=1, changed=True, source_form=None, context_phrase=None):
+    return word_phrase, action, word_id, changed, source_form, context_phrase
 
 
 def test_word_keeper_uses_structured_specialist_purpose(mock_settings, mock_chat_model):
@@ -109,39 +110,45 @@ def test_word_keeper_uses_structured_specialist_purpose(mock_settings, mock_chat
 
 
 def test_word_keeper_prompt_limits_pre_stage_to_explicit_save_requests():
-    assert "### Pre-response phase" in WORDKEEPER_SYSTEM_PROMPT
-    assert "Save ONLY when the student explicitly requests it" in WORDKEEPER_SYSTEM_PROMPT
-    assert "Do NOT save words just because an earlier assistant message in `history` highlighted" in (
-        WORDKEEPER_SYSTEM_PROMPT
+    assert "## Request Scope" in WORDKEEPER_SAVE_REQUEST_EXTRACTION_PROMPT
+    assert "Evaluate `message` as the active save request." in WORDKEEPER_SAVE_REQUEST_EXTRACTION_PROMPT
+    assert "you may use `teacher_response` only to resolve the immediately preceding teacher context" in (
+        WORDKEEPER_SAVE_REQUEST_EXTRACTION_PROMPT
+    )
+    assert "Return candidates only if `message` explicitly asks to save vocabulary" in (
+        WORDKEEPER_SAVE_REQUEST_EXTRACTION_PROMPT
     )
 
 
-def test_word_keeper_prompt_uses_teacher_response_as_current_post_stage_signal():
-    assert "### Post-response phase" in WORDKEEPER_SYSTEM_PROMPT
-    assert "Treat `teacher_response` as the authoritative current teacher message." in WORDKEEPER_SYSTEM_PROMPT
-    assert "By default, ignore older assistant messages in `history` when deciding what to save." in (
-        WORDKEEPER_SYSTEM_PROMPT
-    )
+def test_word_keeper_prompt_is_pre_response_only():
+    assert "teacher_response" in WORDKEEPER_SAVE_REQUEST_EXTRACTION_PROMPT
+    assert "post-response" not in WORDKEEPER_SAVE_REQUEST_EXTRACTION_PROMPT
+    assert "immediately preceding teacher context" in WORDKEEPER_SAVE_REQUEST_EXTRACTION_PROMPT
 
 
 def test_word_keeper_prompt_rejects_exercise_wording_as_save_signal():
-    assert "Do NOT treat ordinary exercise wording as a save signal" in WORDKEEPER_SYSTEM_PROMPT
-    assert 'Do NOT save words from prompts like "use X or Y in a sentence"' in WORDKEEPER_SYSTEM_PROMPT
+    assert "Words that are only mentioned as options in a practice prompt or writing exercise." in (
+        WORDKEEPER_SAVE_REQUEST_EXTRACTION_PROMPT
+    )
     assert "Bolded words that are emphasized for an exercise but not presented as vocabulary to memorize." in (
-        WORDKEEPER_SYSTEM_PROMPT
+        WORDKEEPER_SAVE_REQUEST_EXTRACTION_PROMPT
     )
 
 
 def test_word_keeper_prompt_saves_corrected_word_not_misspelling():
-    assert "Save the corrected Swedish vocabulary item" in WORDKEEPER_SYSTEM_PROMPT
-    assert "Never save the student's erroneous form in this case." in WORDKEEPER_SYSTEM_PROMPT
-    assert "save only the corrected Swedish item supplied by the teacher" in WORDKEEPER_SYSTEM_PROMPT
+    assert "Misspelled, invalid, or nonexistent student-written word forms" in (
+        WORDKEEPER_SAVE_REQUEST_EXTRACTION_PROMPT
+    )
+    assert "the corrected target item" in WORDKEEPER_SAVE_REQUEST_EXTRACTION_PROMPT
 
 
 def test_word_keeper_extraction_schema_is_key_only():
     fields = WordSaveCandidate.model_fields
-    assert set(fields) == {"word_phrase", "source_form"}
-    assert "Do not generate translations, examples, grammar notes, or reasons." in WORDKEEPER_SYSTEM_PROMPT
+    assert set(fields) == {"word_phrase", "source_form", "context_phrase"}
+    assert "Do not generate translations, examples, grammar notes, or reasons." in (
+        WORDKEEPER_SAVE_REQUEST_EXTRACTION_PROMPT
+    )
+    assert "generate a short, natural Swedish" in WORDKEEPER_SAVE_REQUEST_EXTRACTION_PROMPT
 
 
 def test_word_keeper_enrichment_prompt_owns_full_save_fields():
@@ -151,6 +158,10 @@ def test_word_keeper_enrichment_prompt_owns_full_save_fields():
     assert "`extra_info`" in WORDKEEPER_ENRICHMENT_PROMPT
     assert "`en-word noun; plural: hundar; definite: hunden`" in WORDKEEPER_ENRICHMENT_PROMPT
     assert "If unsure, leave `extra_info` empty rather than guess." in WORDKEEPER_ENRICHMENT_PROMPT
+    assert "`translation` and `example_phrase` should be filled whenever reasonably possible." in (
+        WORDKEEPER_ENRICHMENT_PROMPT
+    )
+    assert "teacher_response" not in WORDKEEPER_ENRICHMENT_PROMPT
 
 
 def test_word_keeper_models_decode_double_escaped_unicode():
@@ -204,10 +215,6 @@ def test_word_keeper_models_decode_double_escaped_non_bmp_unicode():
 
 @pytest.mark.anyio
 async def test_word_keeper_prioritizes_existing_without_enrichment(specialist, mock_chat_model, mock_user):
-    mock_chat_model.extraction_model.ainvoke.return_value = WordKeeperExtraction(
-        decision="save_words",
-        candidates=[WordSaveCandidate(word_phrase="noggrann")],
-    )
     vocabulary_service = _mock_vocabulary_service(
         priority_actions=_priority_actions(_priority_entry("noggrann", "prioritized", word_id=2))
     )
@@ -222,11 +229,13 @@ async def test_word_keeper_prioritizes_existing_without_enrichment(specialist, m
                 history=[ChatMessage(role="assistant", content="Noggrann means careful.")],
                 user=mock_user,
                 teacher_response="The key words here are noggrann.",
-                routing_reason="teacher highlighted key words",
+                vocabulary_candidates=[WordSaveCandidate(word_phrase="noggrann")],
+                routing_reason="teacher emitted vocabulary_candidates",
             )
         )
 
     assert result.status == "action_taken"
+    mock_chat_model.extraction_model.ainvoke.assert_not_awaited()
     assert result.artifacts["saved_words"] == ["noggrann"]
     assert result.artifacts["action_counts"]["prioritized"] == 1
     assert result.artifacts["priority_actions"][0]["action"] == "prioritized"
@@ -291,11 +300,68 @@ async def test_word_keeper_enriches_and_saves_new_word(specialist, mock_chat_mod
 
 
 @pytest.mark.anyio
-async def test_word_keeper_saves_corrected_word_instead_of_student_misspelling(specialist, mock_chat_model, mock_user):
-    mock_chat_model.extraction_model.ainvoke.return_value = WordKeeperExtraction(
-        decision="save_words",
-        candidates=[WordSaveCandidate(word_phrase="våren", source_form="varen")],
+async def test_word_keeper_direct_candidates_skip_extraction_and_reach_enrichment(
+    specialist, mock_chat_model, mock_user
+):
+    mock_chat_model.enrichment_model.ainvoke.return_value = WordKeeperEnrichment(
+        items=[
+            WordEnrichmentItem(
+                candidate_id="0",
+                word_phrase="begripa",
+                translation="understand",
+                example_phrase="Jag begriper inte.",
+            )
+        ]
     )
+    vocabulary_service = _mock_vocabulary_service(
+        priority_actions=_priority_actions(
+            _priority_entry(
+                "begripa",
+                "missing",
+                word_id=None,
+                changed=False,
+                source_form="begriper",
+                context_phrase="Jag begriper inte.",
+            )
+        ),
+        upsert_return={"action": "created", "word_id": 3, "changed": True},
+    )
+
+    with patch(
+        "runestone.agents.specialists.word_keeper.provide_vocabulary_service",
+        _service_provider(vocabulary_service),
+    ):
+        result = await specialist.run(
+            SpecialistContext(
+                message="Jag begriper inte.",
+                history=[],
+                user=mock_user,
+                teacher_response="Good sentence. Let's keep begripa in mind.",
+                vocabulary_candidates=[
+                    WordSaveCandidate(
+                        word_phrase="begripa",
+                        source_form="begriper",
+                        context_phrase="Jag begriper inte.",
+                    )
+                ],
+                routing_reason="teacher emitted vocabulary_candidates",
+            )
+        )
+
+    assert result.status == "action_taken"
+    mock_chat_model.extraction_model.ainvoke.assert_not_awaited()
+    priority_candidates = vocabulary_service.prepare_priority_word_save.call_args.args[0]
+    assert [candidate.model_dump(exclude_none=True) for candidate in priority_candidates] == [
+        {"word_phrase": "begripa", "source_form": "begriper", "context_phrase": "Jag begriper inte."}
+    ]
+    enrichment_payload = json.loads(mock_chat_model.enrichment_model.ainvoke.call_args.args[0][1].content)
+    assert enrichment_payload["new_words"][0]["context_phrase"] == "Jag begriper inte."
+    assert enrichment_payload["target_translation_language"] == "English"
+    assert set(enrichment_payload) == {"new_words", "target_translation_language"}
+
+
+@pytest.mark.anyio
+async def test_word_keeper_saves_corrected_word_instead_of_student_misspelling(specialist, mock_chat_model, mock_user):
     mock_chat_model.enrichment_model.ainvoke.return_value = WordKeeperEnrichment(
         items=[
             WordEnrichmentItem(
@@ -324,14 +390,16 @@ async def test_word_keeper_saves_corrected_word_instead_of_student_misspelling(s
                 history=[],
                 user=mock_user,
                 teacher_response="There is no such word as 'varen'; use 'våren' for spring.",
-                routing_reason="teacher corrected misspelled vocabulary item",
+                vocabulary_candidates=[WordSaveCandidate(word_phrase="våren", source_form="varen")],
+                routing_reason="teacher emitted vocabulary_candidates",
             )
         )
 
     assert result.status == "action_taken"
+    mock_chat_model.extraction_model.ainvoke.assert_not_awaited()
     assert result.artifacts["saved_words"] == ["våren"]
     priority_candidates = vocabulary_service.prepare_priority_word_save.call_args[0][0]
-    assert [candidate.model_dump() for candidate in priority_candidates] == [
+    assert [candidate.model_dump(exclude_none=True) for candidate in priority_candidates] == [
         {"word_phrase": "våren", "source_form": "varen"}
     ]
 
@@ -356,13 +424,6 @@ async def test_word_keeper_saves_corrected_word_instead_of_student_misspelling(s
 
 @pytest.mark.anyio
 async def test_word_keeper_mixed_existing_and_new_enriches_only_new_word(specialist, mock_chat_model, mock_user):
-    mock_chat_model.extraction_model.ainvoke.return_value = WordKeeperExtraction(
-        decision="save_words",
-        candidates=[
-            WordSaveCandidate(word_phrase="noggrann"),
-            WordSaveCandidate(word_phrase="begripa", source_form="begriper"),
-        ],
-    )
     mock_chat_model.enrichment_model.ainvoke.return_value = WordKeeperEnrichment(
         items=[
             WordEnrichmentItem(
@@ -392,11 +453,16 @@ async def test_word_keeper_mixed_existing_and_new_enriches_only_new_word(special
                 history=[],
                 user=mock_user,
                 teacher_response="Let's keep this new word in mind: begripa.",
-                routing_reason="teacher highlighted words to memorize",
+                vocabulary_candidates=[
+                    WordSaveCandidate(word_phrase="noggrann"),
+                    WordSaveCandidate(word_phrase="begripa", source_form="begriper"),
+                ],
+                routing_reason="teacher emitted vocabulary_candidates",
             )
         )
 
     assert result.status == "action_taken"
+    mock_chat_model.extraction_model.ainvoke.assert_not_awaited()
     assert result.artifacts["saved_words"] == ["noggrann", "begripa"]
     assert result.artifacts["action_counts"] == {
         "created": 1,
@@ -490,10 +556,6 @@ async def test_word_keeper_skips_new_words_when_enrichment_fails(specialist, moc
 
 @pytest.mark.anyio
 async def test_word_keeper_skips_new_word_with_incomplete_enrichment(specialist, mock_chat_model, mock_user):
-    mock_chat_model.extraction_model.ainvoke.return_value = WordKeeperExtraction(
-        decision="save_words",
-        candidates=[WordSaveCandidate(word_phrase="förutsättning")],
-    )
     mock_chat_model.enrichment_model.ainvoke.return_value = WordKeeperEnrichment(
         items=[
             WordEnrichmentItem(
@@ -518,11 +580,13 @@ async def test_word_keeper_skips_new_word_with_incomplete_enrichment(specialist,
                 history=[],
                 user=mock_user,
                 teacher_response="These are good words to memorize: förutsättning.",
-                routing_reason="teacher highlighted words to memorize",
+                vocabulary_candidates=[WordSaveCandidate(word_phrase="förutsättning")],
+                routing_reason="teacher emitted vocabulary_candidates",
             )
         )
 
     assert result.status == "no_action"
+    mock_chat_model.extraction_model.ainvoke.assert_not_awaited()
     assert result.artifacts["saved_words"] == []
     assert result.artifacts["skipped_words"] == [
         {"word_phrase": "förutsättning", "reason": "missing_required_fields_after_enrichment"}
@@ -638,6 +702,8 @@ async def test_word_keeper_payload_uses_user_mother_tongue(specialist, mock_chat
     call_args = mock_chat_model.extraction_model.ainvoke.call_args[0][0]
     payload = call_args[1].content
     assert '"target_translation_language": "Finnish"' in payload
+    assert '"message": "Save this word for me: avgörande"' in payload
+    assert '"teacher_response": null' in payload
 
 
 @pytest.mark.anyio
@@ -656,56 +722,28 @@ async def test_word_keeper_payload_defaults_translation_language_to_english(spec
     call_args = mock_chat_model.extraction_model.ainvoke.call_args[0][0]
     payload = call_args[1].content
     assert '"target_translation_language": "English"' in payload
+    assert '"message": "Save this word for me: avgörande"' in payload
+    assert '"teacher_response": null' in payload
 
 
 @pytest.mark.anyio
-async def test_word_keeper_post_response_payload_keeps_previous_teacher_message_in_history_but_marks_post_phase(
+async def test_word_keeper_extraction_payload_includes_teacher_response_for_deictic_save_request(
     specialist, mock_chat_model, mock_user
 ):
     mock_chat_model.extraction_model.ainvoke.return_value = WordKeeperExtraction(decision="no_action", candidates=[])
 
     await specialist.run(
         SpecialistContext(
-            message="Jag begriper inte.",
-            history=[
-                ChatMessage(role="user", content="Can you explain these words?"),
-                ChatMessage(role="assistant", content="Let's save these words: beskriva, bekräfta."),
-            ],
+            message="Save that word for me.",
+            history=[],
+            teacher_response="Begripa means understand.",
             user=mock_user,
-            teacher_response="Let's keep this new word in mind: begripa.",
-            routing_reason="teacher highlighted words to memorize",
+            routing_reason="explicit save request",
         )
     )
 
     call_args = mock_chat_model.extraction_model.ainvoke.call_args[0][0]
     payload = call_args[1].content
-    assert '"phase": "post_response"' in payload
-    assert '"teacher_response": "Let\'s keep this new word in mind: begripa."' in payload
-    assert '"content": "Let\'s save these words: beskriva, bekräfta."' in payload
-
-
-@pytest.mark.anyio
-async def test_word_keeper_payload_preserves_earlier_history_for_explicit_revisit_request(
-    specialist, mock_chat_model, mock_user
-):
-    mock_chat_model.extraction_model.ainvoke.return_value = WordKeeperExtraction(decision="no_action", candidates=[])
-
-    await specialist.run(
-        SpecialistContext(
-            message="Ok, save the words you mentioned before.",
-            history=[
-                ChatMessage(role="user", content="Can you explain these words?"),
-                ChatMessage(role="assistant", content="Let's save these words: beskriva, bekräfta."),
-                ChatMessage(role="user", content="Thanks, and one more question."),
-                ChatMessage(role="assistant", content="Sure, ask away."),
-            ],
-            user=mock_user,
-            routing_reason="explicit earlier-history save request",
-        )
-    )
-
-    call_args = mock_chat_model.extraction_model.ainvoke.call_args[0][0]
-    payload = call_args[1].content
-    assert '"phase": "pre_response"' in payload
-    assert '"message": "Ok, save the words you mentioned before."' in payload
-    assert '"content": "Let\'s save these words: beskriva, bekräfta."' in payload
+    assert '"message": "Save that word for me."' in payload
+    assert '"target_translation_language": "English"' in payload
+    assert '"teacher_response": "Begripa means understand."' in payload

--- a/tests/agents/test_coordinator.py
+++ b/tests/agents/test_coordinator.py
@@ -64,18 +64,15 @@ def test_init_coordinator_model(mock_settings, mock_chat_model):
 def test_word_keeper_prompt_eligibility():
     """Coordinator prompt should define WordKeeper eligibility correctly."""
     assert "word_keeper" in COORDINATOR_PRE_RESPONSE_PROMPT
-    assert "word_keeper" in COORDINATOR_POST_RESPONSE_PROMPT
-    assert "If the current student explicitly asks to save words from an earlier turn" in (
-        COORDINATOR_PRE_RESPONSE_PROMPT
-    )
+    assert "word_keeper" not in COORDINATOR_POST_RESPONSE_PROMPT
+    assert "immediately preceding" in COORDINATOR_PRE_RESPONSE_PROMPT
     assert "An earlier teacher message highlighted vocabulary but the student did not request saving it." in (
         COORDINATOR_PRE_RESPONSE_PROMPT
     )
     assert "Words were already saved in earlier turns — do not re-trigger on later turns." in (
         COORDINATOR_PRE_RESPONSE_PROMPT
     )
-    assert "For all normal word_keeper cases, set `chat_history_size` to `2`." in COORDINATOR_PRE_RESPONSE_PROMPT
-    assert "For all normal word_keeper cases, set `chat_history_size` to `2`." in COORDINATOR_POST_RESPONSE_PROMPT
+    assert "Set `chat_history_size` to `0` for `word_keeper`." in COORDINATOR_PRE_RESPONSE_PROMPT
 
 
 def test_memory_reader_is_absent_from_pre_prompt():
@@ -120,13 +117,7 @@ def test_grammar_is_absent_from_coordinator_prompt():
 
 def test_word_keeper_prompt_does_not_allow_anticipatory_post_routing():
     assert "anticipate the teacher reply" not in COORDINATOR_POST_RESPONSE_PROMPT
-    assert (
-        "The actual `teacher_response` explicitly marks vocabulary as worth saving" in COORDINATOR_POST_RESPONSE_PROMPT
-    )
-    assert "The teacher is only asking the student to practice, answer, or write another sentence using words." in (
-        COORDINATOR_POST_RESPONSE_PROMPT
-    )
-    assert "provides\n  the corrected Swedish vocabulary item" in COORDINATOR_POST_RESPONSE_PROMPT
+    assert "word_keeper" not in COORDINATOR_POST_RESPONSE_PROMPT
 
 
 def test_word_keeper_prompt_limits_pre_stage_to_explicit_save_requests():
@@ -134,6 +125,10 @@ def test_word_keeper_prompt_limits_pre_stage_to_explicit_save_requests():
     assert "The current student message explicitly asks to save vocabulary in this turn" in (
         COORDINATOR_PRE_RESPONSE_PROMPT
     )
+    assert "save `begripa` and `noggrann`" in COORDINATOR_PRE_RESPONSE_PROMPT
+    assert "save these words for me: beskriva, bekräfta" in COORDINATOR_PRE_RESPONSE_PROMPT
+    assert "save that word" in COORDINATOR_PRE_RESPONSE_PROMPT
+    assert "If the student explicitly asks to save words from an earlier turn" not in COORDINATOR_PRE_RESPONSE_PROMPT
     assert "An earlier teacher message highlighted vocabulary but the student did not request saving it." in (
         COORDINATOR_PRE_RESPONSE_PROMPT
     )

--- a/tests/agents/test_manager.py
+++ b/tests/agents/test_manager.py
@@ -19,6 +19,7 @@ from runestone.agents.schemas import (
 )
 from runestone.agents.specialists.base import BaseSpecialist, SpecialistContext, SpecialistResult
 from runestone.config import AgentLLMSettings, ReasoningLevel, Settings
+from runestone.schemas.vocabulary_save import WordSaveCandidate
 from runestone.services.agent_side_effect_service import AgentSideEffectService
 
 
@@ -118,7 +119,14 @@ async def test_process_turn_returns_teacher_reply_and_starts_background_post(
     manager = AgentsManager(mock_settings)
     manager.handle_stale_post_task = AsyncMock()
     manager.prepare_pre_turn = AsyncMock(return_value=(_make_plan(), [{"name": "pre"}], "", []))
-    manager.generate_teacher_response = AsyncMock(return_value=("Teacher says hi", [{"title": "Src"}], "happy"))
+    manager.generate_teacher_response = AsyncMock(
+        return_value=(
+            "Teacher says hi",
+            [{"title": "Src"}],
+            "happy",
+            [WordSaveCandidate(word_phrase="begripa", context_phrase="Jag begriper inte.")],
+        )
+    )
     manager.start_background_post_turn = AsyncMock()
 
     response, sources, teacher_emotion = await manager.process_turn(
@@ -148,6 +156,7 @@ async def test_process_turn_returns_teacher_reply_and_starts_background_post(
         history=[ChatMessage(role="assistant", content="Earlier")],
         user=mock_user,
         teacher_response="Teacher says hi",
+        vocabulary_candidates=[WordSaveCandidate(word_phrase="begripa", context_phrase="Jag begriper inte.")],
         pre_results=[{"name": "pre"}],
         coordinator_row_id=42,
     )
@@ -160,7 +169,7 @@ async def test_process_turn_skips_stale_check_on_first_turn(
     manager = AgentsManager(mock_settings)
     manager.handle_stale_post_task = AsyncMock()
     manager.prepare_pre_turn = AsyncMock(return_value=(_make_plan(), [], "", []))
-    manager.generate_teacher_response = AsyncMock(return_value=("Teacher says hi", None, "neutral"))
+    manager.generate_teacher_response = AsyncMock(return_value=("Teacher says hi", None, "neutral", []))
     manager.start_background_post_turn = AsyncMock()
 
     await manager.process_turn(
@@ -362,7 +371,7 @@ async def test_generate_teacher_response_returns_text_and_sources(mock_settings,
     manager.teacher = AsyncMock()
     manager.teacher.generate_response.return_value = TeacherGenerationResult(message="Hi there!", final_messages=[])
 
-    response, sources, teacher_emotion = await manager.generate_teacher_response(
+    response, sources, teacher_emotion, vocabulary_candidates = await manager.generate_teacher_response(
         message="Hello",
         history=[],
         user=mock_user,
@@ -374,6 +383,7 @@ async def test_generate_teacher_response_returns_text_and_sources(mock_settings,
     assert response == "Hi there!"
     assert sources is None
     assert teacher_emotion == "neutral"
+    assert vocabulary_candidates == []
 
 
 @pytest.mark.anyio
@@ -384,7 +394,7 @@ async def test_generate_teacher_response_returns_teacher_emotion(mock_settings, 
         message="Great work!", emotion="happy", final_messages=[]
     )
 
-    response, sources, teacher_emotion = await manager.generate_teacher_response(
+    response, sources, teacher_emotion, vocabulary_candidates = await manager.generate_teacher_response(
         message="Hello",
         history=[],
         user=mock_user,
@@ -396,6 +406,33 @@ async def test_generate_teacher_response_returns_teacher_emotion(mock_settings, 
     assert response == "Great work!"
     assert sources is None
     assert teacher_emotion == "happy"
+    assert vocabulary_candidates == []
+
+
+@pytest.mark.anyio
+async def test_generate_teacher_response_returns_vocabulary_candidates(mock_settings, mock_user):
+    manager = AgentsManager(mock_settings)
+    manager.teacher = AsyncMock()
+    candidate = WordSaveCandidate(word_phrase="begripa", context_phrase="Jag begriper inte.")
+    manager.teacher.generate_response.return_value = TeacherGenerationResult(
+        message="Great work!",
+        vocabulary_candidates=[candidate],
+        final_messages=[],
+    )
+
+    response, sources, teacher_emotion, vocabulary_candidates = await manager.generate_teacher_response(
+        message="Hello",
+        history=[],
+        user=mock_user,
+        pre_results=[],
+        starter_memory="",
+        recent_side_effects=[],
+    )
+
+    assert response == "Great work!"
+    assert sources is None
+    assert teacher_emotion == "neutral"
+    assert vocabulary_candidates == [candidate]
 
 
 @pytest.mark.anyio
@@ -416,7 +453,7 @@ async def test_generate_teacher_response_extracts_news_sources(mock_settings, mo
         ],
     )
 
-    response, sources, _teacher_emotion = await manager.generate_teacher_response(
+    response, sources, _teacher_emotion, _vocabulary_candidates = await manager.generate_teacher_response(
         message="Nyheter",
         history=[],
         user=mock_user,
@@ -448,7 +485,7 @@ async def test_generate_teacher_response_combines_news_sources_from_pre_results(
         ],
     )
 
-    response, sources, _teacher_emotion = await manager.generate_teacher_response(
+    response, sources, _teacher_emotion, _vocabulary_candidates = await manager.generate_teacher_response(
         message="Nyheter",
         history=[],
         user=mock_user,
@@ -494,7 +531,7 @@ async def test_generate_teacher_response_deduplicates_sources_across_pre_results
         ],
     )
 
-    _response, sources, _teacher_emotion = await manager.generate_teacher_response(
+    _response, sources, _teacher_emotion, _vocabulary_candidates = await manager.generate_teacher_response(
         message="Nyheter",
         history=[],
         user=mock_user,
@@ -538,7 +575,7 @@ async def test_generate_teacher_response_filters_unsafe_urls(mock_settings, mock
         ],
     )
 
-    _response, sources, _teacher_emotion = await manager.generate_teacher_response(
+    _response, sources, _teacher_emotion, _vocabulary_candidates = await manager.generate_teacher_response(
         message="Nyheter", history=[], user=mock_user, pre_results=[], starter_memory="", recent_side_effects=[]
     )
 
@@ -557,7 +594,7 @@ async def test_generate_teacher_response_requires_search_grammar_result_for_gram
         final_messages=[],
     )
 
-    _response, sources, _teacher_emotion = await manager.generate_teacher_response(
+    _response, sources, _teacher_emotion, _vocabulary_candidates = await manager.generate_teacher_response(
         message="Grammatik", history=[], user=mock_user, pre_results=[], starter_memory="", recent_side_effects=[]
     )
 
@@ -590,7 +627,7 @@ async def test_generate_teacher_response_caps_search_grammar_selected_sources(mo
         ],
     )
 
-    _response, sources, _teacher_emotion = await manager.generate_teacher_response(
+    _response, sources, _teacher_emotion, _vocabulary_candidates = await manager.generate_teacher_response(
         message="Grammatik", history=[], user=mock_user, pre_results=[], starter_memory="", recent_side_effects=[]
     )
 
@@ -632,7 +669,7 @@ async def test_generate_teacher_response_uses_selected_grammar_sources(mock_sett
         ],
     )
 
-    _response, sources, _teacher_emotion = await manager.generate_teacher_response(
+    _response, sources, _teacher_emotion, _vocabulary_candidates = await manager.generate_teacher_response(
         message="Grammatik", history=[], user=mock_user, pre_results=[], starter_memory="", recent_side_effects=[]
     )
 
@@ -672,7 +709,7 @@ async def test_generate_teacher_response_rejects_grammar_sources_not_returned_by
         ],
     )
 
-    _response, sources, _teacher_emotion = await manager.generate_teacher_response(
+    _response, sources, _teacher_emotion, _vocabulary_candidates = await manager.generate_teacher_response(
         message="Grammatik", history=[], user=mock_user, pre_results=[], starter_memory="", recent_side_effects=[]
     )
 
@@ -707,7 +744,7 @@ async def test_generate_teacher_response_rejects_same_host_invented_grammar_sour
         ],
     )
 
-    _response, sources, _teacher_emotion = await manager.generate_teacher_response(
+    _response, sources, _teacher_emotion, _vocabulary_candidates = await manager.generate_teacher_response(
         message="Grammatik", history=[], user=mock_user, pre_results=[], starter_memory="", recent_side_effects=[]
     )
 
@@ -735,7 +772,7 @@ async def test_generate_teacher_response_rejects_unsafe_search_grammar_source(mo
         ],
     )
 
-    _response, sources, _teacher_emotion = await manager.generate_teacher_response(
+    _response, sources, _teacher_emotion, _vocabulary_candidates = await manager.generate_teacher_response(
         message="Grammatik", history=[], user=mock_user, pre_results=[], starter_memory="", recent_side_effects=[]
     )
 
@@ -761,7 +798,7 @@ async def test_generate_teacher_response_rejects_disallowed_port_search_grammar_
         ],
     )
 
-    _response, sources, _teacher_emotion = await manager.generate_teacher_response(
+    _response, sources, _teacher_emotion, _vocabulary_candidates = await manager.generate_teacher_response(
         message="Grammatik", history=[], user=mock_user, pre_results=[], starter_memory="", recent_side_effects=[]
     )
 
@@ -778,7 +815,7 @@ async def test_generate_teacher_response_can_hide_irrelevant_grammar_sources(moc
         final_messages=[],
     )
 
-    _response, sources, _teacher_emotion = await manager.generate_teacher_response(
+    _response, sources, _teacher_emotion, _vocabulary_candidates = await manager.generate_teacher_response(
         message="Grammatik", history=[], user=mock_user, pre_results=[], starter_memory="", recent_side_effects=[]
     )
 
@@ -815,15 +852,15 @@ async def test_generate_teacher_response_passes_pre_results(mock_settings, mock_
 async def test_run_post_turn_runs_post_specialists(mock_settings, mock_user, mock_side_effect_service):
     manager = AgentsManager(mock_settings)
     manager.coordinator.plan_post_turn = AsyncMock(
-        return_value=_make_plan(post=[RoutingItem(name="word_keeper", reason="save words", chat_history_size=0)])
+        return_value=_make_plan(post=[RoutingItem(name="memory_keeper", reason="save memory", chat_history_size=0)])
     )
 
     class _ActionSpecialist(BaseSpecialist):
         def __init__(self):
-            super().__init__(name="word_keeper")
+            super().__init__(name="memory_keeper")
 
         async def run(self, context: SpecialistContext) -> SpecialistResult:
-            return SpecialistResult(status="action_taken", info_for_teacher="Saved words.")
+            return SpecialistResult(status="action_taken", info_for_teacher="Saved memory.")
 
     manager.registry.register(_ActionSpecialist(), overwrite=True)
 
@@ -833,6 +870,7 @@ async def test_run_post_turn_runs_post_specialists(mock_settings, mock_user, moc
         history=[],
         user=mock_user,
         teacher_response="Great words!",
+        vocabulary_candidates=[],
         pre_results=[],
         side_effect_service=mock_side_effect_service,
         coordinator_row_id=99,
@@ -844,12 +882,272 @@ async def test_run_post_turn_runs_post_specialists(mock_settings, mock_user, moc
     assert kwargs["user_id"] == mock_user.id
     assert kwargs["chat_id"] == "chat-1"
     assert kwargs["coordinator_row_id"] == 99
-    assert kwargs["results"][0]["name"] == "word_keeper"
+    assert kwargs["results"][0]["name"] == "memory_keeper"
     assert kwargs["results"][0]["result"]["status"] == "action_taken"
     manager.coordinator.plan_post_turn.assert_awaited_once()
     mock_side_effect_service.mark_coordinator_done_if_current.assert_awaited_once_with(
         row_id=99, user_id=mock_user.id, chat_id="chat-1"
     )
+
+
+@pytest.mark.anyio
+async def test_run_post_turn_excludes_word_keeper_from_coordinator_available_specialists(
+    mock_settings, mock_user, mock_side_effect_service
+):
+    manager = AgentsManager(mock_settings)
+    manager.coordinator.plan_post_turn = AsyncMock(return_value=_make_plan())
+
+    await manager.run_post_turn(
+        message="Hello",
+        chat_id="chat-1",
+        history=[],
+        user=mock_user,
+        teacher_response="Hi!",
+        vocabulary_candidates=[],
+        pre_results=[],
+        side_effect_service=mock_side_effect_service,
+        coordinator_row_id=99,
+    )
+
+    _args, kwargs = manager.coordinator.plan_post_turn.call_args
+    assert "word_keeper" not in kwargs["available_specialists"]
+    assert "memory_keeper" in kwargs["available_specialists"]
+
+
+@pytest.mark.anyio
+async def test_run_post_turn_routes_teacher_vocabulary_candidates_directly(
+    mock_settings, mock_user, mock_side_effect_service
+):
+    manager = AgentsManager(mock_settings)
+    manager.coordinator.plan_post_turn = AsyncMock(return_value=_make_plan())
+    capture = _CaptureHistorySpecialist()
+    capture.name = "word_keeper"
+    manager.registry.register(capture, overwrite=True)
+    candidate = WordSaveCandidate(word_phrase="begripa", context_phrase="Jag begriper inte.")
+
+    await manager.run_post_turn(
+        message="Jag begriper inte.",
+        chat_id="chat-1",
+        history=[ChatMessage(role="user", content="Earlier")],
+        user=mock_user,
+        teacher_response="Good sentence. Let's keep begripa in mind.",
+        vocabulary_candidates=[candidate],
+        pre_results=[],
+        side_effect_service=mock_side_effect_service,
+        coordinator_row_id=99,
+    )
+
+    assert capture.seen_vocabulary_candidates == [candidate]
+    assert capture.seen_teacher_response is None
+    assert capture.seen_routing_reason == "teacher emitted vocabulary_candidates"
+    kwargs = mock_side_effect_service.replace_post_specialist_results.call_args.kwargs
+    assert kwargs["results"][0]["name"] == "word_keeper"
+
+
+@pytest.mark.anyio
+async def test_run_post_turn_persists_direct_word_keeper_when_coordinator_fails(
+    mock_settings, mock_user, mock_side_effect_service
+):
+    manager = AgentsManager(mock_settings)
+    manager.coordinator.plan_post_turn = AsyncMock(side_effect=RuntimeError("coordinator exploded"))
+
+    class _ActionSpecialist(BaseSpecialist):
+        def __init__(self):
+            super().__init__(name="word_keeper")
+
+        async def run(self, context: SpecialistContext) -> SpecialistResult:
+            return SpecialistResult(status="action_taken", info_for_teacher="Saved words.")
+
+    manager.registry.register(_ActionSpecialist(), overwrite=True)
+
+    await manager.run_post_turn(
+        message="Jag begriper inte.",
+        chat_id="chat-1",
+        history=[],
+        user=mock_user,
+        teacher_response="Good sentence. Let's keep begripa in mind.",
+        vocabulary_candidates=[WordSaveCandidate(word_phrase="begripa")],
+        pre_results=[],
+        side_effect_service=mock_side_effect_service,
+        coordinator_row_id=99,
+    )
+
+    kwargs = mock_side_effect_service.replace_post_specialist_results.call_args.kwargs
+    assert kwargs["results"][0]["name"] == "word_keeper"
+    assert kwargs["results"][0]["result"]["status"] == "action_taken"
+    mock_side_effect_service.mark_coordinator_failed_if_current.assert_awaited_once_with(
+        row_id=99, user_id=mock_user.id, chat_id="chat-1"
+    )
+    mock_side_effect_service.mark_coordinator_done_if_current.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_run_post_turn_persists_coordinator_and_direct_word_keeper_results_together(
+    mock_settings, mock_user, mock_side_effect_service
+):
+    manager = AgentsManager(mock_settings)
+    manager.coordinator.plan_post_turn = AsyncMock(
+        return_value=_make_plan(post=[RoutingItem(name="memory_keeper", reason="memory", chat_history_size=0)])
+    )
+
+    class _NamedSpecialist(BaseSpecialist):
+        async def run(self, context: SpecialistContext) -> SpecialistResult:
+            return SpecialistResult(status="action_taken", info_for_teacher=f"{self.name} done.")
+
+    manager.registry.register(_NamedSpecialist("memory_keeper"), overwrite=True)
+    manager.registry.register(_NamedSpecialist("word_keeper"), overwrite=True)
+
+    await manager.run_post_turn(
+        message="Jag begriper inte.",
+        chat_id="chat-1",
+        history=[],
+        user=mock_user,
+        teacher_response="Good sentence. Let's keep begripa in mind.",
+        vocabulary_candidates=[WordSaveCandidate(word_phrase="begripa")],
+        pre_results=[],
+        side_effect_service=mock_side_effect_service,
+        coordinator_row_id=99,
+    )
+
+    kwargs = mock_side_effect_service.replace_post_specialist_results.call_args.kwargs
+    assert [item["name"] for item in kwargs["results"]] == ["memory_keeper", "word_keeper"]
+
+
+@pytest.mark.anyio
+async def test_run_post_turn_does_not_route_word_keeper_without_candidates(
+    mock_settings, mock_user, mock_side_effect_service
+):
+    manager = AgentsManager(mock_settings)
+    manager.coordinator.plan_post_turn = AsyncMock(return_value=_make_plan())
+    capture = _CaptureHistorySpecialist()
+    capture.name = "word_keeper"
+    manager.registry.register(capture, overwrite=True)
+
+    await manager.run_post_turn(
+        message="Hello",
+        chat_id="chat-1",
+        history=[],
+        user=mock_user,
+        teacher_response="Hi!",
+        vocabulary_candidates=[],
+        pre_results=[],
+        side_effect_service=mock_side_effect_service,
+        coordinator_row_id=99,
+    )
+
+    assert capture.seen_vocabulary_candidates is None
+    kwargs = mock_side_effect_service.replace_post_specialist_results.call_args.kwargs
+    assert kwargs["results"] == []
+
+
+@pytest.mark.anyio
+async def test_run_post_turn_skips_teacher_candidates_already_saved_in_pre_phase(
+    mock_settings, mock_user, mock_side_effect_service
+):
+    manager = AgentsManager(mock_settings)
+    manager.coordinator.plan_post_turn = AsyncMock(return_value=_make_plan())
+    capture = _CaptureHistorySpecialist()
+    capture.name = "word_keeper"
+    manager.registry.register(capture, overwrite=True)
+
+    await manager.run_post_turn(
+        message="Save that word for me.",
+        chat_id="chat-1",
+        history=[ChatMessage(role="assistant", content="Begripa means understand.")],
+        user=mock_user,
+        teacher_response="Let's save begripa for later.",
+        vocabulary_candidates=[WordSaveCandidate(word_phrase="begripa", context_phrase="Jag begriper inte.")],
+        pre_results=[
+            {
+                "name": "word_keeper",
+                "result": {
+                    "status": "action_taken",
+                    "artifacts": {
+                        "saved_words": [" Begripa "],
+                    },
+                },
+            }
+        ],
+        side_effect_service=mock_side_effect_service,
+        coordinator_row_id=99,
+    )
+
+    assert capture.seen_vocabulary_candidates is None
+    kwargs = mock_side_effect_service.replace_post_specialist_results.call_args.kwargs
+    assert kwargs["results"] == []
+
+
+@pytest.mark.anyio
+async def test_run_post_turn_keeps_teacher_candidates_when_pre_phase_only_extracted_them(
+    mock_settings, mock_user, mock_side_effect_service
+):
+    manager = AgentsManager(mock_settings)
+    manager.coordinator.plan_post_turn = AsyncMock(return_value=_make_plan())
+    capture = _CaptureHistorySpecialist()
+    capture.name = "word_keeper"
+    manager.registry.register(capture, overwrite=True)
+    candidate = WordSaveCandidate(word_phrase="begripa", context_phrase="Jag begriper inte.")
+
+    await manager.run_post_turn(
+        message="Save that word for me.",
+        chat_id="chat-1",
+        history=[ChatMessage(role="assistant", content="Begripa means understand.")],
+        user=mock_user,
+        teacher_response="Let's save begripa for later.",
+        vocabulary_candidates=[candidate],
+        pre_results=[
+            {
+                "name": "word_keeper",
+                "result": {
+                    "status": "error",
+                    "artifacts": {
+                        "saved_words": [],
+                        "save_candidates": [{"word_phrase": "begripa"}],
+                    },
+                },
+            }
+        ],
+        side_effect_service=mock_side_effect_service,
+        coordinator_row_id=99,
+    )
+
+    assert capture.seen_vocabulary_candidates == [candidate]
+    kwargs = mock_side_effect_service.replace_post_specialist_results.call_args.kwargs
+    assert kwargs["results"][0]["name"] == "word_keeper"
+
+
+@pytest.mark.anyio
+async def test_run_post_turn_records_direct_word_keeper_failure_without_raising(
+    mock_settings, mock_user, mock_side_effect_service
+):
+    manager = AgentsManager(mock_settings)
+    manager.coordinator.plan_post_turn = AsyncMock(return_value=_make_plan())
+
+    class _FailingSpecialist(BaseSpecialist):
+        def __init__(self):
+            super().__init__(name="word_keeper")
+
+        async def run(self, context: SpecialistContext) -> SpecialistResult:
+            raise RuntimeError("word keeper failed")
+
+    manager.registry.register(_FailingSpecialist(), overwrite=True)
+
+    await manager.run_post_turn(
+        message="Jag begriper inte.",
+        chat_id="chat-1",
+        history=[],
+        user=mock_user,
+        teacher_response="Good sentence. Let's keep begripa in mind.",
+        vocabulary_candidates=[WordSaveCandidate(word_phrase="begripa")],
+        pre_results=[],
+        side_effect_service=mock_side_effect_service,
+        coordinator_row_id=99,
+    )
+
+    kwargs = mock_side_effect_service.replace_post_specialist_results.call_args.kwargs
+    assert kwargs["results"][0]["name"] == "word_keeper"
+    assert kwargs["results"][0]["result"]["status"] == "error"
+    mock_side_effect_service.mark_coordinator_done_if_current.assert_awaited_once()
 
 
 @pytest.mark.anyio
@@ -865,6 +1163,7 @@ async def test_run_post_turn_marks_failed_on_exception(mock_settings, mock_user,
             history=[],
             user=mock_user,
             teacher_response="Hi!",
+            vocabulary_candidates=[],
             pre_results=[],
             side_effect_service=mock_side_effect_service,
             coordinator_row_id=99,
@@ -890,6 +1189,7 @@ async def test_run_post_turn_skips_done_mark_when_persistence_is_stale(
         history=[],
         user=mock_user,
         teacher_response="Hi!",
+        vocabulary_candidates=[],
         pre_results=[],
         side_effect_service=mock_side_effect_service,
         coordinator_row_id=99,
@@ -1005,6 +1305,7 @@ async def test_start_background_post_turn_creates_task(mock_settings, mock_user,
             history=[],
             user=mock_user,
             teacher_response="Hi!",
+            vocabulary_candidates=[],
             pre_results=[],
             coordinator_row_id=42,
         )
@@ -1040,6 +1341,7 @@ async def test_start_background_post_turn_returns_before_slow_post_finishes(
             history=[],
             user=mock_user,
             teacher_response="Hi!",
+            vocabulary_candidates=[],
             pre_results=[],
             coordinator_row_id=42,
         )
@@ -1072,6 +1374,7 @@ async def test_start_background_post_turn_marks_failed_on_timeout(mock_settings,
             history=[],
             user=mock_user,
             teacher_response="Hi!",
+            vocabulary_candidates=[],
             pre_results=[],
             coordinator_row_id=42,
         )
@@ -1093,11 +1396,13 @@ class _CaptureHistorySpecialist(BaseSpecialist):
         super().__init__(name="capture_history")
         self.seen_history = None
         self.seen_teacher_response = None
+        self.seen_vocabulary_candidates = None
         self.seen_routing_reason = None
 
     async def run(self, context: SpecialistContext) -> SpecialistResult:
         self.seen_history = context.history
         self.seen_teacher_response = context.teacher_response
+        self.seen_vocabulary_candidates = context.vocabulary_candidates
         self.seen_routing_reason = context.routing_reason
         return SpecialistResult(status="no_action")
 
@@ -1164,7 +1469,7 @@ async def test_specialist_history_truncation_logs_warning(mock_settings, mock_us
 
 
 @pytest.mark.anyio
-async def test_word_keeper_history_is_capped_to_two_messages(
+async def test_word_keeper_receives_latest_teacher_message_without_history(
     mock_settings, mock_user, mock_memory_item_service, mock_side_effect_service
 ):
     manager = AgentsManager(mock_settings)
@@ -1172,7 +1477,7 @@ async def test_word_keeper_history_is_capped_to_two_messages(
     capture.name = "word_keeper"
     manager.registry.register(capture, overwrite=True)
     manager.coordinator.plan_pre_turn = AsyncMock(
-        return_value=_make_plan(pre=[RoutingItem(name="word_keeper", reason="save words", chat_history_size=6)])
+        return_value=_make_plan(pre=[RoutingItem(name="word_keeper", reason="save words", chat_history_size=0)])
     )
 
     history = [
@@ -1192,23 +1497,50 @@ async def test_word_keeper_history_is_capped_to_two_messages(
     )
 
     assert capture.seen_history is not None
-    assert len(capture.seen_history) == 2
-    assert [msg.content for msg in capture.seen_history] == ["m3", "m4"]
+    assert capture.seen_history == []
+    assert capture.seen_teacher_response == "m4"
 
 
 @pytest.mark.anyio
-async def test_run_post_turn_passes_previous_history_and_current_teacher_response_to_word_keeper(
+async def test_word_keeper_does_not_receive_non_adjacent_teacher_message(
+    mock_settings, mock_user, mock_memory_item_service, mock_side_effect_service
+):
+    manager = AgentsManager(mock_settings)
+    capture = _CaptureHistorySpecialist()
+    capture.name = "word_keeper"
+    manager.registry.register(capture, overwrite=True)
+    manager.coordinator.plan_pre_turn = AsyncMock(
+        return_value=_make_plan(pre=[RoutingItem(name="word_keeper", reason="save words", chat_history_size=0)])
+    )
+
+    history = [
+        ChatMessage(role="assistant", content="m1"),
+        ChatMessage(role="user", content="m2"),
+    ]
+
+    await manager.prepare_pre_turn(
+        message="Save that word for me.",
+        chat_id="chat-1",
+        history=history,
+        user=mock_user,
+        memory_item_service=mock_memory_item_service,
+        side_effect_service=mock_side_effect_service,
+    )
+
+    assert capture.seen_history is not None
+    assert capture.seen_history == []
+    assert capture.seen_teacher_response is None
+
+
+@pytest.mark.anyio
+async def test_run_post_turn_passes_candidates_without_chat_history_or_teacher_response_to_word_keeper(
     mock_settings, mock_user, mock_side_effect_service
 ):
     manager = AgentsManager(mock_settings)
     capture = _CaptureHistorySpecialist()
     capture.name = "word_keeper"
     manager.registry.register(capture, overwrite=True)
-    manager.coordinator.plan_post_turn = AsyncMock(
-        return_value=_make_plan(
-            post=[RoutingItem(name="word_keeper", reason="teacher highlighted words", chat_history_size=2)]
-        )
-    )
+    manager.coordinator.plan_post_turn = AsyncMock(return_value=_make_plan())
 
     history = [
         ChatMessage(role="user", content="Can you explain these words?"),
@@ -1221,18 +1553,16 @@ async def test_run_post_turn_passes_previous_history_and_current_teacher_respons
         history=history,
         user=mock_user,
         teacher_response="Let's keep this new word in mind: begripa.",
+        vocabulary_candidates=[WordSaveCandidate(word_phrase="begripa")],
         pre_results=[],
         side_effect_service=mock_side_effect_service,
         coordinator_row_id=99,
     )
 
     assert capture.seen_history is not None
-    assert [msg.content for msg in capture.seen_history] == [
-        "Can you explain these words?",
-        "Let's save these words: beskriva, bekräfta.",
-    ]
-    assert capture.seen_teacher_response == "Let's keep this new word in mind: begripa."
-    assert capture.seen_routing_reason == "teacher highlighted words"
+    assert capture.seen_history == []
+    assert capture.seen_teacher_response is None
+    assert capture.seen_routing_reason == "teacher emitted vocabulary_candidates"
 
 
 @pytest.mark.anyio

--- a/tests/agents/test_teacher.py
+++ b/tests/agents/test_teacher.py
@@ -14,6 +14,7 @@ from runestone.agents.specialists.base import INFO_FOR_TEACHER_MAX_CHARS
 from runestone.agents.specialists.teacher import TeacherAgent
 from runestone.config import AgentLLMSettings, ReasoningLevel, Settings
 from runestone.constants import MAX_TEACHER_GRAMMAR_SOURCE_LINKS
+from runestone.schemas.vocabulary_save import WordSaveCandidate
 
 
 @pytest.fixture
@@ -104,8 +105,16 @@ def test_build_agent(mock_settings, mock_chat_model):
             assert "read-only in this phase" in call_kwargs["system_prompt"]
             assert "only say words were definitely saved" in call_kwargs["system_prompt"].lower()
             assert "WORDKEEPER SPECIALIST" in call_kwargs["system_prompt"]
-            assert "The key words here are" in call_kwargs["system_prompt"]
-            assert "Write a sentence with" in call_kwargs["system_prompt"]
+            assert "vocabulary_candidates" in call_kwargs["system_prompt"]
+            assert "structured field is the authoritative signal" in call_kwargs["system_prompt"]
+            assert "Leave `vocabulary_candidates` empty" in call_kwargs["system_prompt"]
+            assert "You may still naturally highlight useful vocabulary" in call_kwargs["system_prompt"]
+            assert "No leading articles: save `hund`, not `en hund`" in call_kwargs["system_prompt"]
+            assert "Prefer lemma or base form unless the inflected form matters." in call_kwargs["system_prompt"]
+            assert "Keep Swedish characters; never ASCII-fold `å`, `ä`, or `ö`." in call_kwargs["system_prompt"]
+            assert "Do not save grammar-only tokens as vocabulary unless explicitly presented as learning items." in (
+                call_kwargs["system_prompt"]
+            )
             assert "MEMORYKEEPER POST-PHASE SIGNALS" in call_kwargs["system_prompt"]
             assert "prefer to include one short" in call_kwargs["system_prompt"]
             assert "explicit sentence" in call_kwargs["system_prompt"]
@@ -254,6 +263,7 @@ async def test_run_returns_structured_teacher_emotion(teacher_agent, mock_user):
             message="Bra jobbat!",
             emotion="happy",
             grammar_source_urls=["https://example.com/grammar"],
+            vocabulary_candidates=[WordSaveCandidate(word_phrase="begripa")],
         ),
     }
 
@@ -262,6 +272,7 @@ async def test_run_returns_structured_teacher_emotion(teacher_agent, mock_user):
     assert generated.message == "Bra jobbat!"
     assert generated.emotion == "happy"
     assert generated.grammar_source_urls == ["https://example.com/grammar"]
+    assert generated.vocabulary_candidates == [WordSaveCandidate(word_phrase="begripa")]
     assert isinstance(generated.final_messages, list)
 
 
@@ -544,6 +555,21 @@ def test_teacher_output_normalizes_and_deduplicates_grammar_source_urls():
         "https://example.com/1",
         "https://example.com/2",
         "https://example.com/3",
+    ]
+
+
+def test_teacher_output_defaults_and_preserves_vocabulary_candidates():
+    empty_payload = TeacherOutput(message="Hej")
+    payload = TeacherOutput(
+        message="Hej",
+        vocabulary_candidates=[
+            WordSaveCandidate(word_phrase="begripa", context_phrase="Jag begriper inte."),
+        ],
+    )
+
+    assert empty_payload.vocabulary_candidates == []
+    assert payload.vocabulary_candidates == [
+        WordSaveCandidate(word_phrase="begripa", context_phrase="Jag begriper inte."),
     ]
 
 


### PR DESCRIPTION
## Summary
- move post-response vocabulary saving to structured `TeacherOutput.vocabulary_candidates` as the authoritative signal
- route teacher-emitted vocabulary directly to `word_keeper` in post-processing (parallel with coordinator post work), while excluding post `word_keeper` routing from coordinator
- add optional `context_phrase` to vocabulary candidates and carry it through prioritization/enrichment
- simplify `word_keeper` inputs: pre-extraction now uses student `message` (+ optional immediately preceding `teacher_response` for deictic requests), enrichment uses candidate artifacts + target language
- make pre-response deictic behavior explicit and adjacent-only (`teacher_response` only when immediately preceding assistant message exists)
- prevent duplicate same-turn saves by filtering post teacher candidates against words actually saved by pre-response `word_keeper`
- update coordinator/teacher/manager/wordkeeper prompts and contracts accordingly
- refresh architecture/todo docs and add future follow-up notes

## Key files
- `src/runestone/agents/manager.py`
- `src/runestone/agents/coordinator.py`
- `src/runestone/agents/specialists/teacher.py`
- `src/runestone/agents/specialists/word_keeper.py`
- `src/runestone/schemas/vocabulary_save.py`
- `src/runestone/services/vocabulary_service.py`
- `tests/agents/test_manager.py`
- `tests/agents/specialists/test_word_keeper.py`
- `tests/agents/test_coordinator.py`
- `tests/agents/test_teacher.py`
- docs updates under `docs/`

## Validation
- `UV_CACHE_DIR=.uv-cache uv run pytest tests/agents/test_manager.py tests/agents/specialists/test_word_keeper.py tests/agents/test_coordinator.py tests/agents/test_teacher.py -q`
- `UV_CACHE_DIR=.uv-cache uv run pytest tests/agents/test_manager.py tests/agents/specialists/test_word_keeper.py -q`
- `make lint-check`
- `git diff --check`

## Notes
- A broader run including `tests/services/test_services_vocabulary_service.py` can fail in restricted sandbox environments due to local Postgres access constraints; focused suites above passed.
