### PR TITLE
fix: require structured output for vocabulary improvement

### DIFF
--- a/src/runestone/services/vocabulary_service.py
+++ b/src/runestone/services/vocabulary_service.py
@@ -1,8 +1,8 @@
 """
 Service layer for vocabulary operations.
 
-This module contains service classes that handle business logic
-for vocabulary-related operations.
+This module contains service classes that handle vocabulary business logic and
+normalize the LLM response shape used by enrichment workflows.
 """
 
 from typing import List
@@ -211,13 +211,7 @@ class VocabularyService:
         # Build improvement prompt using PromptBuilder
         prompt = self.builder.build_vocabulary_prompt(word_phrase=request.word_phrase, mode=request.mode)
 
-        # Get improvement from LLM (async call)
-        self.logger.info(
-            "Improving vocabulary item with provider=%s model=%s",
-            self.settings.resolve_service_llm_provider(),
-            self.settings.resolve_service_llm_model(),
-        )
-        response_text = extract_message_text(await self.llm_model.ainvoke(prompt))
+        response_text = await self._invoke_vocabulary_item(prompt)
 
         # Parse response using ResponseParser (includes automatic fallback)
         try:
@@ -266,13 +260,7 @@ class VocabularyService:
                 # Build batch prompt
                 prompt = self.builder.build_vocabulary_batch_prompt(word_phrases)
 
-                # Get batch improvements from LLM (async call)
-                self.logger.info(
-                    "Improving vocabulary batch with provider=%s model=%s",
-                    self.settings.resolve_service_llm_provider(),
-                    self.settings.resolve_service_llm_model(),
-                )
-                response_text = extract_message_text(await self.llm_model.ainvoke(prompt))
+                response_text = await self._invoke_vocabulary_batch(prompt)
 
                 # Parse batch response
                 enrichments = self.parser.parse_vocabulary_batch_response(response_text)
@@ -324,6 +312,16 @@ class VocabularyService:
         )
 
         return enriched_items
+
+    async def _invoke_vocabulary_item(self, prompt: str) -> str:
+        """Return single-item vocabulary output."""
+        response = await self.llm_model.ainvoke(prompt)
+        return extract_message_text(response)
+
+    async def _invoke_vocabulary_batch(self, prompt: str) -> str:
+        """Return batch vocabulary output."""
+        response = await self.llm_model.ainvoke(prompt)
+        return extract_message_text(response)
 
     async def get_existing_word_phrases(self, word_phrases: List[str], user_id: int) -> List[str]:
         """Get existing word phrases from the repository."""

--- a/src/runestone/services/vocabulary_service.py
+++ b/src/runestone/services/vocabulary_service.py
@@ -7,8 +7,8 @@ normalize the LLM response shape used by enrichment workflows.
 
 from typing import List
 
-from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.exceptions import OutputParserException
+from langchain_core.language_models.chat_models import BaseChatModel
 
 from ..api.schemas import ImprovementMode
 from ..api.schemas import Vocabulary as VocabularySchema
@@ -36,7 +36,12 @@ class VocabularyService:
     """Service for vocabulary-related business logic."""
 
     def __init__(self, vocabulary_repository: VocabularyRepository, settings: Settings, llm_model: BaseChatModel):
-        """Initialize service with vocabulary repository, settings, and LLM model."""
+        """
+        Initialize service with vocabulary repository, settings, and LangChain chat model.
+
+        The provided model must support `with_structured_output` because
+        `improve_item` relies on schema-backed output validation.
+        """
         self.repo = vocabulary_repository
         self.settings = settings
         self.llm_model = llm_model
@@ -228,7 +233,7 @@ class VocabularyService:
             raise RuntimeError(f"Structured vocabulary response failed: {exc}") from exc
 
     @staticmethod
-    def _to_improve_response(vocab_response: VocabularyResponse, mode: str | object) -> VocabularyImproveResponse:
+    def _to_improve_response(vocab_response: VocabularyResponse, mode: ImprovementMode) -> VocabularyImproveResponse:
         """Map schema output into API response while preserving mode compatibility."""
         if mode == ImprovementMode.EXAMPLE_ONLY:
             return VocabularyImproveResponse(
@@ -333,11 +338,6 @@ class VocabularyService:
         )
 
         return enriched_items
