### PR TITLE
Fix vocabulary improvement prompt parity

### DIFF
--- a/.codex/skills/runestone-orchestration/SKILL.md
+++ b/.codex/skills/runestone-orchestration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: runestone-orchestration
-description: Thin Runestone adapter for the global dev-work-item-orchestration lifecycle. Use by default for any implementation command while working in /Users/40min/www/runestone, including "let's do ...", "start ...", "implement ...", "apply this plan", "fix this", or "take this through PR", unless the user explicitly says not to use orchestration. Do not use for creating or modifying skills; use skill-creator for skill work instead.
+description: Thin Runestone adapter for the global dev-work-item-orchestration lifecycle. Use by default for any implementation command while working in any Runestone checkout, including /Users/40min/www/runestone and Codex worktrees such as /Users/40min/.codex/worktrees/*/runestone. Trigger on requests like "let's do ...", "let's tackle ...", "start ...", "implement ...", "apply this plan", "fix this", "take this through PR", or when the user references a Runestone task id to investigate or implement. Do not use for creating or modifying skills; use skill-creator for skill work instead.
 ---
 
 # Runestone Orchestration
@@ -11,28 +11,30 @@ Use this skill as the Runestone adapter for `/Users/40min/.codex/skills/dev-work
 
 - Lifecycle sequence and gates: `/Users/40min/.codex/skills/dev-work-item-orchestration/SKILL.md`.
 - Dart task CRUD and generic task safety: `/Users/40min/.codex/skills/dev-project-task-management/SKILL.md`.
-- Runestone Dart defaults: `/Users/40min/www/runestone/.codex/skills/runestone-task-management/SKILL.md`.
-- Repository conventions: `/Users/40min/www/runestone/AGENTS.md`.
+- Runestone Dart defaults: read `.codex/skills/runestone-task-management/SKILL.md` from the active Runestone checkout.
+- Repository conventions: read `AGENTS.md` from the active Runestone checkout.
 
 Load those files when this skill triggers. Do not copy their rules into this skill.
 
 ## Runestone Defaults
 
-- Repository: `/Users/40min/www/runestone`.
+- Repository: the active Runestone checkout, including `/Users/40min/www/runestone` and Codex worktrees such as `/Users/40min/.codex/worktrees/<id>/runestone`.
 - Task wrapper skill: `runestone-task-management`.
 - Branch names: use `feat/<slug>` for new functionality and `fix/<slug>` for bug fixes. Do not use the generic `codex/` branch prefix for Runestone work.
 
 ## Trigger Coverage
 
-Treat this adapter as the default entrypoint for implementation work in `/Users/40min/www/runestone`, not only for exact phrase matches. If the user gives any implementation command, use this lifecycle unless they explicitly opt out of orchestration.
+Treat this adapter as the default entrypoint for implementation work in any Runestone checkout, not only for exact phrase matches. If the user gives any implementation command, use this lifecycle unless they explicitly opt out of orchestration.
 
 Trigger this skill when the user:
 
 - asks to implement code changes (for example: "implement this", "please implement this plan", "apply this plan", "fix this", "add this endpoint")
+- asks to investigate and fix behavior in the codebase, even if phrased as debugging or comparison work
 - asks to carry work through checks/commit/PR
 - asks to continue or finish an in-flight Runestone change that already has code edits
+- references a Runestone task id or issue id together with implementation intent, for example "let's tackle 9fzWVGdbo2HP" or "take task 9fzWVGdbo2HP"
 
-Do not wait for literal phrases like "let's do", "start", or "take this through PR" if the implementation intent is already clear. Do not skip this skill merely because the request looks small, frontend-only, backend-only, docs-only, or test-only.
+Do not wait for literal phrases like "let's do", "let's tackle", "start", or "take this through PR" if the implementation intent is already clear. Do not skip this skill merely because the request looks small, frontend-only, backend-only, docs-only, investigation-heavy, or test-only.
 
 Do not trigger this lifecycle for creating or modifying skills, including skill trigger text, skill workflows, bundled skill scripts, or skill metadata. Use `skill-creator` for those requests unless the user explicitly asks to run Runestone orchestration for the skill work.
 

--- a/.codex/skills/runestone-orchestration/SKILL.md
+++ b/.codex/skills/runestone-orchestration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: runestone-orchestration
-description: Thin Runestone adapter for the global dev-work-item-orchestration lifecycle. Use by default for any implementation command while working in any Runestone checkout, including /Users/40min/www/runestone and Codex worktrees such as /Users/40min/.codex/worktrees/*/runestone. Trigger on requests like "let's do ...", "let's tackle ...", "start ...", "implement ...", "apply this plan", "fix this", "take this through PR", or when the user references a Runestone task id to investigate or implement. Do not use for creating or modifying skills; use skill-creator for skill work instead.
+description: Thin Runestone adapter for the global dev-work-item-orchestration lifecycle. Use by default for any implementation command while working in an active Runestone checkout, whether that is the primary repository clone or a Codex worktree. Trigger on requests like "let's do ...", "let's tackle ...", "start ...", "implement ...", "apply this plan", "fix this", "take this through PR", or when the user references a Runestone task id to investigate or implement. Do not use for creating or modifying skills; use skill-creator for skill work instead.
 ---
 
 # Runestone Orchestration
