### PR TITLE
Add structured output to content analysis flow

### DIFF
--- a/src/runestone/core/analyzer.py
+++ b/src/runestone/core/analyzer.py
@@ -72,8 +72,8 @@ class ContentAnalyzer:
                 method="json_schema",
             )
             response = await structured_model.ainvoke(analysis_prompt)
-            if isinstance(response, ContentAnalysis):
-                return response
+            if response is None:
+                raise ContentAnalysisError("No analysis returned from LLM")
             return ContentAnalysis.model_validate(response)
 
         except ContentAnalysisError:

--- a/src/runestone/core/analyzer.py
+++ b/src/runestone/core/analyzer.py
@@ -7,15 +7,13 @@ grammar rules, vocabulary, and generate learning resources.
 
 from typing import Optional
 
+from langchain_core.exceptions import OutputParserException
 from langchain_core.language_models.chat_models import BaseChatModel
 
 from runestone.config import Settings
 from runestone.core.exceptions import ContentAnalysisError
 from runestone.core.logging_config import get_logger
 from runestone.core.prompt_builder.builder import PromptBuilder
-from runestone.core.prompt_builder.exceptions import ResponseParseError
-from runestone.core.prompt_builder.parsers import ResponseParser
-from runestone.core.service_llm import extract_message_text
 from runestone.schemas.analysis import ContentAnalysis
 
 
@@ -33,7 +31,8 @@ class ContentAnalyzer:
 
         Args:
             settings: Centralized application settings
-            model: LangChain chat model for processing
+            model: LangChain chat model for processing. It must support
+                `with_structured_output(ContentAnalysis)`.
             verbose: Enable verbose logging. If None, uses settings.verbose
         """
         # Use provided settings or create default
@@ -43,9 +42,8 @@ class ContentAnalyzer:
 
         self.model = model
 
-        # Initialize prompt builder and parser
+        # Initialize prompt builder
         self.builder = PromptBuilder()
-        self.parser = ResponseParser()
 
     async def analyze_content(self, extracted_text: str) -> ContentAnalysis:
         """
@@ -55,7 +53,7 @@ class ContentAnalyzer:
             extracted_text: Raw text extracted from the textbook page
 
         Returns:
-            AnalysisResponse object containing analyzed content with grammar, vocabulary, and resources
+            ContentAnalysis object containing analyzed content with grammar, vocabulary, and resources
 
         Raises:
             ContentAnalysisError: If content analysis fails
@@ -69,23 +67,18 @@ class ContentAnalyzer:
                 self.settings.resolve_service_llm_provider(),
                 self.settings.resolve_service_llm_model(),
             )
-            response_text = extract_message_text(await self.model.ainvoke(analysis_prompt))
-
-            if not response_text:
-                raise ContentAnalysisError("No analysis returned from LLM")
-
-            # Log the raw response for debugging
-            self.logger.debug(f"[ContentAnalyzer] Raw LLM response (first 500 chars): {response_text[:500]}")
-
-            # Parse response using ResponseParser (includes automatic fallback)
-            try:
-                analysis_response = self.parser.parse_analysis_response(response_text)
-                return analysis_response
-            except ResponseParseError as e:
-                self.logger.warning(f"[ContentAnalyzer] Response parsing failed: {e}")
-                raise ContentAnalysisError(f"Failed to parse analysis response: {str(e)}")
+            structured_model = self.model.with_structured_output(
+                ContentAnalysis,
+                method="json_schema",
+            )
+            response = await structured_model.ainvoke(analysis_prompt)
+            if isinstance(response, ContentAnalysis):
+                return response
+            return ContentAnalysis.model_validate(response)
 
         except ContentAnalysisError:
             raise
+        except OutputParserException as e:
+            raise ContentAnalysisError(f"Structured content analysis validation failed: {str(e)}") from e
         except Exception as e:
             raise ContentAnalysisError(f"Content analysis failed: {str(e)}")

--- a/tests/core/test_analyzer.py
+++ b/tests/core/test_analyzer.py
@@ -1,12 +1,9 @@
-"""
-Tests for the content analysis module.
-"""
+"""Tests for the content analysis module."""
 
