### PR TITLE
fix: restore time cheatsheet grammar tag

### DIFF
--- a/cheatsheets/index.json
+++ b/cheatsheets/index.json
@@ -197,7 +197,8 @@
       "time",
       "clock",
       "days",
-      "seasons"
+      "seasons",
+      "swedish grammar"
     ],
     "annotation": "Comprehensive guide to Swedish time expressions, prepositions for time, and telling the clock.",
     "path": "prepositions/time_and_days.md"

--- a/tests/rag/test_cheatsheet_index_metadata.py
+++ b/tests/rag/test_cheatsheet_index_metadata.py
@@ -1,0 +1,13 @@
+"""Regression checks for production cheatsheet index metadata."""
+
+import json
+from pathlib import Path
+
+
+def test_time_and_days_keeps_swedish_grammar_tag():
+    """Preserve generic grammar discoverability for the time prepositions cheatsheet."""
+    entries = json.loads(Path("cheatsheets/index.json").read_text(encoding="utf-8"))
+
+    time_and_days = next(entry for entry in entries if entry.get("path") == "prepositions/time_and_days.md")
+
+    assert "swedish grammar" in time_and_days["tags"]


### PR DESCRIPTION
## Summary
- restore the `swedish grammar` tag for `prepositions/time_and_days.md` in `cheatsheets/index.json`
- add a regression test that locks this metadata in place

## Why
The commit `c46d287` removed the tag from a production cheatsheet entry. The grammar RAG loader uses tags as BM25 keyword content, so the page became less discoverable for generic grammar searches. In a targeted BM25 comparison for `swedish grammar time expressions`, this page dropped from 3rd to 5th after the tag removal.

## Validation
- `UV_CACHE_DIR=.uv-cache uv run --extra dev python -m pytest tests/rag/test_loader.py tests/rag/test_index.py tests/rag/test_cheatsheet_index_metadata.py -v`