@@ -18,7 +18,7 @@ Load those files when this skill triggers. Do not copy their rules into this ski
 
 ## Runestone Defaults
 
-- Repository: the active Runestone checkout, including `/Users/40min/www/runestone` and Codex worktrees such as `/Users/40min/.codex/worktrees/<id>/runestone`.
+- Repository: the active Runestone checkout, whether that is the primary repository clone or a Codex worktree.
 - Task wrapper skill: `runestone-task-management`.
 - Branch names: use `feat/<slug>` for new functionality and `fix/<slug>` for bug fixes. Do not use the generic `codex/` branch prefix for Runestone work.
 

--- a/src/runestone/core/prompt_builder/builder.py
+++ b/src/runestone/core/prompt_builder/builder.py
@@ -85,24 +85,24 @@ class PromptBuilder:
 
         Args:
             word_phrase: Swedish word or phrase to improve
-            mode: Type of improvement requested
+            mode: Type of improvement requested. The prompt is shared across
+                modes; filtering happens after the model response is parsed.
 
         Returns:
             Complete vocabulary improvement prompt string
         """
         template = self._templates[PromptType.VOCABULARY_IMPROVE]
 
-        params = self._build_vocabulary_params(word_phrase, mode)
+        params = self._build_vocabulary_params(word_phrase)
 
         return template.render(**params)
 
-    def _build_vocabulary_params(self, word_phrase: str, mode: ImprovementMode) -> Dict[str, str]:
+    def _build_vocabulary_params(self, word_phrase: str) -> Dict[str, str]:
         """
         Build parameters for the shared vocabulary template.
 
         Args:
             word_phrase: Swedish word or phrase
-            mode: Improvement mode, retained for API compatibility
 
         Returns:
             Dictionary of template parameters

--- a/src/runestone/core/prompt_builder/builder.py
+++ b/src/runestone/core/prompt_builder/builder.py
@@ -77,12 +77,11 @@ class PromptBuilder:
 
     def build_vocabulary_prompt(self, word_phrase: str, mode: ImprovementMode = ImprovementMode.EXAMPLE_ONLY) -> str:
         """
-        Build vocabulary improvement prompt based on mode.
+        Build the vocabulary improvement prompt.
 
-        This method constructs different prompts depending on the improvement mode:
-        - EXAMPLE_ONLY: Request only example phrase
-        - EXTRA_INFO_ONLY: Request only grammatical information
-        - ALL_FIELDS: Request translation, example, and extra info
+        All improvement modes share the same rich prompt so the model always gets
+        the same linguistic context. The requested mode is applied later when the
+        response is filtered for the caller.
 
         Args:
             word_phrase: Swedish word or phrase to improve
@@ -93,28 +92,21 @@ class PromptBuilder:
         """
         template = self._templates[PromptType.VOCABULARY_IMPROVE]
 
-        # Build mode-specific parameters
         params = self._build_vocabulary_params(word_phrase, mode)
 
         return template.render(**params)
 
     def _build_vocabulary_params(self, word_phrase: str, mode: ImprovementMode) -> Dict[str, str]:
         """
-        Build parameters for vocabulary template based on improvement mode.
-
-        This method encapsulates the conditional logic for different vocabulary
-        improvement modes, extracted from VocabularyService._build_improvement_prompt().
-
-        Strategy: Start with ALL_FIELDS mode and then filter based on specific mode flags.
+        Build parameters for the shared vocabulary template.
 
         Args:
             word_phrase: Swedish word or phrase
-            mode: Improvement mode
+            mode: Improvement mode, retained for API compatibility
 
         Returns:
             Dictionary of template parameters
         """