-import json
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-from langchain_core.messages import AIMessage
+from langchain_core.exceptions import OutputParserException
 
 from runestone.config import Settings
 from runestone.core.analyzer import ContentAnalyzer
@@ -51,11 +48,10 @@ class TestContentAnalyzer:
             core_topics=["greetings", "introductions"],
         )
 
-        # Mock client response - now async
-        mock_response = analysis_result.model_dump_json()
-
-        mock_model = AsyncMock()
-        mock_model.ainvoke.return_value = AIMessage(content=mock_response)
+        mock_model = Mock()
+        structured_model = AsyncMock()
+        structured_model.ainvoke.return_value = analysis_result
+        mock_model.with_structured_output.return_value = structured_model
 
         analyzer = ContentAnalyzer(settings=self.settings, model=mock_model)
         result = await analyzer.analyze_content(self.sample_text)
@@ -76,78 +72,105 @@ class TestContentAnalyzer:
         assert hasattr(result.grammar_focus, "rules")
 
         # Verify client was called correctly
-        mock_model.ainvoke.assert_called_once()
-        args = mock_model.ainvoke.call_args[0]
+        mock_model.with_structured_output.assert_called_once_with(ContentAnalysis, method="json_schema")
+        structured_model.ainvoke.assert_called_once()
+        args = structured_model.ainvoke.call_args[0]
         assert self.sample_text in args[0]
         assert "JSON format" in args[0]
 
     @pytest.mark.anyio
-    async def test_analyze_content_invalid_json(self):
-        """Test handling of invalid JSON response."""
-        # Mock invalid JSON response - now async
-        mock_response = "This is not valid JSON"
-
-        mock_model = AsyncMock()
-        mock_model.ainvoke.return_value = AIMessage(content=mock_response)
-
-        analyzer = ContentAnalyzer(settings=self.settings, model=mock_model)
-        result = await analyzer.analyze_content(self.sample_text)
-
-        # Should get fallback analysis with default structure
-        assert isinstance(result, ContentAnalysis)
-        assert isinstance(result.grammar_focus, GrammarFocus)
-        assert isinstance(result.vocabulary, list)
-        assert isinstance(result.core_topics, list)
-        # Fallback provides minimal valid structure
-        assert result.grammar_focus.topic == "Swedish language practice"
-        assert isinstance(result.vocabulary, list)
-
-    @pytest.mark.anyio
-    async def test_analyze_content_missing_fields(self):
-        """Test handling of JSON with missing required fields."""
-        # Mock incomplete JSON response - now async
-        incomplete_result = {
+    async def test_analyze_content_accepts_dict_payload(self):
+        """Accept a plain mapping when the structured model does not return the schema instance."""
+        mock_model = Mock()
+        structured_model = AsyncMock()
+        structured_model.ainvoke.return_value = {
             "grammar_focus": {
                 "has_explicit_rules": True,
                 "topic": "Swedish greetings",
-                # Missing explanation
-            }
-            # Missing other required fields
+                "rules": "Hej [hello] - greeting",
+                "explanation": "Basic greeting patterns in Swedish",
+            },
+            "vocabulary": [
+                {"swedish": "hej", "english": "hello", "example_phrase": None, "known": False},
+            ],
+            "core_topics": ["greetings"],
         }
+        mock_model.with_structured_output.return_value = structured_model
 
-        mock_response = json.dumps(incomplete_result)
+        analyzer = ContentAnalyzer(settings=self.settings, model=mock_model)
+        result = await analyzer.analyze_content(self.sample_text)
 