-
-    async def _invoke_vocabulary_item(self, prompt: str) -> str:
-        """Return single-item vocabulary output."""
-        response = await self.llm_model.ainvoke(prompt)
-        return extract_message_text(response)
 
     async def _invoke_vocabulary_batch(self, prompt: str) -> str:
         """Return batch vocabulary output."""

--- a/src/runestone/services/vocabulary_service.py
+++ b/src/runestone/services/vocabulary_service.py
@@ -8,7 +8,9 @@ normalize the LLM response shape used by enrichment workflows.
 from typing import List
 
 from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.exceptions import OutputParserException
 
+from ..api.schemas import ImprovementMode
 from ..api.schemas import Vocabulary as VocabularySchema
 from ..api.schemas import (
     VocabularyImproveRequest,
@@ -22,7 +24,6 @@ from ..core.constants import VOCABULARY_BATCH_SIZE
 from ..core.exceptions import VocabularyItemExists
 from ..core.logging_config import get_logger
 from ..core.prompt_builder.builder import PromptBuilder
-from ..core.prompt_builder.exceptions import ResponseParseError
 from ..core.prompt_builder.parsers import ResponseParser
 from ..core.service_llm import extract_message_text
 from ..db.models import Vocabulary
@@ -210,22 +211,42 @@ class VocabularyService:
         """Improve a vocabulary item using LLM to generate translation, example phrase, and extra info."""
         # Build improvement prompt using PromptBuilder
         prompt = self.builder.build_vocabulary_prompt(word_phrase=request.word_phrase, mode=request.mode)
+        structured_response = await self._invoke_vocabulary_item_structured(prompt)
+        return self._to_improve_response(structured_response, request.mode)
 
-        response_text = await self._invoke_vocabulary_item(prompt)
-
-        # Parse response using ResponseParser (includes automatic fallback)
+    async def _invoke_vocabulary_item_structured(self, prompt: str) -> VocabularyResponse:
+        """Return schema-backed vocabulary improvement via LangChain structured output."""
         try:
-            vocab_response: VocabularyResponse = self.parser.parse_vocabulary_response(response_text, request.mode)
+            structured_model = self.llm_model.with_structured_output(VocabularyResponse)
+            response = await structured_model.ainvoke(prompt)
+            if isinstance(response, VocabularyResponse):
+                return response
+            return VocabularyResponse.model_validate(response)
+        except OutputParserException as exc:
+            raise ValueError(f"Structured vocabulary response validation failed: {exc}") from exc
+        except Exception as exc:
+            raise RuntimeError(f"Structured vocabulary response failed: {exc}") from exc
 
+    @staticmethod
+    def _to_improve_response(vocab_response: VocabularyResponse, mode: str | object) -> VocabularyImproveResponse:
+        """Map schema output into API response while preserving mode compatibility."""
+        if mode == ImprovementMode.EXAMPLE_ONLY:
             return VocabularyImproveResponse(
-                translation=vocab_response.translation,
+                translation=None,
                 example_phrase=vocab_response.example_phrase,
+                extra_info=None,
+            )
+        if mode == ImprovementMode.EXTRA_INFO_ONLY:
+            return VocabularyImproveResponse(
+                translation=None,
+                example_phrase=None,
                 extra_info=vocab_response.extra_info,
             )
-        except ResponseParseError as e:
-            self.logger.error(f"Failed to parse vocabulary response: {e}")
-            # Return empty response as fallback
-            return VocabularyImproveResponse(translation=None, example_phrase="", extra_info=None)
+        return VocabularyImproveResponse(
+            translation=vocab_response.translation,
+            example_phrase=vocab_response.example_phrase,
+            extra_info=vocab_response.extra_info,
+        )
 
     async def _enrich_vocabulary_items(self, items: List[VocabularyItemCreate]) -> List[VocabularyItemCreate]:
         """

--- a/tests/services/test_services_vocabulary_service.py
+++ b/tests/services/test_services_vocabulary_service.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from langchain_core.exceptions import OutputParserException
 from langchain_core.messages import AIMessage
 from sqlalchemy import func, select
 
@@ -20,6 +21,7 @@ from runestone.core.exceptions import VocabularyItemExists
 from runestone.db.models import User as UserModel
 from runestone.db.models import Vocabulary as VocabularyModel
 from runestone.db.vocabulary_repository import VocabularyRepository
+from runestone.schemas.vocabulary import VocabularyResponse
 from runestone.schemas.vocabulary_save import PriorityWordSaveItem, WordSaveCandidate
 from runestone.services.vocabulary_service import VocabularyService
 
@@ -570,11 +572,13 @@ class TestVocabularyService:
 
     async def test_improve_item_success(self, service):
         """Test successful vocabulary item improvement with ALL_FIELDS mode."""
-        # Mock LLM client from the service fixture
-        service.llm_model.ainvoke.return_value = AIMessage(
-            content='{"translation": "an apple", "example_phrase": "Jag äter ett äpple varje dag.", '
-            '"extra_info": "en-word, noun"}'
+        structured_model = AsyncMock()
+        structured_model.ainvoke.return_value = VocabularyResponse(
+            translation="an apple",
+            example_phrase="Jag äter ett äpple varje dag.",
+            extra_info="en-word, noun",
         )
+        service.llm_model.with_structured_output = Mock(return_value=structured_model)
 
         # Test request with ALL_FIELDS mode
         request = VocabularyImproveRequest(word_phrase="ett äpple", mode=ImprovementMode.ALL_FIELDS)
@@ -588,16 +592,19 @@ class TestVocabularyService:
         assert result.extra_info == "en-word, noun"
 
         # Verify LLM client was called correctly
-        service.llm_model.ainvoke.assert_called_once()
-        prompt_arg = service.llm_model.ainvoke.call_args[0][0]
+        structured_model.ainvoke.assert_awaited_once()
+        prompt_arg = structured_model.ainvoke.call_args[0][0]
         assert "ett äpple" in prompt_arg
 
-    async def test_improve_item_falls_back_to_client_method(self, service):
-        """Use the legacy client helpers when the injected model lacks ainvoke."""
-        service.llm_model = object()
-        service.llm_client.improve_vocabulary_item = AsyncMock(
-            return_value='{"translation": "an apple", "example_phrase": "Jag äter ett äpple varje dag."}'
+    async def test_improve_item_uses_structured_output_when_available(self, service):
+        """Prefer LangChain schema output over legacy text parsing when supported."""
+        structured_model = AsyncMock()
+        structured_model.ainvoke.return_value = VocabularyResponse(
+            translation="an apple",
+            example_phrase="Jag äter ett äpple varje dag.",
+            extra_info="en-word, noun",
         )
+        service.llm_model.with_structured_output = Mock(return_value=structured_model)
 
         request = VocabularyImproveRequest(word_phrase="ett äpple", mode=ImprovementMode.ALL_FIELDS)
 
@@ -606,14 +613,59 @@ class TestVocabularyService:
         assert isinstance(result, VocabularyImproveResponse)
         assert result.translation == "an apple"
         assert result.example_phrase == "Jag äter ett äpple varje dag."
-        service.llm_client.improve_vocabulary_item.assert_awaited_once()
+        assert result.extra_info == "en-word, noun"
+        service.llm_model.with_structured_output.assert_called_once()
+        structured_model.ainvoke.assert_awaited_once()
+        service.llm_model.ainvoke.assert_not_called()
+
+    async def test_improve_item_structured_output_respects_mode_compatibility(self, service):
+        """Structured output should preserve existing mode-specific response fields."""
+        structured_model = AsyncMock()
+        structured_model.ainvoke.return_value = VocabularyResponse(
+            translation="an apple",
+            example_phrase="Jag äter ett äpple varje dag.",
+            extra_info="en-word, noun",
+        )
+        service.llm_model.with_structured_output = Mock(return_value=structured_model)
+
+        request = VocabularyImproveRequest(word_phrase="ett äpple", mode=ImprovementMode.EXTRA_INFO_ONLY)
+
+        result = await service.improve_item(request)
+
+        assert isinstance(result, VocabularyImproveResponse)
+        assert result.translation is None
+        assert result.example_phrase is None
+        assert result.extra_info == "en-word, noun"
+
+    async def test_improve_item_without_structured_output_support_fails(self, service):
+        """Fail when the configured model lacks structured output support."""
+        service.llm_model = object()
+
+        request = VocabularyImproveRequest(word_phrase="ett äpple", mode=ImprovementMode.ALL_FIELDS)
+
+        with pytest.raises(RuntimeError, match="Structured vocabulary response failed"):
+            await service.improve_item(request)
+
+    async def test_improve_item_structured_output_parser_failure_is_signaled(self, service):
+        """Propagate schema parsing failures instead of silently falling back."""
+        structured_model = AsyncMock()
+        structured_model.ainvoke.side_effect = OutputParserException("bad schema output")
+        service.llm_model.with_structured_output = Mock(return_value=structured_model)
+
+        request = VocabularyImproveRequest(word_phrase="ett äpple", mode=ImprovementMode.ALL_FIELDS)
+
+        with pytest.raises(ValueError, match="Structured vocabulary response validation failed"):
+            await service.improve_item(request)
 
     async def test_improve_item_without_translation(self, service):
         """Test vocabulary improvement with EXAMPLE_ONLY mode."""
-        # Mock LLM client from the service fixture
-        service.llm_model.ainvoke.return_value = AIMessage(
-            content='{"example_phrase": "Jag äter ett äpple varje dag."}'
+        structured_model = AsyncMock()
+        structured_model.ainvoke.return_value = VocabularyResponse(
+            translation="an apple",
+            example_phrase="Jag äter ett äpple varje dag.",
+            extra_info="en-word, noun",
         )
+        service.llm_model.with_structured_output = Mock(return_value=structured_model)
 
         # Test request with EXAMPLE_ONLY mode
         request = VocabularyImproveRequest(word_phrase="ett äpple", mode=ImprovementMode.EXAMPLE_ONLY)
@@ -627,34 +679,35 @@ class TestVocabularyService:
         assert result.extra_info is None
 
     async def test_improve_item_malformed_response_handling(self, service):
-        """Test vocabulary improvement with malformed LLM response that gets parsed gracefully."""
-
-        # Mock LLM client from the service fixture
-        service.llm_model.ainvoke.return_value = AIMessage(
-            content='translation: "clear", example_phrase: "Det är tydliga instruktioner.", extra_info: "adjective"'
+        """Test vocabulary improvement with structured schema output."""
+        structured_model = AsyncMock()
+        structured_model.ainvoke.return_value = VocabularyResponse(
+            translation="clear",
+            example_phrase="Det är tydliga instruktioner.",
+            extra_info="adjective",
         )
+        service.llm_model.with_structured_output = Mock(return_value=structured_model)
 
         # Test request with ALL_FIELDS mode
         request = VocabularyImproveRequest(word_phrase="tydliga", mode=ImprovementMode.ALL_FIELDS)
 
         result = await service.improve_item(request)
 
-        # Should handle malformed response gracefully and extract what it can
+        # Structured output should map directly
         assert isinstance(result, VocabularyImproveResponse)
-        # The parser should extract "clear" from the translation field
         assert result.translation == "clear"
-        # The parser should extract the example phrase from the example_phrase field
         assert result.example_phrase == "Det är tydliga instruktioner."
-        # The parser should extract extra_info
         assert result.extra_info == "adjective"
 
     async def test_improve_item_with_extra_info(self, service):
         """Test vocabulary improvement with ALL_FIELDS mode including extra_info."""
-        # Mock LLM client from the service fixture
-        service.llm_model.ainvoke.return_value = AIMessage(
-            content='{"translation": "an apple", "example_phrase": "Jag äter ett äpple varje dag.", '
-            '"extra_info": "en-word, noun, base form: äpple"}'
+        structured_model = AsyncMock()
+        structured_model.ainvoke.return_value = VocabularyResponse(
+            translation="an apple",
+            example_phrase="Jag äter ett äpple varje dag.",
+            extra_info="en-word, noun, base form: äpple",
         )
+        service.llm_model.with_structured_output = Mock(return_value=structured_model)
 
         # Test request with ALL_FIELDS mode
         request = VocabularyImproveRequest(word_phrase="ett äpple", mode=ImprovementMode.ALL_FIELDS)
@@ -667,16 +720,20 @@ class TestVocabularyService:
         assert result.example_phrase == "Jag äter ett äpple varje dag."
         assert result.extra_info == "en-word, noun, base form: äpple"
 
-        # Verify LLM client was called correctly
-        service.llm_model.ainvoke.assert_called_once()
-        prompt_arg = service.llm_model.ainvoke.call_args[0][0]
+        service.llm_model.with_structured_output.assert_called_once()
+        prompt_arg = structured_model.ainvoke.call_args[0][0]
         assert "ett äpple" in prompt_arg
         assert "extra_info" in prompt_arg
 
     async def test_improve_item_extra_info_only(self, service):
         """Test vocabulary improvement with EXTRA_INFO_ONLY mode."""
-        # Mock LLM client from the service fixture
-        service.llm_model.ainvoke.return_value = AIMessage(content='{"extra_info": "en-word, noun, base form: äpple"}')
+        structured_model = AsyncMock()
+        structured_model.ainvoke.return_value = VocabularyResponse(
+            translation="an apple",
+            example_phrase="Jag äter ett äpple varje dag.",
+            extra_info="en-word, noun, base form: äpple",
+        )
+        service.llm_model.with_structured_output = Mock(return_value=structured_model)
 
         # Test request with EXTRA_INFO_ONLY mode
         request = VocabularyImproveRequest(word_phrase="ett äpple", mode=ImprovementMode.EXTRA_INFO_ONLY)
@@ -689,11 +746,7 @@ class TestVocabularyService:
         assert result.example_phrase is None
         assert result.extra_info == "en-word, noun, base form: äpple"
 
-        service.llm_model.ainvoke.assert_called_once()
-        prompt_arg = service.llm_model.ainvoke.call_args[0][0]
-        assert '"translation"' in prompt_arg
-        assert '"example_phrase"' in prompt_arg
-        assert '"extra_info"' in prompt_arg
+        structured_model.ainvoke.assert_awaited_once()
 
     async def test_enrich_vocabulary_items_success(self, service):
         """Test successful vocabulary items batch enrichment."""

--- a/tests/services/test_services_vocabulary_service.py
+++ b/tests/services/test_services_vocabulary_service.py
@@ -592,6 +592,22 @@ class TestVocabularyService:
         prompt_arg = service.llm_model.ainvoke.call_args[0][0]
         assert "ett äpple" in prompt_arg
 
+    async def test_improve_item_falls_back_to_client_method(self, service):
+        """Use the legacy client helpers when the injected model lacks ainvoke."""
+        service.llm_model = object()
+        service.llm_client.improve_vocabulary_item = AsyncMock(
+            return_value='{"translation": "an apple", "example_phrase": "Jag äter ett äpple varje dag."}'
+        )
+
+        request = VocabularyImproveRequest(word_phrase="ett äpple", mode=ImprovementMode.ALL_FIELDS)
+
+        result = await service.improve_item(request)
+
+        assert isinstance(result, VocabularyImproveResponse)
+        assert result.translation == "an apple"
+        assert result.example_phrase == "Jag äter ett äpple varje dag."
+        service.llm_client.improve_vocabulary_item.assert_awaited_once()
+
     async def test_improve_item_without_translation(self, service):
         """Test vocabulary improvement with EXAMPLE_ONLY mode."""
         # Mock LLM client from the service fixture
@@ -707,6 +723,23 @@ class TestVocabularyService:
         assert enriched_items[0].extra_info == "en-word, noun, base form: äpple"
         assert enriched_items[1].extra_info == "en-word, noun"
         assert enriched_items[2].extra_info == "verb, forms: vara, är, var, varit"
+
+    async def test_enrich_vocabulary_items_fall_back_to_client_method(self, service):
+        """Use the legacy batch helper when the injected model lacks ainvoke."""
+        service.llm_model = object()
+        service.llm_client.improve_vocabulary_batch = AsyncMock(
+            return_value='{"ett äpple": "en-word, noun, base form: äpple"}'
+        )
+
+        items = [
+            VocabularyItemCreate(word_phrase="ett äpple", translation="an apple", example_phrase="Jag äter ett äpple.")
+        ]
+
+        enriched_items = await service._enrich_vocabulary_items(items)
+
+        assert len(enriched_items) == 1
+        assert enriched_items[0].extra_info == "en-word, noun, base form: äpple"
+        service.llm_client.improve_vocabulary_batch.assert_awaited_once()
 
     async def test_enrich_vocabulary_items_llm_exception(self, service):
         """Test vocabulary items enrichment when LLM raises exception."""


### PR DESCRIPTION
## Summary
- switch `VocabularyService.improve_item` to use LangChain `with_structured_output(VocabularyResponse)` directly
- remove fallback parsing path and surface structured output failures explicitly
- keep mode-compatible response mapping for `EXAMPLE_ONLY`, `EXTRA_INFO_ONLY`, and `ALL_FIELDS`
- update improve-item service tests to cover strict structured-output behavior

## Validation
- `uv run pytest tests/services/test_services_vocabulary_service.py -k "improve_item" -v`