-        # Start with ALL_FIELDS - all parts of the prompt defined
         params = {
             "word_phrase": word_phrase,
             "content_type": "translation, example phrase and extra info",
@@ -145,48 +137,6 @@ class PromptBuilder:
                 "already in basic form. Provide comparative forms for adjectives."
             ),
         }
-
-        # Apply mode-specific filtering
-        if mode == ImprovementMode.EXTRA_INFO_ONLY:
-            # Only extra info requested - remove translation and example
-            params["content_type"] = "extra info"
-            params["translation_instruction_json"] = ""
-            params["translation_detail"] = ""
-            params["example_phrase_json"] = ""
-            params["example_phrase_detail"] = ""
-            # Remove leading comma from extra_info_json since it's now the first field
-            params["extra_info_json"] = (
-                '"extra_info": "A concise description of grammatical details '
-                '(e.g., word form, base form, en/ett classification)"'
-            )
-            # Re-number the instruction for extra_info to be 1 instead of 3
-            params["extra_info_detail"] = (
-                "1. For extra_info:\n    - Provide grammatical information about "
-                "the Swedish word/phrase\n    - Include word form (noun, verb, "
-                "adjective, etc.), en/ett classification for nouns, base forms, etc.\n"
-                '    - Keep it concise and human-readable (e.g., "en-word, noun, '
-                'base form: ord")\n    - Focus on the most important grammatical '
-                "details for language learners"
-            )
-        elif mode == ImprovementMode.EXAMPLE_ONLY:
-            # Only example requested - remove translation and extra info
-            params["content_type"] = "example phrase"
-            params["translation_instruction_json"] = ""
-            params["translation_detail"] = ""
-            params["extra_info_json"] = ""
-            params["extra_info_detail"] = ""
-            # Remove leading comma from example_phrase_json since it's now the first field
-            params["example_phrase_json"] = (
-                '"example_phrase": "A natural Swedish sentence using the ' 'word/phrase in context"'
-            )
-            # Re-number the instruction for example_phrase to be 1 instead of 2
-            params["example_phrase_detail"] = (
-                "1. For example_phrase:\n    - Create a natural, conversational "
-                "Swedish sentence that uses the word/phrase\n    - The sentence "
-                "should clearly demonstrate the meaning and usage\n    - Keep it "
-                "simple and appropriate for language learners\n    - The example "
-                "should be practical and realistic"
-            )
 
         return params
 

--- a/tests/core/prompt_builder/test_builder.py
+++ b/tests/core/prompt_builder/test_builder.py
@@ -133,49 +133,27 @@ class TestBuildVocabularyPrompt:
         """Set up test fixtures."""
         self.builder = PromptBuilder()
 
-    def test_build_vocabulary_prompt_example_only_mode(self):
-        """Test building vocabulary prompt in EXAMPLE_ONLY mode."""
+    def test_build_vocabulary_prompt_contains_shared_rich_instructions(self):
+        """Test the shared vocabulary prompt contains all rich fields and instructions."""
         word_phrase = "hund"
-        prompt = self.builder.build_vocabulary_prompt(word_phrase, ImprovementMode.EXAMPLE_ONLY)
-
-        assert isinstance(prompt, str)
-        assert word_phrase in prompt
-        assert "example phrase" in prompt.lower()
-        # Should not request translation or extra info
-        assert "translation" not in prompt.lower() or '"translation"' not in prompt
-
-    def test_build_vocabulary_prompt_extra_info_only_mode(self):
-        """Test building vocabulary prompt in EXTRA_INFO_ONLY mode."""
-        word_phrase = "katt"
-        prompt = self.builder.build_vocabulary_prompt(word_phrase, ImprovementMode.EXTRA_INFO_ONLY)
-
-        assert isinstance(prompt, str)
-        assert word_phrase in prompt
-        assert "extra info" in prompt.lower() or "extra_info" in prompt
-        # Should not request translation or example
-        assert "translation" not in prompt.lower() or '"translation"' not in prompt
-
-    def test_build_vocabulary_prompt_all_fields_mode(self):
-        """Test building vocabulary prompt in ALL_FIELDS mode."""
-        word_phrase = "bil"
         prompt = self.builder.build_vocabulary_prompt(word_phrase, ImprovementMode.ALL_FIELDS)
 
         assert isinstance(prompt, str)
         assert word_phrase in prompt
