### PR TITLE
Fix content analyzer structured output compatibility

### DIFF
--- a/src/runestone/core/analyzer.py
+++ b/src/runestone/core/analyzer.py
@@ -67,10 +67,7 @@ class ContentAnalyzer:
                 self.settings.resolve_service_llm_provider(),
                 self.settings.resolve_service_llm_model(),
             )
-            structured_model = self.model.with_structured_output(
-                ContentAnalysis,
-                method="json_schema",
-            )
+            structured_model = self.model.with_structured_output(ContentAnalysis)
             response = await structured_model.ainvoke(analysis_prompt)
             if response is None:
                 raise ContentAnalysisError("No analysis returned from LLM")

--- a/tests/core/test_analyzer.py
+++ b/tests/core/test_analyzer.py
@@ -72,7 +72,7 @@ class TestContentAnalyzer:
         assert hasattr(result.grammar_focus, "rules")
 
         # Verify client was called correctly
-        mock_model.with_structured_output.assert_called_once_with(ContentAnalysis, method="json_schema")
+        mock_model.with_structured_output.assert_called_once_with(ContentAnalysis)
         structured_model.ainvoke.assert_called_once()
         args = structured_model.ainvoke.call_args[0]
         assert self.sample_text in args[0]
@@ -105,8 +105,8 @@ class TestContentAnalyzer:
         assert result.vocabulary[0].swedish == "hej"
 
     @pytest.mark.anyio
-    async def test_analyze_content_uses_json_schema_method(self):
-        """Use native JSON schema structured output for content analysis."""
+    async def test_analyze_content_uses_default_structured_output_method(self):
+        """Use the provider-default structured output method for content analysis."""
         mock_model = Mock()
         structured_model = AsyncMock()
         structured_model.ainvoke.return_value = ContentAnalysis(
@@ -124,7 +124,7 @@ class TestContentAnalyzer:
         analyzer = ContentAnalyzer(settings=self.settings, model=mock_model)
         await analyzer.analyze_content(self.sample_text)
 
-        mock_model.with_structured_output.assert_called_once_with(ContentAnalysis, method="json_schema")
+        mock_model.with_structured_output.assert_called_once_with(ContentAnalysis)
 
     @pytest.mark.anyio
     async def test_analyze_content_validation_failure(self):


### PR DESCRIPTION
## Summary
- remove the hardcoded `json_schema` structured-output method from `ContentAnalyzer`
- keep analyzer structured parsing on the provider-default path used elsewhere in the repo
- update analyzer tests to assert the compatibility-safe call shape

## Evidence
- merged commit `29b8aa9` introduced `with_structured_output(ContentAnalysis, method="json_schema")` in [`src/runestone/core/analyzer.py`](/Users/40min/.codex/worktrees/f0f7/runestone/src/runestone/core/analyzer.py)
- PR #126 review explicitly flagged the hardcoded method as a multi-provider compatibility risk
- the service LLM builder supports both `openai` and `openrouter`, while the vocabulary service uses plain `with_structured_output(schema)` without forcing a method

## Validation
- `UV_CACHE_DIR=.uv-cache uv run --extra dev python -m pytest tests/core/test_analyzer.py -q`