### PR TITLE
Fix legacy OPENAI_MODEL service config

### DIFF
--- a/src/runestone/config.py
+++ b/src/runestone/config.py
@@ -10,7 +10,7 @@ from enum import Enum
 from typing import Literal, Optional
 
 from dotenv import load_dotenv
-from pydantic import BaseModel, model_validator
+from pydantic import AliasChoices, BaseModel, Field, model_validator
 from pydantic_settings import BaseSettings
 
 DEFAULT_SERVICE_LLM_MODEL = "gpt-5.4-nano"
@@ -40,7 +40,7 @@ class Settings(BaseSettings):
 
     # LLM Provider Configuration
     llm_provider: str
-    llm_model_name: Optional[str] = None
+    llm_model_name: Optional[str] = Field(default=None, validation_alias=AliasChoices("LLM_MODEL_NAME", "OPENAI_MODEL"))
 
     # OpenAI Configuration
     openai_api_key: str

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -165,6 +165,28 @@ class TestSettings:
         assert test_settings.teacher_provider == "openai"
         assert test_settings.teacher_model == "teacher-env-model"
 
+    def test_service_llm_model_accepts_legacy_openai_model_env_name(self):
+        """OPENAI_MODEL should keep configuring the shared service model during the migration."""
+        env_vars = {
+            "LLM_PROVIDER": "openai",
+            "OPENAI_API_KEY": "test-key",
+            "OPENAI_MODEL": "gpt-4o-mini",
+            "OPENROUTER_API_KEY": "test-openrouter-key",
+            "ALLOWED_ORIGINS": "http://localhost:3000",
+            "DATABASE_URL": "sqlite:///./test.db",
+            "TELEGRAM_BOT_TOKEN": "test-token",
+            "FRONTEND_URL": "http://localhost:5173",
+            "JWT_SECRET_KEY": "secret",
+            "TEACHER_MODEL": "teacher-model",
+            "COORDINATOR_MODEL": "coordinator-model",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            test_settings = Settings()
+
+        assert test_settings.llm_model_name == "gpt-4o-mini"
+        assert test_settings.resolve_service_llm_model() == "gpt-4o-mini"
+
     def test_service_llm_resolvers_use_default_fallbacks(self):
         """Service-side resolver helpers should centralize default provider/model selection."""
         test_settings = Settings.model_construct(


### PR DESCRIPTION
## Summary
- restore `OPENAI_MODEL` as a valid env source for `Settings.llm_model_name`
- cover the regression with a focused config test

## Evidence
- commit `e08b32b` migrated service LLM config from the legacy client layer to `Settings.llm_model_name`
- repo docs and container wiring still pass `OPENAI_MODEL` (`README.md`, `docker-compose.yml`)
- before this patch, running with `OPENAI_MODEL=gpt-4o-mini` produced `settings.llm_model_name is None` and `resolve_service_llm_model() == "gpt-5.4-nano"`

## Validation
- `UV_CACHE_DIR=.uv-cache uv run --extra dev python -m pytest tests/test_config.py tests/core/test_factory.py tests/test_cli.py tests/core/test_analyzer.py tests/core/test_ocr.py tests/test_dependencies.py -q`