-        # Should request all fields
-        assert "translation" in prompt.lower()
-        assert "example" in prompt.lower()
-        assert "extra" in prompt.lower()
+        assert '"translation"' in prompt
+        assert '"example_phrase"' in prompt
+        assert '"extra_info"' in prompt
+        assert "1. For translation" in prompt
+        assert "2. For example_phrase" in prompt
+        assert "3. For extra_info" in prompt
 
-    def test_build_vocabulary_prompt_default_mode(self):
-        """Test building vocabulary prompt with default mode (EXAMPLE_ONLY)."""
+    def test_build_vocabulary_prompt_is_shared_across_modes(self):
+        """Test all improvement modes reuse the same prompt structure."""
         word_phrase = "hus"
-        prompt = self.builder.build_vocabulary_prompt(word_phrase)
+        prompts = {mode: self.builder.build_vocabulary_prompt(word_phrase, mode) for mode in ImprovementMode}
 
-        assert isinstance(prompt, str)
-        assert word_phrase in prompt
-        # Default should be EXAMPLE_ONLY
-        assert "example" in prompt.lower()
+        assert prompts[ImprovementMode.EXAMPLE_ONLY] == prompts[ImprovementMode.EXTRA_INFO_ONLY]
+        assert prompts[ImprovementMode.EXTRA_INFO_ONLY] == prompts[ImprovementMode.ALL_FIELDS]
 
     def test_build_vocabulary_prompt_with_special_characters(self):
         """Test building vocabulary prompt with Swedish special characters."""
@@ -199,8 +177,8 @@ class TestBuildVocabularyParams:
         """Set up test fixtures."""
         self.builder = PromptBuilder()
 
-    def test_build_params_all_fields_mode(self):
-        """Test building parameters for ALL_FIELDS mode."""
+    def test_build_params_returns_shared_rich_structure(self):
+        """Test vocabulary params always contain the full shared prompt structure."""
         params = self.builder._build_vocabulary_params("test", ImprovementMode.ALL_FIELDS)
 
         assert params["word_phrase"] == "test"
@@ -211,40 +189,6 @@ class TestBuildVocabularyParams:
         assert params["example_phrase_detail"] != ""
         assert params["extra_info_json"] != ""
         assert params["extra_info_detail"] != ""
-
-    def test_build_params_example_only_mode(self):
-        """Test building parameters for EXAMPLE_ONLY mode."""
-        params = self.builder._build_vocabulary_params("test", ImprovementMode.EXAMPLE_ONLY)
-
-        assert params["word_phrase"] == "test"
-        assert "example phrase" in params["content_type"]
-        # Translation and extra_info should be empty
-        assert params["translation_instruction_json"] == ""
-        assert params["translation_detail"] == ""
-        assert params["extra_info_json"] == ""
-        assert params["extra_info_detail"] == ""
-        # Example phrase should be populated
-        assert params["example_phrase_json"] != ""
-        assert params["example_phrase_detail"] != ""
-        # Example phrase should not have leading comma
-        assert not params["example_phrase_json"].startswith(",")
-
-    def test_build_params_extra_info_only_mode(self):
-        """Test building parameters for EXTRA_INFO_ONLY mode."""
-        params = self.builder._build_vocabulary_params("test", ImprovementMode.EXTRA_INFO_ONLY)
-
-        assert params["word_phrase"] == "test"
-        assert "extra info" in params["content_type"]
-        # Translation and example should be empty
-        assert params["translation_instruction_json"] == ""
-        assert params["translation_detail"] == ""
-        assert params["example_phrase_json"] == ""
-        assert params["example_phrase_detail"] == ""
-        # Extra info should be populated
-        assert params["extra_info_json"] != ""
-        assert params["extra_info_detail"] != ""
-        # Extra info should not have leading comma
-        assert not params["extra_info_json"].startswith(",")
 
     def test_build_params_all_modes_have_word_phrase(self):
         """Test all modes include word_phrase parameter."""
@@ -259,18 +203,9 @@ class TestBuildVocabularyParams:
             assert params["content_type"] != ""
             assert isinstance(params["content_type"], str)
 
