### PR TITLE
Hide teacher chat controls behind a collapsible panel

### DIFF
--- a/frontend/src/components/ChatView.test.tsx
+++ b/frontend/src/components/ChatView.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import ChatView from './ChatView';
 import { AuthProvider } from '../context/AuthContext';
+import * as voiceRecordingHook from '../hooks/useVoiceRecording';
 
 // Mock the API
 const mockFetch = vi.fn();
@@ -158,6 +159,35 @@ describe('ChatView', () => {
     expect(screen.getByRole('combobox', { name: /speech language/i })).toBeInTheDocument();
     expect(screen.getByText('Autosend')).toBeInTheDocument();
     expect(screen.getByText('Speed:')).toBeInTheDocument();
+  });
+
+  it('keeps chat controls expanded and disables the toggle while recording', () => {
+    const startRecording = vi.fn();
+    const stopRecording = vi.fn();
+    const useVoiceRecordingSpy = vi
+      .spyOn(voiceRecordingHook, 'useVoiceRecording')
+      .mockReturnValue({
+        isRecording: true,
+        isProcessing: false,
+        recordedDuration: 12,
+        startRecording,
+        stopRecording,
+        error: null,
+        clearError: vi.fn(),
+      });
+
+    render(
+      <AuthProvider>
+        <ChatView />
+      </AuthProvider>
+    );
+
+    const toggleButton = screen.getByRole('button', { name: /chat controls/i });
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
+    expect(toggleButton).toBeDisabled();
+    expect(screen.getByRole('combobox', { name: /speech language/i })).toBeInTheDocument();
+
+    useVoiceRecordingSpy.mockRestore();
   });
 
   it('uses stored speech language before profile language', () => {

--- a/frontend/src/components/ChatView.test.tsx
+++ b/frontend/src/components/ChatView.test.tsx
@@ -72,6 +72,10 @@ const getSendButton = () => {
   return screen.getByRole('button', { name: /send message/i });
 };
 
+const expandChatControls = () => {
+  fireEvent.click(screen.getByRole('button', { name: /chat controls/i }));
+};
+
 describe('ChatView', () => {
   const resetLocalStorage = (userData: Record<string, unknown> = {
     id: '1',
@@ -122,7 +126,38 @@ describe('ChatView', () => {
       </AuthProvider>
     );
 
+    expandChatControls();
     expect(screen.getByRole('combobox', { name: /speech language/i })).toHaveTextContent('Finnish');
+  });
+
+  it('keeps teacher chat controls collapsed by default', () => {
+    render(
+      <AuthProvider>
+        <ChatView />
+      </AuthProvider>
+    );
+
+    expect(screen.getByRole('button', { name: /chat controls/i })).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('combobox', { name: /speech language/i })).not.toBeInTheDocument();
+    expect(screen.queryByText('Autosend')).not.toBeInTheDocument();
+    expect(screen.queryByText('Speed:')).not.toBeInTheDocument();
+  });
+
+  it('expands teacher chat controls when toggled', async () => {
+    render(
+      <AuthProvider>
+        <ChatView />
+      </AuthProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /chat controls/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /chat controls/i })).toHaveAttribute('aria-expanded', 'true');
+    });
+    expect(screen.getByRole('combobox', { name: /speech language/i })).toBeInTheDocument();
+    expect(screen.getByText('Autosend')).toBeInTheDocument();
+    expect(screen.getByText('Speed:')).toBeInTheDocument();
   });
 
   it('uses stored speech language before profile language', () => {
@@ -146,6 +181,7 @@ describe('ChatView', () => {
       </AuthProvider>
     );
 
+    expandChatControls();
     expect(screen.getByRole('combobox', { name: /speech language/i })).toHaveTextContent('German');
   });
 
@@ -170,6 +206,7 @@ describe('ChatView', () => {
       </AuthProvider>
     );
 
+    expandChatControls();
     expect(screen.getByRole('combobox', { name: /speech language/i })).toHaveTextContent('Finnish');
   });
 
