### PR TITLE
[codex] Add analyzer none-response coverage

### DIFF
--- a/tests/core/test_analyzer.py
+++ b/tests/core/test_analyzer.py
@@ -140,6 +140,19 @@ class TestContentAnalyzer:
             await analyzer.analyze_content(self.sample_text)
 
     @pytest.mark.anyio
+    async def test_analyze_content_none_response(self):
+        """Raise a content-analysis error when the structured model returns no data."""
+        mock_model = Mock()
+        structured_model = AsyncMock()
+        structured_model.ainvoke.return_value = None
+        mock_model.with_structured_output.return_value = structured_model
+
+        analyzer = ContentAnalyzer(settings=self.settings, model=mock_model)
+
+        with pytest.raises(ContentAnalysisError, match="No analysis returned from LLM"):
+            await analyzer.analyze_content(self.sample_text)
+
+    @pytest.mark.anyio
     async def test_analyze_content_model_validate_failure(self):
         """Wrap schema validation failures from plain mappings."""
         mock_model = Mock()


### PR DESCRIPTION
## What changed
- added a focused analyzer test for the structured-output `None` response path
- verified `ContentAnalyzer.analyze_content()` raises `ContentAnalysisError` with the expected message when the LLM returns no payload

## Why
The recent structured-output migration in `src/runestone/core/analyzer.py` introduced an explicit `response is None` branch, but the tests added with that change did not cover it.

## Impact
This keeps the regression surface tight around the new analyzer behavior and ensures the failure mode is exercised before broader integration code depends on it.

## Validation
- `UV_CACHE_DIR=.uv-cache UV_HTTP_TIMEOUT=120 uv run python -m pytest tests/core/test_analyzer.py -v`