-    def test_build_params_numbering_consistency(self):
-        """Test that instruction numbering is consistent for each mode."""
-        # EXAMPLE_ONLY should have "1. For example_phrase"
-        params_example = self.builder._build_vocabulary_params("test", ImprovementMode.EXAMPLE_ONLY)
-        assert "1. For example_phrase" in params_example["example_phrase_detail"]
+    def test_build_params_are_identical_across_modes(self):
+        """Test all improvement modes reuse the same prompt parameters."""
+        params_by_mode = {mode: self.builder._build_vocabulary_params("test", mode) for mode in ImprovementMode}
 
-        # EXTRA_INFO_ONLY should have "1. For extra_info"
-        params_extra = self.builder._build_vocabulary_params("test", ImprovementMode.EXTRA_INFO_ONLY)
-        assert "1. For extra_info" in params_extra["extra_info_detail"]
-
-        # ALL_FIELDS should have numbered instructions
-        params_all = self.builder._build_vocabulary_params("test", ImprovementMode.ALL_FIELDS)
-        assert "1. For translation" in params_all["translation_detail"]
-        assert "2. For example_phrase" in params_all["example_phrase_detail"]
-        assert "3. For extra_info" in params_all["extra_info_detail"]
+        assert params_by_mode[ImprovementMode.EXAMPLE_ONLY] == params_by_mode[ImprovementMode.EXTRA_INFO_ONLY]
+        assert params_by_mode[ImprovementMode.EXTRA_INFO_ONLY] == params_by_mode[ImprovementMode.ALL_FIELDS]

--- a/tests/core/prompt_builder/test_builder.py
+++ b/tests/core/prompt_builder/test_builder.py
@@ -179,7 +179,7 @@ class TestBuildVocabularyParams:
 
     def test_build_params_returns_shared_rich_structure(self):
         """Test vocabulary params always contain the full shared prompt structure."""
-        params = self.builder._build_vocabulary_params("test", ImprovementMode.ALL_FIELDS)
+        params = self.builder._build_vocabulary_params("test")
 
         assert params["word_phrase"] == "test"
         assert "translation, example phrase and extra info" in params["content_type"]
@@ -193,19 +193,19 @@ class TestBuildVocabularyParams:
     def test_build_params_all_modes_have_word_phrase(self):
         """Test all modes include word_phrase parameter."""
         for mode in ImprovementMode:
-            params = self.builder._build_vocabulary_params("testord", mode)
+            params = self.builder._build_vocabulary_params("testord")
             assert params["word_phrase"] == "testord"
 
     def test_build_params_all_modes_have_content_type(self):
         """Test all modes include content_type parameter."""
         for mode in ImprovementMode:
-            params = self.builder._build_vocabulary_params("test", mode)
+            params = self.builder._build_vocabulary_params("test")
             assert params["content_type"] != ""
             assert isinstance(params["content_type"], str)
 
     def test_build_params_are_identical_across_modes(self):
         """Test all improvement modes reuse the same prompt parameters."""
-        params_by_mode = {mode: self.builder._build_vocabulary_params("test", mode) for mode in ImprovementMode}
+        params_by_mode = {mode: self.builder._build_vocabulary_params("test") for mode in ImprovementMode}
 
         assert params_by_mode[ImprovementMode.EXAMPLE_ONLY] == params_by_mode[ImprovementMode.EXTRA_INFO_ONLY]
         assert params_by_mode[ImprovementMode.EXTRA_INFO_ONLY] == params_by_mode[ImprovementMode.ALL_FIELDS]

--- a/tests/services/test_services_vocabulary_service.py
+++ b/tests/services/test_services_vocabulary_service.py
@@ -671,6 +671,12 @@ class TestVocabularyService:
         assert result.example_phrase is None
         assert result.extra_info == "en-word, noun, base form: äpple"
 
+        service.llm_client.improve_vocabulary_item.assert_called_once()
+        prompt_arg = service.llm_client.improve_vocabulary_item.call_args[0][0]
+        assert '"translation"' in prompt_arg
+        assert '"example_phrase"' in prompt_arg
+        assert '"extra_info"' in prompt_arg
+
     async def test_enrich_vocabulary_items_success(self, service):
         """Test successful vocabulary items batch enrichment."""
         # Mock LLM client to return batch response

