### PR TITLE
[codex] Support LangChain ainvoke responses in vocabulary service

### DIFF
--- a/src/runestone/services/vocabulary_service.py
+++ b/src/runestone/services/vocabulary_service.py
@@ -1,11 +1,13 @@
 """
 Service layer for vocabulary operations.
 
-This module contains service classes that handle business logic
-for vocabulary-related operations.
+This module contains service classes that handle vocabulary business logic and
+normalize the LLM response shape used by enrichment workflows.
 """
 
 from typing import List
+
+from langchain_core.messages import BaseMessage
 
 from ..api.schemas import Vocabulary as VocabularySchema
 from ..api.schemas import (
@@ -37,6 +39,7 @@ class VocabularyService:
         self.repo = vocabulary_repository
         self.settings = settings
         self.llm_client = llm_client
+        self.llm_model = llm_client
         self.logger = get_logger(__name__)
 
         # Initialize prompt builder and parser
@@ -210,7 +213,7 @@ class VocabularyService:
         prompt = self.builder.build_vocabulary_prompt(word_phrase=request.word_phrase, mode=request.mode)
 
         # Get improvement from LLM (async call)
-        response_text = await self.llm_client.improve_vocabulary_item(prompt)
+        response_text = await self._invoke_vocabulary_item(prompt)
 
         # Parse response using ResponseParser (includes automatic fallback)
         try:
@@ -260,7 +263,7 @@ class VocabularyService:
                 prompt = self.builder.build_vocabulary_batch_prompt(word_phrases)
 
                 # Get batch improvements from LLM (async call)
-                response_text = await self.llm_client.improve_vocabulary_batch(prompt)
+                response_text = await self._invoke_vocabulary_batch(prompt)
 
                 # Parse batch response
                 enrichments = self.parser.parse_vocabulary_batch_response(response_text)
@@ -312,6 +315,27 @@ class VocabularyService:
         )
 
         return enriched_items
+
+    async def _invoke_vocabulary_item(self, prompt: str) -> str:
+        """Return single-item vocabulary output from either supported LLM interface."""
+        if hasattr(self.llm_model, "ainvoke"):
+            response = await self.llm_model.ainvoke(prompt)
+            return self._extract_message_text(response)
+        return await self.llm_client.improve_vocabulary_item(prompt)
+
+    async def _invoke_vocabulary_batch(self, prompt: str) -> str:
+        """Return batch vocabulary output from either supported LLM interface."""
+        if hasattr(self.llm_model, "ainvoke"):
+            response = await self.llm_model.ainvoke(prompt)
+            return self._extract_message_text(response)
+        return await self.llm_client.improve_vocabulary_batch(prompt)
+
+    @staticmethod
+    def _extract_message_text(response: str | BaseMessage) -> str:
+        """Normalize LLM responses into plain text before parsing."""
+        if isinstance(response, BaseMessage):
+            return response.text
+        return response
 
     async def get_existing_word_phrases(self, word_phrases: List[str], user_id: int) -> List[str]:
         """Get existing word phrases from the repository."""

--- a/tests/services/test_services_vocabulary_service.py
+++ b/tests/services/test_services_vocabulary_service.py
@@ -592,6 +592,22 @@ class TestVocabularyService:
         prompt_arg = service.llm_model.ainvoke.call_args[0][0]
         assert "ett äpple" in prompt_arg
 
+    async def test_improve_item_falls_back_to_client_method(self, service):
+        """Use the legacy client helpers when the injected model lacks ainvoke."""
+        service.llm_model = object()
+        service.llm_client.improve_vocabulary_item = AsyncMock(
+            return_value='{"translation": "an apple", "example_phrase": "Jag äter ett äpple varje dag."}'
+        )
+
+        request = VocabularyImproveRequest(word_phrase="ett äpple", mode=ImprovementMode.ALL_FIELDS)
+
+        result = await service.improve_item(request)
+
+        assert isinstance(result, VocabularyImproveResponse)
+        assert result.translation == "an apple"
+        assert result.example_phrase == "Jag äter ett äpple varje dag."
+        service.llm_client.improve_vocabulary_item.assert_awaited_once()
+
     async def test_improve_item_without_translation(self, service):
         """Test vocabulary improvement with EXAMPLE_ONLY mode."""
         # Mock LLM client from the service fixture
@@ -707,6 +723,23 @@ class TestVocabularyService:
         assert enriched_items[0].extra_info == "en-word, noun, base form: äpple"
         assert enriched_items[1].extra_info == "en-word, noun"
         assert enriched_items[2].extra_info == "verb, forms: vara, är, var, varit"
+
+    async def test_enrich_vocabulary_items_fall_back_to_client_method(self, service):
+        """Use the legacy batch helper when the injected model lacks ainvoke."""
+        service.llm_model = object()
+        service.llm_client.improve_vocabulary_batch = AsyncMock(
+            return_value='{"ett äpple": "en-word, noun, base form: äpple"}'
+        )
+
+        items = [
+            VocabularyItemCreate(word_phrase="ett äpple", translation="an apple", example_phrase="Jag äter ett äpple.")
+        ]
+
+        enriched_items = await service._enrich_vocabulary_items(items)
+
+        assert len(enriched_items) == 1
+        assert enriched_items[0].extra_info == "en-word, noun, base form: äpple"
+        service.llm_client.improve_vocabulary_batch.assert_awaited_once()
 
     async def test_enrich_vocabulary_items_llm_exception(self, service):
         """Test vocabulary items enrichment when LLM raises exception."""


### PR DESCRIPTION
## Summary
- normalize `BaseMessage` responses returned by LangChain `ainvoke()` before parsing vocabulary enrichments
- keep compatibility with legacy `improve_vocabulary_item` and `improve_vocabulary_batch` helpers
- add regression coverage for both invocation paths

## Testing
- `uv run pytest tests/services/test_services_vocabulary_service.py -v`