-        mock_model = AsyncMock()
-        mock_model.ainvoke.return_value = AIMessage(content=mock_response)
+        assert isinstance(result, ContentAnalysis)
+        assert result.grammar_focus.topic == "Swedish greetings"
+        assert result.vocabulary[0].swedish == "hej"
+
+    @pytest.mark.anyio
+    async def test_analyze_content_uses_json_schema_method(self):
+        """Use native JSON schema structured output for content analysis."""
+        mock_model = Mock()
+        structured_model = AsyncMock()
+        structured_model.ainvoke.return_value = ContentAnalysis(
+            grammar_focus=GrammarFocus(
+                has_explicit_rules=False,
+                topic="Greetings",
+                explanation="Greeting practice",
+                rules=None,
+            ),
+            vocabulary=[],
+            core_topics=["greetings"],
+        )
+        mock_model.with_structured_output.return_value = structured_model
+
+        analyzer = ContentAnalyzer(settings=self.settings, model=mock_model)
+        await analyzer.analyze_content(self.sample_text)
+
+        mock_model.with_structured_output.assert_called_once_with(ContentAnalysis, method="json_schema")
+
+    @pytest.mark.anyio
+    async def test_analyze_content_validation_failure(self):
+        """Raise a content-analysis error when structured parsing fails."""
+        mock_model = Mock()
+        structured_model = AsyncMock()
+        structured_model.ainvoke.side_effect = OutputParserException("bad schema output")
+        mock_model.with_structured_output.return_value = structured_model
 
         analyzer = ContentAnalyzer(settings=self.settings, model=mock_model)
 
-        # With the new parser, missing fields trigger fallback
-        result = await analyzer.analyze_content(self.sample_text)
-
-        # Should get fallback analysis that preserves extracted data and fills missing fields
-        assert isinstance(result, ContentAnalysis)
-        assert isinstance(result.grammar_focus, GrammarFocus)
-        assert isinstance(result.vocabulary, list)
-        # The topic from the partial JSON should be preserved
-        assert result.grammar_focus.topic == "Swedish greetings"
-        # Missing fields should be filled with defaults
-        assert result.grammar_focus.explanation != ""
+        with pytest.raises(ContentAnalysisError, match="Structured content analysis validation failed"):
+            await analyzer.analyze_content(self.sample_text)
 
     @pytest.mark.anyio
-    async def test_analyze_content_no_response(self):
-        """Test handling of empty response."""
-        mock_response = ""
+    async def test_analyze_content_model_validate_failure(self):
+        """Wrap schema validation failures from plain mappings."""
+        mock_model = Mock()
+        structured_model = AsyncMock()
+        structured_model.ainvoke.return_value = {
+            "grammar_focus": {
+                "has_explicit_rules": True,
+                "topic": "Swedish greetings",
+            }
+        }
+        mock_model.with_structured_output.return_value = structured_model
 
-        mock_model = AsyncMock()
-        mock_model.ainvoke.return_value = AIMessage(content=mock_response)
+        analyzer = ContentAnalyzer(settings=self.settings, model=mock_model)
+
+        with pytest.raises(ContentAnalysisError, match="Content analysis failed"):
+            await analyzer.analyze_content(self.sample_text)
+
+    @pytest.mark.anyio
+    async def test_analyze_content_runtime_failure(self):
+        """Wrap unexpected structured-output failures as content-analysis errors."""
+        mock_model = Mock()
+        structured_model = AsyncMock()
+        structured_model.ainvoke.side_effect = RuntimeError("provider unavailable")
+        mock_model.with_structured_output.return_value = structured_model
 
         analyzer = ContentAnalyzer(settings=self.settings, model=mock_model)
 
         with pytest.raises(ContentAnalysisError) as exc_info:
             await analyzer.analyze_content(self.sample_text)
 
-        assert "No analysis returned" in str(exc_info.value)
+        assert "Content analysis failed: provider unavailable" in str(exc_info.value)
 
     def test_fallback_analysis_structure(self):
         """Test structure of fallback analysis via parser."""


### PR DESCRIPTION
## Summary
- switch content analysis to LangChain structured output using the ContentAnalysis schema
- keep explicit validation and error handling for structured output failures and plain mapping fallback
- update analyzer tests to cover schema mode selection and structured validation paths

## Checks
- uv run pytest tests/core/test_analyzer.py -v
- uv run pytest tests/core/test_processor.py -k run_analysis -v tests/api/test_endpoints.py -k analyze -v
- make backend-test

## Task
- Dart: xU9hWSfHwrc6