@@ -180,6 +217,7 @@ describe('ChatView', () => {
       </AuthProvider>
     );
 
+    expandChatControls();
     fireEvent.mouseDown(screen.getByRole('combobox', { name: /speech language/i }));
     fireEvent.click(screen.getByRole('option', { name: 'Finnish' }));
 
@@ -195,6 +233,7 @@ describe('ChatView', () => {
       </AuthProvider>
     );
 
+    expandChatControls();
     expect(screen.getByRole('combobox', { name: /speech language/i })).toHaveTextContent('Swedish');
 
     act(() => {
@@ -236,6 +275,7 @@ describe('ChatView', () => {
       </AuthProvider>
     );
 
+    expandChatControls();
     expect(screen.getByRole('combobox', { name: /speech language/i })).toHaveTextContent('German');
 
     act(() => {
@@ -264,6 +304,7 @@ describe('ChatView', () => {
       </AuthProvider>
     );
 
+    expandChatControls();
     fireEvent.mouseDown(screen.getByRole('combobox', { name: /speech language/i }));
     fireEvent.click(screen.getByRole('option', { name: 'German' }));
 
@@ -536,6 +577,7 @@ describe('ChatView', () => {
       expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
     });
 
+    expandChatControls();
     // 1. Upload an image
     const file = new File(['(⌐□_□)'], 'chucknorris.png', { type: 'image/png' });
     const fileInput = container.querySelector('input[type="file"]');
@@ -599,6 +641,7 @@ describe('ChatView', () => {
       expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
     });
 
+    expandChatControls();
     const file = new File(['(⌐□_□)'], 'test.png', { type: 'image/png' });
     const fileInput = container.querySelector('input[type="file"]');
 
@@ -654,6 +697,7 @@ describe('ChatView', () => {
       expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
     });
 
+    expandChatControls();
     const file = new File(['test'], 'test.png', { type: 'image/png' });
     const fileInput = container.querySelector('input[type="file"]');
 
@@ -698,6 +742,7 @@ describe('ChatView', () => {
       expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
     });
 
+    expandChatControls();
     const file = new File(['test'], 'test.png', { type: 'image/png' });
     const fileInput = container.querySelector('input[type="file"]');
 
@@ -746,6 +791,7 @@ describe('ChatView', () => {
 
     const input = screen.getByPlaceholderText('Skriv ditt svar här...') as HTMLInputElement;
     const sendButton = getSendButton();
+    expandChatControls();
     const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
 
     // Type a message to enable send button

--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { Box, Typography } from "@mui/material";
+import { ExpandLess, ExpandMore } from "@mui/icons-material";
+import { Box, ButtonBase, Collapse, Typography } from "@mui/material";
 import {
   ErrorAlert,
   ChatMessageBubble,
@@ -71,6 +72,8 @@ const ChatView: React.FC = () => {
   } = useChatImageUpload();
   const [snackbarError, setSnackbarError] = useState<string | null>(null);
   const [isMemoryModalOpen, setIsMemoryModalOpen] = useState(false);
+  const [areComposerControlsExpanded, setAreComposerControlsExpanded] =
+    useState(false);
 
   // Voice recording with improve option
   const [improveTranscription, setImproveTranscription] = useState(() => {
@@ -469,36 +472,97 @@ const ChatView: React.FC = () => {
             onSendMessage={handleSendMessage}
           />
 
-          <ChatComposerControls
-            isAnyProcessing={isAnyProcessing}
-            isRecording={isRecording}
-            canUseMicrophone={canUseMicrophone}
-            isTranscribing={isTranscribing}
-            recordedDuration={recordedDuration}
-            autoSend={autoSend}
-            improveTranscription={improveTranscription}
-            speechLanguage={speechLanguage}
-            languages={LANGUAGES}
-            onImageUpload={handleImageUpload}
-            onImageError={handleImageError}
-            onStartRecording={handleStartRecording}
-            onStopRecording={handleStopRecording}
-            onAutoSendChange={setAutoSend}
-            onImproveTranscriptionChange={setImproveTranscription}
-            onSpeechLanguageChange={(value) => {
-              setHasSpeechLanguageOverride(true);
-              setSpeechLanguage(value);
+          <Box
+            sx={{
+              borderRadius: 2,
+              border: "1px solid rgba(255, 255, 255, 0.08)",
+              backgroundColor: "rgba(255, 255, 255, 0.03)",
+              overflow: "hidden",
             }}
-          />
+          >
+            <ButtonBase
+              onClick={() =>
+                setAreComposerControlsExpanded((expanded) => !expanded)
+              }
+              aria-expanded={areComposerControlsExpanded}
+              aria-controls="teacher-chat-controls-panel"
+              sx={{
+                width: "100%",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 1,
+                px: 1.5,
+                py: 1,
+                color: "#d1d5db",
+              }}
+            >
+              <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
+                <Typography
+                  component="span"
+                  sx={{ fontSize: "0.85rem", fontWeight: 600, letterSpacing: "0.01em" }}
+                >
+                  Chat controls
+                </Typography>
+                <Typography
+                  component="span"
+                  sx={{ fontSize: "0.72rem", color: "#9ca3af" }}
+                >
+                  Voice, image, and transcription settings
+                </Typography>
+              </Box>
+              {areComposerControlsExpanded ? (
+                <ExpandLess fontSize="small" />
+              ) : (
+                <ExpandMore fontSize="small" />
+              )}
+            </ButtonBase>
 
-          <ChatPlaybackSettings
-            voiceEnabled={voiceEnabled}
-            isAudioPlaying={isAudioPlaying}
-            isAnyProcessing={isAnyProcessing}
-            speechSpeed={speechSpeed}
-            onVoiceEnabledChange={setVoiceEnabled}
-            onSpeechSpeedChange={setSpeechSpeed}
-          />
+            <Collapse
+              in={areComposerControlsExpanded}
+              id="teacher-chat-controls-panel"
+              unmountOnExit
+            >
+              <Box
+                sx={{
+                  px: 1.5,
+                  pb: 1.25,
+                  borderTop: "1px solid rgba(255, 255, 255, 0.08)",
+                }}
+              >
+                <ChatComposerControls
+                  isAnyProcessing={isAnyProcessing}
+                  isRecording={isRecording}
+                  canUseMicrophone={canUseMicrophone}
+                  isTranscribing={isTranscribing}
+                  recordedDuration={recordedDuration}
+                  autoSend={autoSend}
+                  improveTranscription={improveTranscription}
+                  speechLanguage={speechLanguage}
+                  languages={LANGUAGES}
+                  onImageUpload={handleImageUpload}
+                  onImageError={handleImageError}
+                  onStartRecording={handleStartRecording}
+                  onStopRecording={handleStopRecording}
+                  onAutoSendChange={setAutoSend}
+                  onImproveTranscriptionChange={setImproveTranscription}
+                  onSpeechLanguageChange={(value) => {
+                    setHasSpeechLanguageOverride(true);
+                    setSpeechLanguage(value);
+                  }}
+                />
+
+                <ChatPlaybackSettings
+                  voiceEnabled={voiceEnabled}
+                  isAudioPlaying={isAudioPlaying}
+                  isAnyProcessing={isAnyProcessing}
+                  speechSpeed={speechSpeed}
+                  onVoiceEnabledChange={setVoiceEnabled}
+                  onSpeechSpeedChange={setSpeechSpeed}
+                />
+              </Box>
+            </Collapse>
+          </Box>
         </Box>
 
         {/* Upload error display */}

--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -227,6 +227,12 @@ const ChatView: React.FC = () => {
     }
   }, [voiceError, clearVoiceError]);
 
+  useEffect(() => {
+    if (isRecording) {
+      setAreComposerControlsExpanded(true);
+    }
+  }, [isRecording]);
+
   // Auto-scroll to bottom when messages change or loading state changes
   useEffect(() => {
     const container = scrollContainerRef.current;
@@ -484,6 +490,7 @@ const ChatView: React.FC = () => {
               onClick={() =>
                 setAreComposerControlsExpanded((expanded) => !expanded)
               }
+              disabled={isRecording}
               aria-expanded={areComposerControlsExpanded}
               aria-controls="teacher-chat-controls-panel"
               sx={{
@@ -495,6 +502,11 @@ const ChatView: React.FC = () => {
                 px: 1.5,
                 py: 1,
                 color: "#d1d5db",
+                "&.Mui-disabled": {
+                  opacity: 0.6,
+                  color: "#9ca3af",
+                  cursor: "not-allowed",
+                },
               }}
             >
               <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-start" }}>


### PR DESCRIPTION
## Summary
- hide the Teacher chat controls behind a collapsed-by-default toggle to save space on mobile
- keep the existing voice, image, transcription, and playback settings inside the expandable panel
- update ChatView tests to cover the collapsed and expanded states and open the panel before interacting with those controls

## Testing
- npm run lint
- npm run test:run -- src/components/ChatView.test.tsx