--- a/tests/services/test_services_vocabulary_service.py
+++ b/tests/services/test_services_vocabulary_service.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from langchain_core.messages import AIMessage
 from sqlalchemy import func, select
 
 from runestone.api.schemas import ImprovementMode
@@ -54,12 +55,11 @@ class TestVocabularyService:
         """Create a VocabularyService instance."""
         mock_settings = Mock(spec=Settings)
         mock_settings.llm_provider = "openai"
-        mock_llm_client = AsyncMock()
-        # Set default mock response for LLM client to avoid TypeError
-        mock_llm_client.improve_vocabulary_item.return_value = (
-            '{"translation": "mock translation", "example_phrase": "mock example", "extra_info": "mock info"}'
+        mock_llm_model = AsyncMock()
+        mock_llm_model.ainvoke.return_value = AIMessage(
+            content='{"translation": "mock translation", "example_phrase": "mock example", "extra_info": "mock info"}'
         )
-        return VocabularyService(vocabulary_repository, mock_settings, mock_llm_client)
+        return VocabularyService(vocabulary_repository, mock_settings, mock_llm_model)
 
     async def test_save_vocabulary_new(self, service, db_session):
         """Test saving new vocabulary items."""
@@ -571,8 +571,8 @@ class TestVocabularyService:
     async def test_improve_item_success(self, service):
         """Test successful vocabulary item improvement with ALL_FIELDS mode."""
         # Mock LLM client from the service fixture
-        service.llm_client.improve_vocabulary_item.return_value = (
-            '{"translation": "an apple", "example_phrase": "Jag äter ett äpple varje dag.", '
+        service.llm_model.ainvoke.return_value = AIMessage(
+            content='{"translation": "an apple", "example_phrase": "Jag äter ett äpple varje dag.", '
             '"extra_info": "en-word, noun"}'
         )
 
@@ -588,14 +588,16 @@ class TestVocabularyService:
         assert result.extra_info == "en-word, noun"
 
         # Verify LLM client was called correctly
-        service.llm_client.improve_vocabulary_item.assert_called_once()
-        prompt_arg = service.llm_client.improve_vocabulary_item.call_args[0][0]
+        service.llm_model.ainvoke.assert_called_once()
+        prompt_arg = service.llm_model.ainvoke.call_args[0][0]
         assert "ett äpple" in prompt_arg
 
     async def test_improve_item_without_translation(self, service):
         """Test vocabulary improvement with EXAMPLE_ONLY mode."""
         # Mock LLM client from the service fixture
-        service.llm_client.improve_vocabulary_item.return_value = '{"example_phrase": "Jag äter ett äpple varje dag."}'
+        service.llm_model.ainvoke.return_value = AIMessage(
+            content='{"example_phrase": "Jag äter ett äpple varje dag."}'
+        )
 
         # Test request with EXAMPLE_ONLY mode
         request = VocabularyImproveRequest(word_phrase="ett äpple", mode=ImprovementMode.EXAMPLE_ONLY)
@@ -612,8 +614,8 @@ class TestVocabularyService:
         """Test vocabulary improvement with malformed LLM response that gets parsed gracefully."""
 
         # Mock LLM client from the service fixture
-        service.llm_client.improve_vocabulary_item.return_value = (
-            'translation: "clear", example_phrase: "Det är tydliga instruktioner.", extra_info: "adjective"'
+        service.llm_model.ainvoke.return_value = AIMessage(
+            content='translation: "clear", example_phrase: "Det är tydliga instruktioner.", extra_info: "adjective"'
         )
 
         # Test request with ALL_FIELDS mode
@@ -633,8 +635,8 @@ class TestVocabularyService:
     async def test_improve_item_with_extra_info(self, service):
         """Test vocabulary improvement with ALL_FIELDS mode including extra_info."""
         # Mock LLM client from the service fixture
-        service.llm_client.improve_vocabulary_item.return_value = (
-            '{"translation": "an apple", "example_phrase": "Jag äter ett äpple varje dag.", '
+        service.llm_model.ainvoke.return_value = AIMessage(
+            content='{"translation": "an apple", "example_phrase": "Jag äter ett äpple varje dag.", '
             '"extra_info": "en-word, noun, base form: äpple"}'
         )
 
@@ -650,15 +652,15 @@ class TestVocabularyService:
         assert result.extra_info == "en-word, noun, base form: äpple"
 
         # Verify LLM client was called correctly
-        service.llm_client.improve_vocabulary_item.assert_called_once()
-        prompt_arg = service.llm_client.improve_vocabulary_item.call_args[0][0]
+        service.llm_model.ainvoke.assert_called_once()
+        prompt_arg = service.llm_model.ainvoke.call_args[0][0]
         assert "ett äpple" in prompt_arg
         assert "extra_info" in prompt_arg
 
     async def test_improve_item_extra_info_only(self, service):
         """Test vocabulary improvement with EXTRA_INFO_ONLY mode."""
         # Mock LLM client from the service fixture
-        service.llm_client.improve_vocabulary_item.return_value = '{"extra_info": "en-word, noun, base form: äpple"}'
+        service.llm_model.ainvoke.return_value = AIMessage(content='{"extra_info": "en-word, noun, base form: äpple"}')
 
         # Test request with EXTRA_INFO_ONLY mode
         request = VocabularyImproveRequest(word_phrase="ett äpple", mode=ImprovementMode.EXTRA_INFO_ONLY)
@@ -671,8 +673,8 @@ class TestVocabularyService:
         assert result.example_phrase is None
         assert result.extra_info == "en-word, noun, base form: äpple"
 
-        service.llm_client.improve_vocabulary_item.assert_called_once()
-        prompt_arg = service.llm_client.improve_vocabulary_item.call_args[0][0]
+        service.llm_model.ainvoke.assert_called_once()
+        prompt_arg = service.llm_model.ainvoke.call_args[0][0]
         assert '"translation"' in prompt_arg
         assert '"example_phrase"' in prompt_arg
         assert '"extra_info"' in prompt_arg
@@ -680,13 +682,15 @@ class TestVocabularyService:
     async def test_enrich_vocabulary_items_success(self, service):
         """Test successful vocabulary items batch enrichment."""
         # Mock LLM client to return batch response
-        service.llm_client.improve_vocabulary_batch.return_value = """
+        service.llm_model.ainvoke.return_value = AIMessage(
+            content="""
         {
             "ett äpple": "en-word, noun, base form: äpple",
             "en banan": "en-word, noun",
             "vara": "verb, forms: vara, är, var, varit"
         }
         """
+        )
 
         # Test items
         items = [
@@ -707,7 +711,7 @@ class TestVocabularyService:
     async def test_enrich_vocabulary_items_llm_exception(self, service):
         """Test vocabulary items enrichment when LLM raises exception."""
         # Mock LLM to raise exception
-        service.llm_client.improve_vocabulary_batch.side_effect = Exception("LLM error")
+        service.llm_model.ainvoke.side_effect = Exception("LLM error")
 
         items = [
             VocabularyItemCreate(word_phrase="ett äpple", translation="an apple", example_phrase="Jag äter ett äpple."),
@@ -722,7 +726,7 @@ class TestVocabularyService:
     async def test_save_vocabulary_items_with_enrichment(self, service, db_session):
         """Test saving vocabulary items with enrichment enabled."""
         # Mock LLM client
-        service.llm_client.improve_vocabulary_batch.return_value = '{"ett äpple": "en-word, noun"}'
+        service.llm_model.ainvoke.return_value = AIMessage(content='{"ett äpple": "en-word, noun"}')
 
         items = [
             VocabularyItemCreate(word_phrase="ett äpple", translation="an apple", example_phrase="Jag äter ett äpple.")
@@ -751,18 +755,20 @@ class TestVocabularyService:
 
         # Verify item was not enriched - result is a dict with message
         assert result == {"message": "Vocabulary saved successfully"}
-        service.llm_client.improve_vocabulary_batch.assert_not_called()
+        service.llm_model.ainvoke.assert_not_called()
 
     async def test_enrich_vocabulary_items_partial_failure(self, service):
         """Test vocabulary items batch enrichment with partial failures."""
         # Mock LLM with some null values
-        service.llm_client.improve_vocabulary_batch.return_value = """
+        service.llm_model.ainvoke.return_value = AIMessage(
+            content="""
         {
             "ett äpple": "en-word, noun, base form: äpple",
             "en banan": null,
             "vara": "verb, forms: vara, är, var, varit"
         }
         """
+        )
 
         items = [
             VocabularyItemCreate(word_phrase="ett äpple", translation="an apple", example_phrase="Jag äter ett äpple."),
@@ -798,30 +804,32 @@ class TestVocabularyService:
                 # Second batch (100-149)
                 return "{" + ",".join(f'"word_{i}": "info_{i}"' for i in range(100, 150)) + "}"
 
-        service.llm_client.improve_vocabulary_batch.side_effect = mock_batch_response
+        service.llm_model.ainvoke.side_effect = lambda prompt: AIMessage(content=mock_batch_response(prompt))
 
         enriched_items = await service._enrich_vocabulary_items(items)
 
         # Verify all 150 items enriched across 2 batches
         assert len(enriched_items) == 150
         assert all(item.extra_info for item in enriched_items)
-        assert service.llm_client.improve_vocabulary_batch.call_count == 2
+        assert service.llm_model.ainvoke.call_count == 2
 
     async def test_enrich_vocabulary_items_empty_list(self, service):
         """Test vocabulary items enrichment with empty list."""
         enriched_items = await service._enrich_vocabulary_items([])
 
         assert enriched_items == []
-        service.llm_client.improve_vocabulary_batch.assert_not_called()
+        service.llm_model.ainvoke.assert_not_called()
 
     async def test_save_vocabulary_with_batch_enrichment(self, service, db_session):
         """Test save_vocabulary using batch enrichment."""
         # Mock batch enrichment
-        service.llm_client.improve_vocabulary_batch.return_value = """
+        service.llm_model.ainvoke.return_value = AIMessage(
+            content="""
         {
             "ett äpple": "en-word, noun, base form: äpple"
         }
         """
+        )
 
         items = [
             VocabularyItemCreate(word_phrase="ett äpple", translation="an apple", example_phrase="Jag äter ett äpple.")
@@ -837,7 +845,7 @@ class TestVocabularyService:
         vocab = await db_session.scalar(select(VocabularyModel).where(VocabularyModel.word_phrase == "ett äpple"))
         assert vocab is not None
         assert vocab.extra_info == "en-word, noun, base form: äpple"
-        service.llm_client.improve_vocabulary_item.assert_not_called()
+        service.llm_model.ainvoke.assert_called_once()
 
     async def test_get_existing_word_phrases(self, service, db_session):
         """Test retrieving existing word phrases."""
@@ -1284,9 +1292,9 @@ class TestVocabularyService:
         """Concurrent upserts for same word should not surface integrity errors or duplicate rows."""
         mock_settings = Mock(spec=Settings)
         mock_settings.llm_provider = "openai"
-        mock_llm_client = AsyncMock()
-        mock_llm_client.improve_vocabulary_item.return_value = (
-            '{"translation": "mock translation", "example_phrase": "mock example", "extra_info": "mock info"}'
+        mock_llm_model = AsyncMock()
+        mock_llm_model.ainvoke.return_value = AIMessage(
+            content='{"translation": "mock translation", "example_phrase": "mock example", "extra_info": "mock info"}'
         )
         async with db_session_factory() as setup_db:
             race_user = UserModel(
@@ -1303,8 +1311,8 @@ class TestVocabularyService:
             race_user_id = race_user.id
 
         async with db_session_factory() as db1, db_session_factory() as db2:
-            service1 = VocabularyService(VocabularyRepository(db1), mock_settings, mock_llm_client)
-            service2 = VocabularyService(VocabularyRepository(db2), mock_settings, mock_llm_client)
+            service1 = VocabularyService(VocabularyRepository(db1), mock_settings, mock_llm_model)
+            service2 = VocabularyService(VocabularyRepository(db2), mock_settings, mock_llm_model)
 
             result1, result2 = await asyncio.gather(
                 service1.insert_or_prioritize_words(


### PR DESCRIPTION
## Summary
- make vocabulary improvement prompt building use one shared rich prompt for all modes
- keep mode-specific behavior in response filtering so `EXAMPLE_ONLY` and `EXTRA_INFO_ONLY` still return only their requested fields
- simplify prompt-builder tests to reflect the new shared-prompt contract

## Why
The Vocabulary modal's "Fill Extra Info" path produced poorer extra info than "Fill All" because `EXTRA_INFO_ONLY` used a weaker prompt shape. This change makes the extra-info path use the same rich prompt context as the full-flow path.

## Validation
- make backend-test
- make backend-lint
- independent `gpt-5.5` code review: approved