### PR TITLE
feat: background memory maintainer on new chat reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ LangGraph tools may execute concurrently. To keep DB operations safe, use async 
 Design docs:
 
 - Contracts + orchestration flow: [`agent-swarm-architecture.md`](docs/agent-swarm-architecture.md:1)
+- Chat-reset memory maintenance: [`memory-maintainer.md`](docs/memory-maintainer.md:1)
 - Implementation milestones: [`agent-swarm-plan.md`](docs/agent-swarm-plan.md:1)
 - Documentation naming convention: [`docs/README.md`](docs/README.md:1)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,11 @@ Examples:
 - `agent-swarm-architecture.md`
 - `tool-db-di.md`
 
+## Stable Docs
+
+- [`agent-swarm-architecture.md`](agent-swarm-architecture.md): current agent routing, tool ownership, async-post behavior, and memory boundaries
+- [`memory-maintainer.md`](memory-maintainer.md): chat-reset background memory cleanup flow and maintainer tool contract
+
 ## `docs/todo` Purpose
 
 Use `docs/todo/` for temporary planning documents about upcoming work.

--- a/docs/agent-swarm-architecture.md
+++ b/docs/agent-swarm-architecture.md
@@ -7,11 +7,14 @@ Use it to understand how a turn flows through the swarm, which agent owns which 
 Historical exploration has been consolidated into this contract and the implementation tracks. Keep this file authoritative.
 
 For milestone tracking, see [`agent-swarm-plan.md`](agent-swarm-plan.md).
+For chat-reset memory cleanup details, see
+[`memory-maintainer.md`](memory-maintainer.md).
 
 ## Index
 
 - [Current Status](#current-status)
 - [Architecture](#architecture)
+- [Memory Maintainer](#memory-maintainer)
 - [Tool Cases](#tool-cases)
 - [Contracts](#contracts)
 - [Future Work](#future-work)
@@ -30,6 +33,7 @@ Implemented now:
 - in-memory post-task registry with stale next-turn cancellation
 - image flow using the same async-post pattern
 - `MemoryKeeper` specialist running in post stage for durable memory maintenance
+- `memory_maintainer` specialist running in background after chat reset for scoped startup cleanup
 - `NewsAgent` specialist running in pre stage for topic-based news retrieval
 - teacher-side memory model narrowed to read-only lookup (`read_memory`) during response generation
 - compact first-turn starter memory injection (`personal_info` active, top-priority `area_to_improve` struggling/improving)
@@ -174,6 +178,11 @@ Owns:
 - explicit student-requested memory edits in the current turn when routed by post coordinator
 - review and update `area_to_improve` status and priority when the turn shows progress or regression
 
+Does not own:
+
+- broad startup compaction or duplicate cleanup sweeps; those belong to
+  [`memory_maintainer`](memory-maintainer.md)
+
 #### NewsAgent
 
 Owns:
@@ -243,6 +252,21 @@ Area-to-improve review rules:
 - visible progress moves the item toward `improving` and may reduce urgency by raising numeric priority
 - confirmed mastery marks the item `mastered`
 - new recurring issues create a fresh `area_to_improve` item with an explicit initial priority
+
+### Memory Maintainer
+
+`memory_maintainer` is a background specialist scheduled after chat reset. It is
+not routed through the coordinator and does not block the new session from
+starting.
+
+It reviews only `area_to_improve` memory with status `struggling` or
+`improving`, then conservatively consolidates obvious duplicates and adjusts
+priority only when clearly justified. Its tools enforce that merge replacements
+stay in category/status scope and that one merge is completed before another
+begins.
+
+For the full runtime, tool flow, logging contract, and ownership boundary, see
+[`memory-maintainer.md`](memory-maintainer.md).
 
 ### Post-Response Runtime
 

--- a/docs/memory-maintainer.md
+++ b/docs/memory-maintainer.md
@@ -50,6 +50,8 @@ maintainer-specific tools.
 The maintainer owns broad start-of-session cleanup:
 
 - conservatively consolidate obvious duplicate or overlapping weaknesses
+- write memory item content in `User.mother_tongue` (fallback: English)
+- keep memory item keys in English only
 - preserve meaningful sub-cases and examples during consolidation
 - keep separate items when different contexts still carry instructional value
 - conservatively adjust priority when an item is recurring or YKI-critical
@@ -57,6 +59,12 @@ The maintainer owns broad start-of-session cleanup:
 - log the structured maintenance result at info level
 
 No action is a valid successful outcome when memory is already clear.
+
+If merged source cards contain mixed languages, the consolidated card should use
+`User.mother_tongue` for content text while keeping the key in English.
+If target-language content cannot be produced reliably, content falls back to
+English. Swedish study examples are preserved as-is, and unchanged cards are not
+rewritten only for language normalization.
 
 ## Tool Flow
 

--- a/docs/memory-maintainer.md
+++ b/docs/memory-maintainer.md
@@ -1,0 +1,126 @@
+# Memory Maintainer
+
+`memory_maintainer` is an internal background specialist that performs routine
+memory cleanup when a student starts a new chat session.
+
+It exists to keep long-lived learner memory usable without adding latency to the
+student-facing reset flow.
+
+## Runtime Flow
+
+The trigger is `DELETE /api/chat/history`, handled by
+`ChatService.start_new_chat()`.
+
+At reset time:
+
+1. `ChatService` rotates the user's `current_chat_id`.
+2. `ChatService` loads the `User`.
+3. `AgentsManager.start_background_memory_maintenance(user)` schedules the
+   maintainer task.
+4. The reset endpoint returns immediately.
+
+The maintenance task is fire-and-forget. New chat startup does not wait for the
+agent to finish, and students can begin the next session using the memory state
+that existed before the background cleanup completed.
+
+## Duplicate Run Guard
+
+`AgentsManager` keeps an in-memory per-user maintenance registry.
+
+If a maintenance task is already running for `user.id`, another reset for the
+same user does not schedule a second maintainer run. This is intentionally
+process-local and is acceptable for the current single-process deployment.
+
+If the backend later runs multiple worker processes or instances, this guard
+should move to a shared store or durable job system.
+
+## Scope
+
+The maintainer only works on:
+
+- category: `area_to_improve`
+- statuses: `struggling`, `improving`
+
+It should not inspect or rewrite unrelated memory categories, and it should not
+merge across statuses. The scope is enforced both in the prompt and in the
+maintainer-specific tools.
+
+## Responsibilities
+
+The maintainer owns broad start-of-session cleanup:
+
+- conservatively consolidate obvious duplicate or overlapping weaknesses
+- preserve meaningful sub-cases and examples during consolidation
+- keep separate items when different contexts still carry instructional value
+- conservatively adjust priority when an item is recurring or YKI-critical
+- return structured JSON describing what happened
+- log the structured maintenance result at info level
+
+No action is a valid successful outcome when memory is already clear.
+
+## Tool Flow
+
+The specialist uses dedicated tools from
+`src/runestone/agents/tools/memory_maintainer.py`:
+
+- `maintainer_read_memory`
+- `maintainer_insert_memory_item`
+- `maintainer_delete_memory_item`
+- `maintainer_update_memory_priority`
+
+These tools are narrower than the normal memory tools. They reject out-of-scope
+categories/statuses and protect the sequential merge flow.
+
+For a consolidation, the agent must:
+
+1. Read in-scope memory.
+2. Insert a new consolidated item with a new versioned key and
+   `replaced_item_ids` containing all original ids.
+3. Delete only the original ids listed in that active replacement set.
+4. Finish deleting the active replacement set before starting another merge.
+
+The delete tool refuses to delete the newly created consolidated item and refuses
+deletes outside the active replacement set. Pending merge state is cleared at the
+start and end of each specialist run so failed or timed-out runs do not leave the
+next run blocked by stale state.
+
+## Persistence And Atomicity
+
+The maintainer uses normal agent tool calls, not a single database transaction.
+This preserves the same operational model as other specialists, but it means a
+consolidation can be temporarily half-complete if the run is interrupted after
+insert and before all deletes finish.
+
+The next maintenance run can clean up that overlap. The tools reduce accidental
+damage by constraining deletes to the active replacement plan.
+
+## Output And Logging
+
+`MemoryMaintainerSpecialist` expects the final agent message to be valid JSON
+matching `SpecialistResult` conventions:
+
+- `status`: `no_action`, `action_taken`, or `error`
+- `actions`: tool action summaries
+- `artifacts`: maintenance metadata, reviewed count, merge groups, priority
+  updates, summary, and no-change reason
+
+Fenced JSON is accepted. Invalid output or agent execution failure becomes a
+structured `error` result.
+
+`AgentsManager` logs successful completion and failures. Maintainer results are
+not written to `agent_side_effects`; logging is the only persistence surface for
+this maintenance run.
+
+## Ownership Boundary
+
+`memory_maintainer` and `MemoryKeeper` intentionally solve different problems.
+
+`memory_maintainer` runs at chat reset and owns broad cleanup across existing
+in-scope weakness memory.
+
+`MemoryKeeper` runs from normal conversation flow and owns per-turn durable
+memory updates based on the current student message, final teacher response, or
+explicit student memory-edit request.
+
+`WordKeeper` remains vocabulary-specific and does not participate in memory
+consolidation.

--- a/docs/todo/memory-maintainer-on-new-chat.md
+++ b/docs/todo/memory-maintainer-on-new-chat.md
@@ -1,0 +1,152 @@
+# Background Memory Maintainer On New Chat
+
+## Context
+
+This change introduces a dedicated background memory-maintenance specialist that runs
+when a student starts a new chat session. It is intentionally fire-and-forget and
+must not block chat reset.
+
+## Goal
+
+- Run startup memory maintenance after `DELETE /api/chat/history`.
+- Keep normal chat reset response latency low.
+- Avoid duplicate concurrent maintenance runs for the same user.
+- Keep turn-time memory updates and startup maintenance responsibilities separate.
+
+## Implemented Behavior
+
+### 1) New specialist: `memory_maintainer`
+
+Added:
+
+- `src/runestone/agents/specialists/memory_maintainer.py`
+
+The specialist:
+
+- uses a maintenance-specific system prompt
+- runs as an internal agent (not user-facing)
+- scopes review to `area_to_improve` with status `struggling` / `improving`
+- uses maintainer-scoped tools:
+  - `maintainer_read_memory`
+  - `maintainer_insert_memory_item`
+  - `maintainer_delete_memory_item`
+  - `maintainer_update_memory_priority`
+- enforces merge guardrails at tool runtime:
+  - replacement items must stay in category/status scope
+  - cross-status replacement in one merge is rejected
+  - delete is only allowed for ids explicitly listed in the active merge replacement set
+  - duplicate key collisions are handled via DB uniqueness on insert
+- clears pending merge state at run start/end to avoid stale blocked state after failures/timeouts
+- parses `SpecialistResult` from final JSON (including fenced JSON support)
+- returns structured fallback `error` artifacts for invalid output / execution failure
+
+### 2) Manager orchestration and in-memory gating
+
+Updated:
+
+- `src/runestone/agents/manager.py`
+
+Changes:
+
+- instantiate `MemoryMaintainerSpecialist` as `self.memory_maintainer`
+- add a dedicated background registry keyed by `user_id`:
+  - `self._memory_maintenance_registry`
+- add:
+  - `start_background_memory_maintenance(user: User) -> bool`
+  - `run_memory_maintenance(user: User) -> SpecialistResult`
+
+Scheduling behavior:
+
+- if a maintenance task for `user.id` is already running, skip scheduling and return `False`
+- otherwise schedule an `asyncio` background task and return `True`
+- timeout background maintenance runs (`MEMORY_MAINTENANCE_TIMEOUT_SECONDS`)
+- always unregister the task key on completion/failure
+- log structured/sanitized completion result or failures
+
+### 3) Chat reset hook
+
+Updated:
+
+- `src/runestone/services/chat_service.py`
+
+`start_new_chat(user_id)` now:
+
+1. rotates `current_chat_id`
+2. loads user
+3. schedules background memory maintenance
+4. returns immediately
+
+Failure policy:
+
+- if user lookup fails, skip maintenance and keep reset successful
+- if scheduling fails, log error and keep reset successful
+
+### 4) MemoryKeeper boundary clarification
+
+Updated:
+
+- `src/runestone/agents/specialists/memory_keeper.py`
+
+Prompt now explicitly states:
+
+- broad startup consolidation / duplicate-cleanup sweeps are owned by `memory_maintainer`
+- `memory_keeper` should only act on explicit per-turn signals
+
+## Test Coverage Added/Updated
+
+### New tests
+
+- `tests/agents/specialists/test_memory_maintainer.py`
+
+Validates:
+
+- specialist JSON parsing
+- fenced JSON parsing
+- invalid-output fallback
+- pending merge state cleanup on failed run
+- chat-reset payload shape
+- expected tool set passed to `create_agent`
+- prompt includes scope/tool requirements
+- duplicate-key insert rejection and cross-status replacement rejection
+
+### Updated tests
+
+- `tests/agents/specialists/test_memory_keeper.py`
+  - asserts startup-compaction responsibility is excluded
+- `tests/agents/test_manager.py`
+  - schedules maintenance
+  - duplicate scheduling skip while running
+  - registry cleanup after success/failure/timeout
+- `tests/services/test_chat_service.py`
+  - new-chat path schedules maintenance
+  - user-missing skip path
+- `tests/api/conftest.py`
+  - mock agent service includes `start_background_memory_maintenance`
+- `tests/api/test_chat_endpoints.py`
+  - clear history triggers maintenance scheduling
+
+## Validation Run
+
+Executed and passing:
+
+```bash
+make check-readiness
+```
+
+## Known Tradeoff
+
+- Consolidation remains a multi-step agent tool flow (insert, then delete replaced ids), not a single DB transaction.
+- If a run is interrupted between those steps, temporary duplicate overlap can exist until the next maintenance run.
+
+## Changed Files (Implementation Scope)
+
+- `src/runestone/agents/specialists/memory_maintainer.py` (new)
+- `src/runestone/agents/manager.py`
+- `src/runestone/services/chat_service.py`
+- `src/runestone/agents/specialists/memory_keeper.py`
+- `tests/agents/specialists/test_memory_maintainer.py` (new)
+- `tests/agents/specialists/test_memory_keeper.py`
+- `tests/agents/test_manager.py`
+- `tests/services/test_chat_service.py`
+- `tests/api/conftest.py`
+- `tests/api/test_chat_endpoints.py`

--- a/src/runestone/agents/manager.py
+++ b/src/runestone/agents/manager.py
@@ -16,8 +16,9 @@ from runestone.agents.background_task_registry import BackgroundTaskRegistry
 from runestone.agents.coordinator import CoordinatorAgent
 from runestone.agents.schemas import ChatMessage, CoordinatorPlan, RoutingItem, TeacherEmotion, TeacherSideEffect
 from runestone.agents.service_providers import provide_agent_side_effect_service
-from runestone.agents.specialists.base import SpecialistContext
+from runestone.agents.specialists.base import SpecialistContext, SpecialistResult
 from runestone.agents.specialists.memory_keeper import MemoryKeeperSpecialist
+from runestone.agents.specialists.memory_maintainer import MemoryMaintainerSpecialist
 from runestone.agents.specialists.news_agent import NewsAgentSpecialist
 from runestone.agents.specialists.registry import SpecialistRegistry
 from runestone.agents.specialists.teacher import TeacherAgent
@@ -47,6 +48,7 @@ class AgentsManager:
 
     COORDINATOR_MAX_HISTORY_MESSAGES = 5
     POST_TASK_TIMEOUT_SECONDS = 15
+    MEMORY_MAINTENANCE_TIMEOUT_SECONDS = 30
     STARTER_MEMORY_PERSONAL_LIMIT = 50
     STARTER_MEMORY_AREA_LIMIT = 5
 
@@ -75,8 +77,14 @@ class AgentsManager:
         self.registry.register(MemoryKeeperSpecialist(settings))
         self.registry.register(NewsAgentSpecialist(settings))
         self.registry.register(WordKeeperSpecialist(settings))
+        self.memory_maintainer = MemoryMaintainerSpecialist(settings)
 
         self._post_task_registry = BackgroundTaskRegistry(logger=logger, key_name="chat_id")
+        self._memory_maintenance_registry = BackgroundTaskRegistry(
+            logger=logger,
+            log_prefix="[agents:memory-maintenance]",
+            key_name="user_id",
+        )
 
         logger.info(
             "[agents:manager] Initialized AgentsManager with provider=%s, model=%s, persona=%s",
@@ -460,6 +468,74 @@ class AgentsManager:
     def cancel_post_task(self, chat_id: str) -> bool:
         """Cancel any live background post task for chat_id. Returns True if a task was cancelled."""
         return self._post_task_registry.cancel(chat_id)
+
+    async def start_background_memory_maintenance(self, user: User) -> bool:
+        """
+        Schedule background memory maintenance at chat reset time.
+
+        Only one run per user may be active at a time; repeated reset requests
+        while maintenance is still running are treated as a no-op.
+        """
+        user_key = str(user.id)
+        existing_task = self._memory_maintenance_registry.tasks.get(user_key)
+        if existing_task and not existing_task.done():
+            logger.info(
+                "[agents:memory-maintenance] Skipping schedule because maintenance is already running: user_id=%s",
+                user.id,
+            )
+            return False
+
+        async def _run() -> None:
+            try:
+                result = await asyncio.wait_for(
+                    self.run_memory_maintenance(user),
+                    timeout=self.MEMORY_MAINTENANCE_TIMEOUT_SECONDS,
+                )
+                artifacts = result.artifacts if isinstance(result.artifacts, dict) else {}
+                logger.info(
+                    "[agents:memory-maintenance] Completed: user_id=%s status=%s actions=%s reviewed=%s merged=%s "
+                    "priority_updates=%s",
+                    user.id,
+                    result.status,
+                    len(result.actions),
+                    artifacts.get("reviewed_item_count"),
+                    len(artifacts.get("merged_groups", [])) if isinstance(artifacts.get("merged_groups"), list) else 0,
+                    (
+                        len(artifacts.get("priority_updates", []))
+                        if isinstance(artifacts.get("priority_updates"), list)
+                        else 0
+                    ),
+                )
+            except asyncio.TimeoutError:
+                logger.error(
+                    "[agents:memory-maintenance] Timed out after %ss: user_id=%s",
+                    self.MEMORY_MAINTENANCE_TIMEOUT_SECONDS,
+                    user.id,
+                )
+            except Exception:
+                logger.error(
+                    "[agents:memory-maintenance] Failed: user_id=%s",
+                    user.id,
+                    exc_info=True,
+                )
+            finally:
+                self._memory_maintenance_registry.unregister(user_key)
+
+        task = asyncio.create_task(_run())
+        self._memory_maintenance_registry.register(user_key, task)
+        logger.info("[agents:memory-maintenance] Background task started: user_id=%s", user.id)
+        return True
+
+    async def run_memory_maintenance(self, user: User) -> SpecialistResult:
+        """Run the memory maintainer directly for chat-reset startup hygiene."""
+        return await self.memory_maintainer.run(
+            SpecialistContext(
+                message="start_new_chat",
+                history=[],
+                user=user,
+                routing_reason="new_chat_session_started",
+            )
+        )
 
     async def start_background_post_turn(
         self,

--- a/src/runestone/agents/specialists/memory_keeper.py
+++ b/src/runestone/agents/specialists/memory_keeper.py
@@ -51,6 +51,9 @@ If no trigger is detected → return `no_action` immediately. Do not call any to
 - Default to `no_action`. Only proceed when the signal is explicit and durable.
 - Do not infer facts, mastery, or preferences from weak or indirect signals.
 - Prefer updating an existing item over creating a duplicate (that's what Step 1 is for).
+- Broad start-of-session consolidation, duplicate cleanup, and routine reprioritization sweeps
+  are handled by a separate `memory_maintainer`. Do not perform those sweeps unless the
+  current turn explicitly requires a memory change.
 - Never call `read_memory` without filters unless a broad inspection is explicitly required.
 - Never call `read_memory` as a standalone action — it is always a precursor to a write.
 - Treat spelling corrections, nonexistent-word feedback, and one-off wrong vocabulary forms as

--- a/src/runestone/agents/specialists/memory_maintainer.py
+++ b/src/runestone/agents/specialists/memory_maintainer.py
@@ -36,8 +36,6 @@ overlapping entries. The goal is clarity and usability, not compaction for its
 own sake. If everything looks well-organized already, making no changes at all
 is a perfectly valid outcome.
 
-Use English for all memory item keys and content.
-
 When reviewing, consider merging items that:
 - cover the same core grammatical concept, even across slightly different contexts
 - are near-duplicates or explicit repeats
@@ -46,9 +44,19 @@ Be moderate: merge when overlap is obvious and the result preserves all
 meaningful sub-cases and examples from the originals. Keep items separate if
 their different contexts carry distinct instructional value.
 
+Language normalization rules:
+- The content target language is provided in the runtime instruction message.
+- If one or more merged items use another language, write the new consolidated
+  content in the target language while preserving meaning.
+- Always keep memory item keys in English.
+- If you cannot reliably produce target-language content, fall back to English
+  content.
+- Keep Swedish example words/phrases as-is when they are language-study examples.
+- Do not rewrite unrelated untouched items only to normalize language.
+
 For each merge you decide to perform:
 - create one new consolidated item with:
-  - a descriptive key capturing the concept
+  - a descriptive key in English capturing the concept
   - key must be a new versioned key (for example: `<concept>_v2` or `<concept>_merged_v2`)
   - never reuse any original key from the merged items
   - combined content preserving all distinct sub-cases and examples
@@ -144,7 +152,14 @@ class MemoryMaintainerSpecialist(BaseSpecialist):
 
     async def run(self, context: SpecialistContext) -> SpecialistResult:
         clear_pending_merge_plan(context.user.id)
-        prompt = "Run the routine chat-reset memory maintenance check."
+        language = self._memory_item_language(context)
+        prompt = (
+            "Run the routine chat-reset memory maintenance check.\n"
+            "Language policy:\n"
+            f"- Use '{language}' for memory item content.\n"
+            "- If you cannot reliably produce that language, fall back to English content.\n"
+            "- Keep all memory item keys in English only."
+        )
 
         try:
             try:
@@ -211,3 +226,10 @@ class MemoryMaintainerSpecialist(BaseSpecialist):
             except (ValidationError, ValueError):
                 continue
         return None
+
+    @staticmethod
+    def _memory_item_language(context: SpecialistContext) -> str:
+        mother_tongue = getattr(context.user, "mother_tongue", None)
+        if isinstance(mother_tongue, str) and mother_tongue.strip():
+            return mother_tongue.strip()
+        return "English"

--- a/src/runestone/agents/specialists/memory_maintainer.py
+++ b/src/runestone/agents/specialists/memory_maintainer.py
@@ -62,6 +62,7 @@ Merge execution rules:
   `replaced_item_ids` containing all original ids to replace
 - never mix statuses in one merge group; all `replaced_item_ids` must share one status
 - after a merge upsert, only delete ids listed in that `replaced_item_ids` set
+- you must complete one merge (insert then delete all replaced items) before starting another
 
 Deletion safety rule:
 - when maintainer_insert_memory_item returns `Memory item saved: [ID:<n>] ...`, treat `<n>` as the consolidated item id

--- a/src/runestone/agents/specialists/memory_maintainer.py
+++ b/src/runestone/agents/specialists/memory_maintainer.py
@@ -1,0 +1,212 @@
+"""
+Background specialist for start-of-session memory maintenance.
+"""
+
+import logging
+from typing import Any
+
+from langchain.agents import create_agent
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_openai import ChatOpenAI
+from pydantic import ValidationError
+
+from runestone.agents.llm import build_chat_model
+from runestone.agents.specialists.base import BaseSpecialist, SpecialistContext, SpecialistResult
+from runestone.agents.tools.context import AgentContext
+from runestone.agents.tools.memory_maintainer import (
+    clear_pending_merge_plan,
+    maintainer_delete_memory_item,
+    maintainer_insert_memory_item,
+    maintainer_read_memory,
+    maintainer_update_memory_priority,
+)
+from runestone.config import Settings
+
+logger = logging.getLogger(__name__)
+
+MEMORY_MAINTAINER_SYSTEM_PROMPT = """
+You are Björn, a Swedish language teacher. Before starting a new tutoring
+session, perform a routine memory maintenance check.
+
+This is an internal maintenance task. You do not interact with the student.
+
+Review current memory items only in category `area_to_improve` with status
+`struggling` or `improving`. Only where it clearly makes sense, consolidate
+overlapping entries. The goal is clarity and usability, not compaction for its
+own sake. If everything looks well-organized already, making no changes at all
+is a perfectly valid outcome.
+
+Use English for all memory item keys and content.
+
+When reviewing, consider merging items that:
+- cover the same core grammatical concept, even across slightly different contexts
+- are near-duplicates or explicit repeats
+
+Be moderate: merge when overlap is obvious and the result preserves all
+meaningful sub-cases and examples from the originals. Keep items separate if
+their different contexts carry distinct instructional value.
+
+For each merge you decide to perform:
+- create one new consolidated item with:
+  - a descriptive key capturing the concept
+  - key must be a new versioned key (for example: `<concept>_v2` or `<concept>_merged_v2`)
+  - never reuse any original key from the merged items
+  - combined content preserving all distinct sub-cases and examples
+  - the same category `area_to_improve`
+  - the same status as the merged items
+  - priority set to the highest priority (lowest number) among merged items
+- delete all original items being replaced
+
+Merge execution rules:
+- for merge creation, call `maintainer_insert_memory_item` with
+  `replaced_item_ids` containing all original ids to replace
+- never mix statuses in one merge group; all `replaced_item_ids` must share one status
+- after a merge upsert, only delete ids listed in that `replaced_item_ids` set
+
+Deletion safety rule:
+- when maintainer_insert_memory_item returns `Memory item saved: [ID:<n>] ...`, treat `<n>` as the consolidated item id
+- never delete that consolidated item id, even if it was listed among originals by mistake
+
+After merges, briefly review priorities:
+- consider bumping up items that are recurring or YKI exam-critical
+- be conservative and change priority only when clearly justified
+
+Allowed tools:
+- maintainer_read_memory
+- maintainer_insert_memory_item
+- maintainer_delete_memory_item
+- maintainer_update_memory_priority
+
+Broad inspection is allowed for this maintenance task.
+
+Return valid JSON matching this exact structure and nothing else:
+{
+  "status": "no_action" | "action_taken" | "error",
+  "actions": [{"tool": string, "status": "success" | "error", "summary": string}],
+  "artifacts": {
+    "maintenance_type": "chat_reset_memory_maintenance",
+    "scope": {"category": "area_to_improve", "statuses": ["struggling", "improving"]},
+    "reviewed_item_count": number,
+    "merged_groups": [
+      {
+        "new_key": string,
+        "new_priority": number | null,
+        "replaced_item_ids": [number],
+        "replaced_keys": [string],
+        "status": string
+      }
+    ],
+    "priority_updates": [
+      {
+        "item_id": number,
+        "key": string,
+        "from_priority": number | null,
+        "to_priority": number | null,
+        "reason": string
+      }
+    ],
+    "summary": string,
+    "no_change_reason": string | null
+  }
+}
+"""
+
+
+class MemoryMaintainerSpecialist(BaseSpecialist):
+    """Background specialist that consolidates start-of-session learner memory."""
+
+    def __init__(self, settings: Settings):
+        super().__init__(name="memory_maintainer")
+        self.settings = settings
+        # Reuse the memory_keeper model configuration for this adjacent maintenance role.
+        model = build_chat_model(settings, "memory_keeper")
+        self.agent = self._build_agent(model)
+        logger.info(
+            "[agents:memorymaintainer] Initialized MemoryMaintainerSpecialist with provider=%s, model=%s",
+            settings.memory_keeper_provider,
+            settings.memory_keeper_model,
+        )
+
+    def _build_agent(self, model: ChatOpenAI):
+        """Build the internal tool-using agent for background memory maintenance."""
+        return create_agent(
+            model=model,
+            tools=[
+                maintainer_read_memory,
+                maintainer_insert_memory_item,
+                maintainer_delete_memory_item,
+                maintainer_update_memory_priority,
+            ],
+            system_prompt=MEMORY_MAINTAINER_SYSTEM_PROMPT,
+            context_schema=AgentContext,
+        )
+
+    async def run(self, context: SpecialistContext) -> SpecialistResult:
+        clear_pending_merge_plan(context.user.id)
+        prompt = "Run the routine chat-reset memory maintenance check."
+
+        try:
+            try:
+                result = await self.agent.ainvoke(
+                    {"messages": [HumanMessage(content=prompt)]},
+                    context=AgentContext(user=context.user),
+                )
+            except Exception as exc:
+                logger.warning("[agents:memorymaintainer] Agent execution failed: %s", exc, exc_info=True)
+                return SpecialistResult(
+                    status="error",
+                    info_for_teacher="",
+                    actions=[],
+                    artifacts={
+                        "maintenance_type": "chat_reset_memory_maintenance",
+                        "summary": "agent_execution_failed",
+                        "scope": {"category": "area_to_improve", "statuses": ["struggling", "improving"]},
+                        "reviewed_item_count": 0,
+                        "merged_groups": [],
+                        "priority_updates": [],
+                        "no_change_reason": None,
+                    },
+                )
+
+            parsed = self._parse_result(result.get("messages", []))
+            if parsed is None:
+                logger.warning("[agents:memorymaintainer] Failed to parse final agent result")
+                return SpecialistResult(
+                    status="error",
+                    info_for_teacher="",
+                    actions=[],
+                    artifacts={
+                        "maintenance_type": "chat_reset_memory_maintenance",
+                        "summary": "invalid_agent_output",
+                        "scope": {"category": "area_to_improve", "statuses": ["struggling", "improving"]},
+                        "reviewed_item_count": 0,
+                        "merged_groups": [],
+                        "priority_updates": [],
+                        "no_change_reason": None,
+                    },
+                )
+            return parsed
+        finally:
+            clear_pending_merge_plan(context.user.id)
+
+    @staticmethod
+    def _parse_result(messages: list[Any]) -> SpecialistResult | None:
+        for message in reversed(messages):
+            if not isinstance(message, AIMessage):
+                continue
+            if getattr(message, "tool_calls", None):
+                continue
+            content = message.content
+            if not isinstance(content, str) or not content.strip():
+                continue
+            json_content = content.strip()
+            if json_content.startswith("```"):
+                start = json_content.find("{")
+                end = json_content.rfind("}")
+                if start != -1 and end != -1 and end >= start:
+                    json_content = json_content[start : end + 1]
+            try:
+                return SpecialistResult.model_validate_json(json_content)
+            except (ValidationError, ValueError):
+                continue
+        return None

--- a/src/runestone/agents/tools/memory_maintainer.py
+++ b/src/runestone/agents/tools/memory_maintainer.py
@@ -4,6 +4,7 @@ Tool wrappers for memory maintainer background consolidation.
 
 import logging
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Annotated
 
 from langchain.tools import ToolRuntime
@@ -17,7 +18,7 @@ from runestone.agents.tools.memory import _format_tool_error
 from runestone.agents.tools.utils import serialize_memory_items
 from runestone.api.memory_item_schemas import AreaToImproveStatus, MemoryCategory
 from runestone.constants import MEMORY_DEFAULT_AREA_TO_IMPROVE_PRIORITY
-from runestone.core.exceptions import PermissionDeniedError, UserNotFoundError
+from runestone.core.exceptions import MemoryItemNotFoundError, PermissionDeniedError
 from runestone.db.models import MemoryItem
 
 logger = logging.getLogger(__name__)
@@ -181,13 +182,19 @@ async def maintainer_insert_memory_item(
     async with provide_memory_item_service() as service:
         if replaced_item_ids:
             replaced_statuses: set[str] = set()
+            replaced_items = await service.repo.get_by_ids(replaced_item_ids)
+            replaced_by_id = {replaced_item.id: replaced_item for replaced_item in replaced_items}
+            missing_ids = [
+                replaced_item_id for replaced_item_id in replaced_item_ids if replaced_item_id not in replaced_by_id
+            ]
+            if missing_ids:
+                return _format_tool_error(
+                    "maintainer_insert_memory_item",
+                    MemoryItemNotFoundError(f"Memory item with id {missing_ids[0]} not found"),
+                )
+
             for replaced_item_id in replaced_item_ids:
-                replaced_item = await service.repo.get_by_id(replaced_item_id)
-                if not replaced_item:
-                    return _format_tool_error(
-                        "maintainer_insert_memory_item",
-                        UserNotFoundError(f"Memory item with id {replaced_item_id} not found"),
-                    )
+                replaced_item = replaced_by_id[replaced_item_id]
                 if replaced_item.user_id != user.id:
                     return _format_tool_error(
                         "maintainer_insert_memory_item",
@@ -227,7 +234,7 @@ async def maintainer_insert_memory_item(
                 ValueError(f"priority must be between 0 and 9, got {item.priority}"),
             )
 
-        service._validate_status(MemoryCategory.AREA_TO_IMPROVE, status)
+        service.validate_status(MemoryCategory.AREA_TO_IMPROVE, status)
         create_priority = item.priority
         if create_priority is None:
             create_priority = MEMORY_DEFAULT_AREA_TO_IMPROVE_PRIORITY
@@ -241,7 +248,7 @@ async def maintainer_insert_memory_item(
                     content=item.content,
                     status=status,
                     priority=create_priority,
-                    status_changed_at=service._utc_now(),
+                    status_changed_at=datetime.now(timezone.utc),
                 )
             )
         except IntegrityError as exc:
@@ -297,7 +304,7 @@ async def maintainer_delete_memory_item(
         if not item:
             return _format_tool_error(
                 "maintainer_delete_memory_item",
-                UserNotFoundError(f"Memory item with id {delete.item_id} not found"),
+                MemoryItemNotFoundError(f"Memory item with id {delete.item_id} not found"),
             )
         if item.user_id != user.id:
             return _format_tool_error(
@@ -332,7 +339,7 @@ async def maintainer_update_memory_priority(
         if not item:
             return _format_tool_error(
                 "maintainer_update_memory_priority",
-                UserNotFoundError(f"Memory item with id {update.item_id} not found"),
+                MemoryItemNotFoundError(f"Memory item with id {update.item_id} not found"),
             )
         if item.user_id != user.id:
             return _format_tool_error(

--- a/src/runestone/agents/tools/memory_maintainer.py
+++ b/src/runestone/agents/tools/memory_maintainer.py
@@ -1,0 +1,346 @@
+"""
+Tool wrappers for memory maintainer background consolidation.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Annotated
+
+from langchain.tools import ToolRuntime
+from langchain_core.tools import tool
+from pydantic import BaseModel, Field
+from sqlalchemy.exc import IntegrityError
+
+from runestone.agents.service_providers import provide_memory_item_service
+from runestone.agents.tools.context import AgentContext
+from runestone.agents.tools.memory import _format_tool_error
+from runestone.agents.tools.utils import serialize_memory_items
+from runestone.api.memory_item_schemas import AreaToImproveStatus, MemoryCategory
+from runestone.constants import MEMORY_DEFAULT_AREA_TO_IMPROVE_PRIORITY
+from runestone.core.exceptions import PermissionDeniedError, UserNotFoundError
+from runestone.db.models import MemoryItem
+
+logger = logging.getLogger(__name__)
+
+MAINTAINER_ALLOWED_STATUSES = {
+    AreaToImproveStatus.STRUGGLING.value,
+    AreaToImproveStatus.IMPROVING.value,
+}
+
+
+@dataclass
+class PendingMergePlan:
+    """Tracks which item ids can be deleted after a validated consolidation insert."""
+
+    consolidated_item_id: int
+    remaining_delete_ids: set[int]
+
+
+_PENDING_MERGE_DELETIONS: dict[int, PendingMergePlan] = {}
+
+
+def clear_pending_merge_plan(user_id: int) -> None:
+    """Clear any pending merge-delete plan for a user."""
+    _PENDING_MERGE_DELETIONS.pop(user_id, None)
+
+
+class MaintainerInsertInput(BaseModel):
+    """Input for scoped memory maintainer insert."""
+
+    category: MemoryCategory = Field(
+        default=MemoryCategory.AREA_TO_IMPROVE,
+        description="Must be area_to_improve for memory maintainer",
+    )
+    key: str = Field(..., min_length=1, max_length=200, description="Unique key for the memory item")
+    content: str = Field(..., min_length=1, max_length=1000, description="Memory content in English")
+    status: AreaToImproveStatus | None = Field(
+        default=None,
+        description="Status for area_to_improve item; only struggling or improving allowed.",
+    )
+    priority: int | None = Field(
+        default=None,
+        ge=0,
+        le=9,
+        description="Priority 0-9 (0=highest urgency). Null is treated as 9 (lowest/default).",
+    )
+    replaced_item_ids: list[int] = Field(
+        default_factory=list,
+        description=(
+            "Original item ids replaced by this consolidated item. " "For merge flows, must include every replaced id."
+        ),
+    )
+
+
+class MaintainerDeleteInput(BaseModel):
+    """Input for scoped memory maintainer delete."""
+
+    item_id: int = Field(..., description="ID of the memory item to delete")
+
+
+class MaintainerPriorityUpdate(BaseModel):
+    """Input for scoped memory maintainer priority updates."""
+
+    item_id: int = Field(..., description="ID of the area_to_improve memory item")
+    priority: int | None = Field(
+        ...,
+        ge=0,
+        le=9,
+        description="Priority 0-9 (0=highest urgency). Null is treated as 9 (lowest/default).",
+    )
+
+
+def _is_in_maintainer_scope(category: str, status: str) -> bool:
+    return category == MemoryCategory.AREA_TO_IMPROVE.value and status in MAINTAINER_ALLOWED_STATUSES
+
+
+def _scope_error(tool_name: str, item_id: int, category: str, status: str) -> str:
+    return _format_tool_error(
+        tool_name,
+        ValueError(
+            "Item is out of memory maintainer scope "
+            f"(item_id={item_id}, category={category}, status={status}). "
+            "Only area_to_improve items with status struggling/improving are allowed."
+        ),
+    )
+
+
+def _status_value(status: AreaToImproveStatus | str | None) -> str:
+    if isinstance(status, AreaToImproveStatus):
+        return status.value
+    return status or AreaToImproveStatus.STRUGGLING.value
+
+
+@tool
+async def maintainer_read_memory(runtime: ToolRuntime[AgentContext]) -> str:
+    """Read only in-scope memory items for maintenance."""
+    logger.info("Agent tool call: maintainer_read_memory")
+    user = runtime.context.user
+
+    async with provide_memory_item_service() as service:
+        struggling_items = await service.list_memory_items(
+            user_id=user.id,
+            category=MemoryCategory.AREA_TO_IMPROVE,
+            status=AreaToImproveStatus.STRUGGLING.value,
+            limit=200,
+            offset=0,
+        )
+        improving_items = await service.list_memory_items(
+            user_id=user.id,
+            category=MemoryCategory.AREA_TO_IMPROVE,
+            status=AreaToImproveStatus.IMPROVING.value,
+            limit=200,
+            offset=0,
+        )
+
+    items = struggling_items + improving_items
+    if not items:
+        return "No in-scope memory items found."
+    return serialize_memory_items(items)
+
+
+@tool
+async def maintainer_insert_memory_item(
+    runtime: ToolRuntime[AgentContext],
+    item: Annotated[MaintainerInsertInput, Field(description="Memory item to create in maintainer scope")],
+) -> str:
+    """Insert only in-scope memory items and validate merge replacements."""
+    logger.info(
+        "Agent tool call: maintainer_insert_memory_item (category=%s, key=%s, status=%s, priority=%s, replaced_ids=%s)",
+        item.category,
+        item.key,
+        item.status,
+        item.priority,
+        item.replaced_item_ids,
+    )
+    user = runtime.context.user
+    status = _status_value(item.status)
+
+    if item.category != MemoryCategory.AREA_TO_IMPROVE:
+        return _format_tool_error(
+            "maintainer_insert_memory_item",
+            ValueError("Only category 'area_to_improve' is allowed for memory maintainer."),
+        )
+    if status not in MAINTAINER_ALLOWED_STATUSES:
+        return _format_tool_error(
+            "maintainer_insert_memory_item",
+            ValueError("Only statuses 'struggling' and 'improving' are allowed for memory maintainer."),
+        )
+
+    pending_plan = _PENDING_MERGE_DELETIONS.get(user.id)
+    if pending_plan and pending_plan.remaining_delete_ids:
+        return _format_tool_error(
+            "maintainer_insert_memory_item",
+            ValueError(
+                "Cannot start a new consolidation while previous replaced items are still pending deletion "
+                f"(pending_item_ids={sorted(pending_plan.remaining_delete_ids)})."
+            ),
+        )
+
+    replaced_item_ids = sorted(set(item.replaced_item_ids))
+
+    async with provide_memory_item_service() as service:
+        if replaced_item_ids:
+            replaced_statuses: set[str] = set()
+            for replaced_item_id in replaced_item_ids:
+                replaced_item = await service.repo.get_by_id(replaced_item_id)
+                if not replaced_item:
+                    return _format_tool_error(
+                        "maintainer_insert_memory_item",
+                        UserNotFoundError(f"Memory item with id {replaced_item_id} not found"),
+                    )
+                if replaced_item.user_id != user.id:
+                    return _format_tool_error(
+                        "maintainer_insert_memory_item",
+                        PermissionDeniedError("You don't have permission to replace this item"),
+                    )
+                if not _is_in_maintainer_scope(replaced_item.category, replaced_item.status):
+                    return _scope_error(
+                        "maintainer_insert_memory_item",
+                        replaced_item.id,
+                        replaced_item.category,
+                        replaced_item.status,
+                    )
+                replaced_statuses.add(replaced_item.status)
+
+            if len(replaced_statuses) > 1:
+                return _format_tool_error(
+                    "maintainer_insert_memory_item",
+                    ValueError(
+                        "Cross-status consolidation is not allowed. "
+                        f"All replaced items must share one status, got {sorted(replaced_statuses)}."
+                    ),
+                )
+
+            replaced_status = next(iter(replaced_statuses))
+            if status != replaced_status:
+                return _format_tool_error(
+                    "maintainer_insert_memory_item",
+                    ValueError(
+                        "Consolidated item status must match replaced item status "
+                        f"(expected={replaced_status}, got={status})."
+                    ),
+                )
+
+        if item.priority is not None and not (0 <= item.priority <= 9):
+            return _format_tool_error(
+                "maintainer_insert_memory_item",
+                ValueError(f"priority must be between 0 and 9, got {item.priority}"),
+            )
+
+        service._validate_status(MemoryCategory.AREA_TO_IMPROVE, status)
+        create_priority = item.priority
+        if create_priority is None:
+            create_priority = MEMORY_DEFAULT_AREA_TO_IMPROVE_PRIORITY
+
+        try:
+            created_item = await service.repo.create(
+                MemoryItem(
+                    user_id=user.id,
+                    category=MemoryCategory.AREA_TO_IMPROVE.value,
+                    key=item.key,
+                    content=item.content,
+                    status=status,
+                    priority=create_priority,
+                    status_changed_at=service._utc_now(),
+                )
+            )
+        except IntegrityError as exc:
+            await service.repo.db.rollback()
+            return _format_tool_error(
+                "maintainer_insert_memory_item",
+                ValueError(
+                    "Insert failed due to duplicate key for this user/category. "
+                    f"Use a new versioned key. Original error: {exc.__class__.__name__}"
+                ),
+            )
+
+    if replaced_item_ids:
+        _PENDING_MERGE_DELETIONS[user.id] = PendingMergePlan(
+            consolidated_item_id=created_item.id,
+            remaining_delete_ids={item_id for item_id in replaced_item_ids if item_id != created_item.id},
+        )
+
+    priority_str = f", priority: {created_item.priority}" if created_item.priority is not None else ""
+    return (
+        f"Memory item saved: [ID:{created_item.id}] {created_item.key} in {created_item.category} "
+        f"(status: {created_item.status}{priority_str})"
+    )
+
+
+@tool
+async def maintainer_delete_memory_item(
+    runtime: ToolRuntime[AgentContext],
+    delete: Annotated[MaintainerDeleteInput, Field(description="In-scope memory item to delete")],
+) -> str:
+    """Delete only in-scope memory items."""
+    logger.info("Agent tool call: maintainer_delete_memory_item (item_id=%s)", delete.item_id)
+    user = runtime.context.user
+    pending_plan = _PENDING_MERGE_DELETIONS.get(user.id)
+
+    if pending_plan and delete.item_id == pending_plan.consolidated_item_id:
+        return _format_tool_error(
+            "maintainer_delete_memory_item",
+            ValueError(
+                f"Cannot delete the just-created consolidated item (item_id={pending_plan.consolidated_item_id})."
+            ),
+        )
+    if not pending_plan or delete.item_id not in pending_plan.remaining_delete_ids:
+        return _format_tool_error(
+            "maintainer_delete_memory_item",
+            ValueError(
+                "Delete is only allowed for ids listed in replaced_item_ids of the active consolidation upsert call."
+            ),
+        )
+
+    async with provide_memory_item_service() as service:
+        item = await service.repo.get_by_id(delete.item_id)
+        if not item:
+            return _format_tool_error(
+                "maintainer_delete_memory_item",
+                UserNotFoundError(f"Memory item with id {delete.item_id} not found"),
+            )
+        if item.user_id != user.id:
+            return _format_tool_error(
+                "maintainer_delete_memory_item",
+                PermissionDeniedError("You don't have permission to delete this item"),
+            )
+        if not _is_in_maintainer_scope(item.category, item.status):
+            return _scope_error("maintainer_delete_memory_item", item.id, item.category, item.status)
+        await service.delete_item(delete.item_id, user.id)
+
+    pending_plan.remaining_delete_ids.discard(delete.item_id)
+    if not pending_plan.remaining_delete_ids:
+        _PENDING_MERGE_DELETIONS.pop(user.id, None)
+    return f"Deleted memory item: [ID:{delete.item_id}]"
+
+
+@tool
+async def maintainer_update_memory_priority(
+    runtime: ToolRuntime[AgentContext],
+    update: Annotated[MaintainerPriorityUpdate, Field(description="In-scope priority update data")],
+) -> str:
+    """Set priority only for in-scope memory items."""
+    logger.info(
+        "Agent tool call: maintainer_update_memory_priority (item_id=%s, priority=%s)",
+        update.item_id,
+        update.priority,
+    )
+    user = runtime.context.user
+
+    async with provide_memory_item_service() as service:
+        item = await service.repo.get_by_id(update.item_id)
+        if not item:
+            return _format_tool_error(
+                "maintainer_update_memory_priority",
+                UserNotFoundError(f"Memory item with id {update.item_id} not found"),
+            )
+        if item.user_id != user.id:
+            return _format_tool_error(
+                "maintainer_update_memory_priority",
+                PermissionDeniedError("You don't have permission to update this item"),
+            )
+        if not _is_in_maintainer_scope(item.category, item.status):
+            return _scope_error("maintainer_update_memory_priority", item.id, item.category, item.status)
+        result = await service.update_item_priority(update.item_id, update.priority, user.id)
+
+    return f"Priority updated: [ID:{result.id}] {result.key} priority is now {result.priority}"

--- a/src/runestone/core/exceptions.py
+++ b/src/runestone/core/exceptions.py
@@ -98,3 +98,9 @@ class PermissionDeniedError(ValueError):
     """Raised when a user lacks permission to perform an action."""
 
     pass
+
+
+class MemoryItemNotFoundError(ValueError):
+    """Raised when a memory item is not found."""
+
+    pass

--- a/src/runestone/db/memory_item_repository.py
+++ b/src/runestone/db/memory_item_repository.py
@@ -21,6 +21,14 @@ class MemoryItemRepository:
         result = await self.db.execute(stmt)
         return result.scalars().first()
 
+    async def get_by_ids(self, item_ids: list[int]) -> list[MemoryItem]:
+        """Get memory items by IDs."""
+        if not item_ids:
+            return []
+        stmt = select(MemoryItem).filter(MemoryItem.id.in_(item_ids))
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())
+
     async def get_by_user_category_key(self, user_id: int, category: str, key: str) -> Optional[MemoryItem]:
         """
         Get memory item by user_id, category, and key.

--- a/src/runestone/services/chat_service.py
+++ b/src/runestone/services/chat_service.py
@@ -239,8 +239,31 @@ Instructions:
         return await self.user_service.get_or_create_current_chat_id(user_id)
 
     async def start_new_chat(self, user_id: int) -> str:
-        """Rotate the user onto a fresh chat session id."""
-        return await self.user_service.rotate_current_chat_id(user_id)
+        """
+        Rotate the user onto a fresh chat session id and trigger background maintenance.
+
+        Memory maintenance is fire-and-forget on purpose so chat reset stays fast.
+        If scheduling fails, the fresh chat session is still returned successfully.
+        """
+        chat_id = await self.user_service.rotate_current_chat_id(user_id)
+
+        user = await self.user_service.get_user_by_id(user_id)
+        if user is None:
+            logger.warning(
+                "[chat:service] Skipped background memory maintenance because user %s was not found", user_id
+            )
+            return chat_id
+
+        try:
+            await self.agent_service.start_background_memory_maintenance(user)
+        except Exception:
+            logger.error(
+                "[chat:service] Failed to schedule background memory maintenance for user %s",
+                user_id,
+                exc_info=True,
+            )
+
+        return chat_id
 
     async def clear_history(self, user_id: int) -> str:
         """Backward-compatible alias for starting a new chat session."""

--- a/src/runestone/services/memory_item_service.py
+++ b/src/runestone/services/memory_item_service.py
@@ -17,7 +17,7 @@ from runestone.api.memory_item_schemas import (
     SortDirection,
 )
 from runestone.constants import MEMORY_DEFAULT_AREA_TO_IMPROVE_PRIORITY
-from runestone.core.exceptions import PermissionDeniedError, UserNotFoundError
+from runestone.core.exceptions import MemoryItemNotFoundError, PermissionDeniedError
 from runestone.core.logging_config import get_logger
 from runestone.db.memory_item_repository import MemoryItemRepository
 from runestone.db.models import MemoryItem
@@ -39,7 +39,7 @@ class MemoryItemService:
     def _utc_now(self) -> datetime:
         return datetime.now(timezone.utc)
 
-    def _validate_status(self, category: MemoryCategory, status: str) -> None:
+    def validate_status(self, category: MemoryCategory, status: str) -> None:
         """
         Validate that status is valid for the given category.
 
@@ -139,7 +139,7 @@ class MemoryItemService:
             status = self.DEFAULT_STATUS[category]
 
         # Validate status
-        self._validate_status(category, status)
+        self.validate_status(category, status)
 
         # Check if item exists
         existing_item = await self.repo.get_by_user_category_key(user_id, category.value, key)
@@ -193,12 +193,12 @@ class MemoryItemService:
             Updated MemoryItemResponse
 
         Raises:
-            UserNotFoundError: If item not found
+            MemoryItemNotFoundError: If item not found
             ValueError: If user doesn't own item or status is invalid
         """
         item = await self.repo.get_by_id(item_id)
         if not item:
-            raise UserNotFoundError(f"Memory item with id {item_id} not found")
+            raise MemoryItemNotFoundError(f"Memory item with id {item_id} not found")
 
         if item.user_id != user_id:
             raise PermissionDeniedError("You don't have permission to update this item")
@@ -208,7 +208,7 @@ class MemoryItemService:
             category = MemoryCategory(item.category)
         except Exception as e:
             raise ValueError(f"Invalid category '{item.category}' on memory item {item.id}") from e
-        self._validate_status(category, new_status)
+        self.validate_status(category, new_status)
 
         # Update status
         old_status = item.status
@@ -233,13 +233,13 @@ class MemoryItemService:
             Updated MemoryItemResponse
 
         Raises:
-            UserNotFoundError: If item not found
+            MemoryItemNotFoundError: If item not found
             PermissionDeniedError: If user doesn't own item
             ValueError: If category is not area_to_improve or priority out of range
         """
         item = await self.repo.get_by_id(item_id)
         if not item:
-            raise UserNotFoundError(f"Memory item with id {item_id} not found")
+            raise MemoryItemNotFoundError(f"Memory item with id {item_id} not found")
 
         if item.user_id != user_id:
             raise PermissionDeniedError("You don't have permission to update this item")
@@ -267,12 +267,12 @@ class MemoryItemService:
             user_id: User ID (for authorization)
 
         Raises:
-            UserNotFoundError: If item not found
+            MemoryItemNotFoundError: If item not found
             ValueError: If user doesn't own item
         """
         item = await self.repo.get_by_id(item_id)
         if not item:
-            raise UserNotFoundError(f"Memory item with id {item_id} not found")
+            raise MemoryItemNotFoundError(f"Memory item with id {item_id} not found")
 
         if item.user_id != user_id:
             raise PermissionDeniedError("You don't have permission to delete this item")

--- a/tests/agents/specialists/test_memory_keeper.py
+++ b/tests/agents/specialists/test_memory_keeper.py
@@ -150,3 +150,8 @@ def test_memory_keeper_prompt_rejects_misspelled_word_pollution():
     assert "Treat spelling corrections, nonexistent-word feedback" in MEMORY_KEEPER_SYSTEM_PROMPT
     assert "Do not create `area_to_improve` items for misspelled" in MEMORY_KEEPER_SYSTEM_PROMPT
     assert "leave it to WordKeeper unless a recurring durable pattern is named" in MEMORY_KEEPER_SYSTEM_PROMPT
+
+
+def test_memory_keeper_prompt_excludes_broad_startup_compaction():
+    assert "Broad start-of-session consolidation, duplicate cleanup" in MEMORY_KEEPER_SYSTEM_PROMPT
+    assert "handled by a separate `memory_maintainer`" in MEMORY_KEEPER_SYSTEM_PROMPT

--- a/tests/agents/specialists/test_memory_maintainer.py
+++ b/tests/agents/specialists/test_memory_maintainer.py
@@ -1,0 +1,311 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage
+from sqlalchemy.exc import IntegrityError
+
+from runestone.agents.specialists.base import SpecialistContext
+from runestone.agents.specialists.memory_maintainer import MEMORY_MAINTAINER_SYSTEM_PROMPT, MemoryMaintainerSpecialist
+from runestone.agents.tools.memory_maintainer import (
+    _PENDING_MERGE_DELETIONS,
+    PendingMergePlan,
+    maintainer_delete_memory_item,
+    maintainer_insert_memory_item,
+    maintainer_update_memory_priority,
+)
+
+
+@pytest.fixture
+def mock_settings():
+    settings = MagicMock()
+    settings.memory_keeper_provider = "openrouter"
+    settings.memory_keeper_model = "test-model"
+    return settings
+
+
+@pytest.fixture
+def specialist(mock_settings):
+    with patch("runestone.agents.specialists.memory_maintainer.build_chat_model", return_value=MagicMock()) as build:
+        with patch("runestone.agents.specialists.memory_maintainer.create_agent"):
+            specialist = MemoryMaintainerSpecialist(mock_settings)
+            specialist.agent = AsyncMock()
+            specialist._build_chat_model_call = build.call_args
+            return specialist
+
+
+@pytest.fixture
+def mock_user():
+    user = MagicMock()
+    user.id = 1
+    return user
+
+
+@pytest.fixture(autouse=True)
+def clear_pending_merge_registry():
+    _PENDING_MERGE_DELETIONS.clear()
+    yield
+    _PENDING_MERGE_DELETIONS.clear()
+
+
+@pytest.mark.anyio
+async def test_memory_maintainer_returns_parsed_specialist_result(specialist, mock_user):
+    specialist.agent.ainvoke.return_value = {
+        "messages": [
+            AIMessage(
+                content=(
+                    '{"status":"action_taken","actions":[{"tool":"delete_memory_item","status":"success",'
+                    '"summary":"Deleted duplicates"}],'
+                    '"artifacts":{"maintenance_type":"chat_reset_memory_maintenance",'
+                    '"scope":{"category":"area_to_improve",'
+                    '"statuses":["struggling","improving"]},"reviewed_item_count":4,"merged_groups":[],'
+                    '"priority_updates":[],"summary":"merged","no_change_reason":null}}'
+                )
+            )
+        ]
+    }
+
+    result = await specialist.run(
+        SpecialistContext(
+            message="start_new_chat",
+            history=[],
+            user=mock_user,
+            routing_reason="new_chat_session_started",
+        )
+    )
+
+    assert result.status == "action_taken"
+    assert result.actions[0].tool == "delete_memory_item"
+    assert result.artifacts["maintenance_type"] == "chat_reset_memory_maintenance"
+
+
+@pytest.mark.anyio
+async def test_memory_maintainer_uses_chat_reset_prompt(specialist, mock_user):
+    specialist.agent.ainvoke.return_value = {
+        "messages": [
+            AIMessage(
+                content=(
+                    '{"status":"no_action","actions":[],'
+                    '"artifacts":{"maintenance_type":"chat_reset_memory_maintenance",'
+                    '"scope":{"category":"area_to_improve",'
+                    '"statuses":["struggling","improving"]},"reviewed_item_count":0,"merged_groups":[],'
+                    '"priority_updates":[],"summary":"noop","no_change_reason":"already clean"}}'
+                )
+            )
+        ]
+    }
+
+    await specialist.run(
+        SpecialistContext(
+            message="start_new_chat",
+            history=[],
+            user=mock_user,
+            routing_reason="new_chat_session_started",
+        )
+    )
+
+    args, kwargs = specialist.agent.ainvoke.call_args
+    assert args[0]["messages"][0].content == "Run the routine chat-reset memory maintenance check."
+    assert kwargs["context"].user == mock_user
+
+
+@pytest.mark.anyio
+async def test_memory_maintainer_returns_error_when_agent_output_is_invalid(specialist, mock_user):
+    specialist.agent.ainvoke.return_value = {"messages": [AIMessage(content="not json")]}
+
+    result = await specialist.run(
+        SpecialistContext(
+            message="start_new_chat",
+            history=[],
+            user=mock_user,
+            routing_reason="new_chat_session_started",
+        )
+    )
+
+    assert result.status == "error"
+    assert result.artifacts["summary"] == "invalid_agent_output"
+
+
+@pytest.mark.anyio
+async def test_memory_maintainer_clears_pending_merge_state_after_failed_run(specialist, mock_user):
+    _PENDING_MERGE_DELETIONS[mock_user.id] = PendingMergePlan(consolidated_item_id=10, remaining_delete_ids={4, 5})
+    specialist.agent.ainvoke.return_value = {"messages": [AIMessage(content="not json")]}
+
+    await specialist.run(
+        SpecialistContext(
+            message="start_new_chat",
+            history=[],
+            user=mock_user,
+            routing_reason="new_chat_session_started",
+        )
+    )
+
+    assert mock_user.id not in _PENDING_MERGE_DELETIONS
+
+
+@pytest.mark.anyio
+async def test_memory_maintainer_parses_fenced_json_output(specialist, mock_user):
+    specialist.agent.ainvoke.return_value = {
+        "messages": [
+            AIMessage(
+                content=(
+                    "```json\n"
+                    '{"status":"no_action","actions":[],'
+                    '"artifacts":{"maintenance_type":"chat_reset_memory_maintenance",'
+                    '"scope":{"category":"area_to_improve",'
+                    '"statuses":["struggling","improving"]},"reviewed_item_count":0,"merged_groups":[],'
+                    '"priority_updates":[],"summary":"noop","no_change_reason":"already clean"}}'
+                    "\n```"
+                )
+            )
+        ]
+    }
+
+    result = await specialist.run(
+        SpecialistContext(
+            message="start_new_chat",
+            history=[],
+            user=mock_user,
+            routing_reason="new_chat_session_started",
+        )
+    )
+
+    assert result.status == "no_action"
+    assert result.artifacts["no_change_reason"] == "already clean"
+
+
+def test_memory_maintainer_prompt_defines_expected_scope_and_tools():
+    assert "category `area_to_improve` with status" in MEMORY_MAINTAINER_SYSTEM_PROMPT
+    assert "`struggling` or `improving`" in MEMORY_MAINTAINER_SYSTEM_PROMPT
+    assert "- maintainer_delete_memory_item" in MEMORY_MAINTAINER_SYSTEM_PROMPT
+    assert "- maintainer_update_memory_priority" in MEMORY_MAINTAINER_SYSTEM_PROMPT
+    assert "key must be a new versioned key" in MEMORY_MAINTAINER_SYSTEM_PROMPT
+    assert "never reuse any original key from the merged items" in MEMORY_MAINTAINER_SYSTEM_PROMPT
+    assert "never delete that consolidated item id" in MEMORY_MAINTAINER_SYSTEM_PROMPT
+    assert "maintainer_insert_memory_item" in MEMORY_MAINTAINER_SYSTEM_PROMPT
+
+
+def test_memory_maintainer_builds_agent_with_expected_tools(mock_settings):
+    with patch("runestone.agents.specialists.memory_maintainer.build_chat_model", return_value=MagicMock()):
+        with patch("runestone.agents.specialists.memory_maintainer.create_agent") as create_agent_mock:
+            MemoryMaintainerSpecialist(mock_settings)
+
+    tool_names = [tool.name for tool in create_agent_mock.call_args.kwargs["tools"]]
+    assert tool_names == [
+        "maintainer_read_memory",
+        "maintainer_insert_memory_item",
+        "maintainer_delete_memory_item",
+        "maintainer_update_memory_priority",
+    ]
+
+
+@pytest.mark.anyio
+async def test_maintainer_delete_rejects_personal_info_item():
+    user = SimpleNamespace(id=42)
+    out_of_scope_item = SimpleNamespace(id=7, user_id=42, category="personal_info", status="active")
+    mock_service = MagicMock()
+    mock_service.repo.get_by_id = AsyncMock(return_value=out_of_scope_item)
+    mock_service.delete_item = AsyncMock()
+    _PENDING_MERGE_DELETIONS[user.id] = PendingMergePlan(consolidated_item_id=99, remaining_delete_ids={7})
+
+    with patch("runestone.agents.tools.memory_maintainer.provide_memory_item_service") as mock_provider:
+        mock_provider.return_value.__aenter__ = AsyncMock(return_value=mock_service)
+        mock_provider.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        runtime = SimpleNamespace(context=SimpleNamespace(user=user))
+        result = await maintainer_delete_memory_item.coroutine(runtime, delete=SimpleNamespace(item_id=7))
+
+    assert "out of memory maintainer scope" in result
+    mock_service.delete_item.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_maintainer_delete_requires_active_consolidation_ids():
+    user = SimpleNamespace(id=42)
+    runtime = SimpleNamespace(context=SimpleNamespace(user=user))
+
+    result = await maintainer_delete_memory_item.coroutine(runtime, delete=SimpleNamespace(item_id=7))
+
+    assert "Delete is only allowed for ids listed in replaced_item_ids" in result
+
+
+@pytest.mark.anyio
+async def test_maintainer_priority_update_rejects_mastered_item():
+    user = SimpleNamespace(id=42)
+    out_of_scope_item = SimpleNamespace(id=9, user_id=42, category="area_to_improve", status="mastered")
+    mock_service = MagicMock()
+    mock_service.repo.get_by_id = AsyncMock(return_value=out_of_scope_item)
+    mock_service.update_item_priority = AsyncMock()
+
+    with patch("runestone.agents.tools.memory_maintainer.provide_memory_item_service") as mock_provider:
+        mock_provider.return_value.__aenter__ = AsyncMock(return_value=mock_service)
+        mock_provider.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        runtime = SimpleNamespace(context=SimpleNamespace(user=user))
+        result = await maintainer_update_memory_priority.coroutine(
+            runtime,
+            update=SimpleNamespace(item_id=9, priority=1),
+        )
+
+    assert "out of memory maintainer scope" in result
+    mock_service.update_item_priority.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_maintainer_insert_rejects_duplicate_key_on_db_create():
+    user = SimpleNamespace(id=42)
+    mock_service = MagicMock()
+    duplicate_exc = IntegrityError("duplicate", params={}, orig=Exception("unique_violation"))
+    mock_service.repo.create = AsyncMock(side_effect=duplicate_exc)
+    mock_service.repo.rollback = AsyncMock()
+    mock_service.repo.db = SimpleNamespace(rollback=AsyncMock())
+    mock_service._validate_status = MagicMock()
+    mock_service._utc_now = MagicMock(return_value="now")
+
+    with patch("runestone.agents.tools.memory_maintainer.provide_memory_item_service") as mock_provider:
+        mock_provider.return_value.__aenter__ = AsyncMock(return_value=mock_service)
+        mock_provider.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        runtime = SimpleNamespace(context=SimpleNamespace(user=user))
+        item = SimpleNamespace(
+            category="area_to_improve",
+            key="word_order_v2",
+            content="Consolidated item",
+            status="struggling",
+            priority=2,
+            replaced_item_ids=[],
+        )
+        result = await maintainer_insert_memory_item.coroutine(runtime, item=item)
+
+    assert "Insert failed due to duplicate key" in result
+    mock_service.repo.db.rollback.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_maintainer_insert_rejects_cross_status_replacements():
+    user = SimpleNamespace(id=42)
+    item_1 = SimpleNamespace(id=1, user_id=42, category="area_to_improve", status="struggling")
+    item_2 = SimpleNamespace(id=2, user_id=42, category="area_to_improve", status="improving")
+    mock_service = MagicMock()
+    mock_service.repo.get_by_id = AsyncMock(side_effect=[item_1, item_2])
+    mock_service.repo.create = AsyncMock()
+    mock_service._validate_status = MagicMock()
+    mock_service._utc_now = MagicMock(return_value="now")
+
+    with patch("runestone.agents.tools.memory_maintainer.provide_memory_item_service") as mock_provider:
+        mock_provider.return_value.__aenter__ = AsyncMock(return_value=mock_service)
+        mock_provider.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        runtime = SimpleNamespace(context=SimpleNamespace(user=user))
+        item = SimpleNamespace(
+            category="area_to_improve",
+            key="word_order_v3",
+            content="Consolidated item",
+            status="struggling",
+            priority=2,
+            replaced_item_ids=[1, 2],
+        )
+        result = await maintainer_insert_memory_item.coroutine(runtime, item=item)
+
+    assert "Cross-status consolidation is not allowed" in result
+    mock_service.repo.create.assert_not_awaited()

--- a/tests/agents/specialists/test_memory_maintainer.py
+++ b/tests/agents/specialists/test_memory_maintainer.py
@@ -105,8 +105,44 @@ async def test_memory_maintainer_uses_chat_reset_prompt(specialist, mock_user):
     )
 
     args, kwargs = specialist.agent.ainvoke.call_args
-    assert args[0]["messages"][0].content == "Run the routine chat-reset memory maintenance check."
+    prompt = args[0]["messages"][0].content
+    assert prompt.startswith("Run the routine chat-reset memory maintenance check.")
+    assert "Use 'English' for memory item content." in prompt
+    assert "fall back to English content" in prompt
+    assert "Keep all memory item keys in English only." in prompt
     assert kwargs["context"].user == mock_user
+
+
+@pytest.mark.anyio
+async def test_memory_maintainer_uses_user_mother_tongue_in_prompt(specialist):
+    specialist.agent.ainvoke.return_value = {
+        "messages": [
+            AIMessage(
+                content=(
+                    '{"status":"no_action","actions":[],'
+                    '"artifacts":{"maintenance_type":"chat_reset_memory_maintenance",'
+                    '"scope":{"category":"area_to_improve",'
+                    '"statuses":["struggling","improving"]},"reviewed_item_count":0,"merged_groups":[],'
+                    '"priority_updates":[],"summary":"noop","no_change_reason":"already clean"}}'
+                )
+            )
+        ]
+    }
+
+    user = SimpleNamespace(id=7, mother_tongue="Finnish")
+    await specialist.run(
+        SpecialistContext(
+            message="start_new_chat",
+            history=[],
+            user=user,
+            routing_reason="new_chat_session_started",
+        )
+    )
+
+    args, _kwargs = specialist.agent.ainvoke.call_args
+    prompt = args[0]["messages"][0].content
+    assert "Use 'Finnish' for memory item content." in prompt
+    assert "Keep all memory item keys in English only." in prompt
 
 
 @pytest.mark.anyio
@@ -177,6 +213,12 @@ async def test_memory_maintainer_parses_fenced_json_output(specialist, mock_user
 def test_memory_maintainer_prompt_defines_expected_scope_and_tools():
     assert "category `area_to_improve` with status" in MEMORY_MAINTAINER_SYSTEM_PROMPT
     assert "`struggling` or `improving`" in MEMORY_MAINTAINER_SYSTEM_PROMPT
+    assert (
+        "The content target language is provided in the runtime instruction message." in MEMORY_MAINTAINER_SYSTEM_PROMPT
+    )
+    assert "Always keep memory item keys in English." in MEMORY_MAINTAINER_SYSTEM_PROMPT
+    assert "fall back to English" in MEMORY_MAINTAINER_SYSTEM_PROMPT
+    assert "Keep Swedish example words/phrases as-is" in MEMORY_MAINTAINER_SYSTEM_PROMPT
     assert "- maintainer_delete_memory_item" in MEMORY_MAINTAINER_SYSTEM_PROMPT
     assert "- maintainer_update_memory_priority" in MEMORY_MAINTAINER_SYSTEM_PROMPT
     assert "key must be a new versioned key" in MEMORY_MAINTAINER_SYSTEM_PROMPT

--- a/tests/agents/specialists/test_memory_maintainer.py
+++ b/tests/agents/specialists/test_memory_maintainer.py
@@ -287,7 +287,7 @@ async def test_maintainer_insert_rejects_cross_status_replacements():
     item_1 = SimpleNamespace(id=1, user_id=42, category="area_to_improve", status="struggling")
     item_2 = SimpleNamespace(id=2, user_id=42, category="area_to_improve", status="improving")
     mock_service = MagicMock()
-    mock_service.repo.get_by_id = AsyncMock(side_effect=[item_1, item_2])
+    mock_service.repo.get_by_ids = AsyncMock(return_value=[item_1, item_2])
     mock_service.repo.create = AsyncMock()
     mock_service._validate_status = MagicMock()
     mock_service._utc_now = MagicMock(return_value="now")

--- a/tests/agents/test_manager.py
+++ b/tests/agents/test_manager.py
@@ -190,6 +190,86 @@ async def test_process_turn_skips_stale_check_on_first_turn(
     manager.handle_stale_post_task.assert_not_awaited()
 
 
+@pytest.mark.anyio
+async def test_start_background_memory_maintenance_runs_specialist_and_clears_registry(mock_settings, mock_user):
+    manager = _make_manager(mock_settings)
+    manager.memory_maintainer.run = AsyncMock(
+        return_value=SpecialistResult(
+            status="no_action",
+            actions=[],
+            info_for_teacher="",
+            artifacts={},
+        )
+    )
+
+    scheduled = await manager.start_background_memory_maintenance(mock_user)
+
+    assert scheduled is True
+    task = manager._memory_maintenance_registry.tasks[str(mock_user.id)]
+    await task
+    manager.memory_maintainer.run.assert_awaited_once()
+    assert str(mock_user.id) not in manager._memory_maintenance_registry.tasks
+
+
+@pytest.mark.anyio
+async def test_start_background_memory_maintenance_skips_duplicate_run(mock_settings, mock_user):
+    manager = _make_manager(mock_settings)
+    gate = asyncio.Event()
+
+    async def _wait_for_gate(_context):
+        await gate.wait()
+        return SpecialistResult(status="no_action", actions=[], info_for_teacher="", artifacts={})
+
+    manager.memory_maintainer.run = AsyncMock(side_effect=_wait_for_gate)
+
+    first_scheduled = await manager.start_background_memory_maintenance(mock_user)
+    await asyncio.sleep(0)
+    second_scheduled = await manager.start_background_memory_maintenance(mock_user)
+
+    assert first_scheduled is True
+    assert second_scheduled is False
+    manager.memory_maintainer.run.assert_awaited_once()
+
+    gate.set()
+    task = manager._memory_maintenance_registry.tasks[str(mock_user.id)]
+    await task
+
+
+@pytest.mark.anyio
+async def test_start_background_memory_maintenance_clears_registry_on_failure(mock_settings, mock_user, caplog):
+    manager = _make_manager(mock_settings)
+    manager.memory_maintainer.run = AsyncMock(side_effect=RuntimeError("boom"))
+
+    await manager.start_background_memory_maintenance(mock_user)
+
+    task = manager._memory_maintenance_registry.tasks[str(mock_user.id)]
+    with caplog.at_level("ERROR"):
+        await task
+
+    assert str(mock_user.id) not in manager._memory_maintenance_registry.tasks
+    assert "Failed: user_id=1" in caplog.text
+
+
+@pytest.mark.anyio
+async def test_start_background_memory_maintenance_clears_registry_on_timeout(mock_settings, mock_user, caplog):
+    manager = _make_manager(mock_settings)
+    manager.MEMORY_MAINTENANCE_TIMEOUT_SECONDS = 0.01
+
+    async def _slow_run(_context):
+        await asyncio.sleep(0.05)
+        return SpecialistResult(status="no_action", actions=[], info_for_teacher="", artifacts={})
+
+    manager.memory_maintainer.run = AsyncMock(side_effect=_slow_run)
+
+    await manager.start_background_memory_maintenance(mock_user)
+    task = manager._memory_maintenance_registry.tasks[str(mock_user.id)]
+    with caplog.at_level("ERROR"):
+        await task
+
+    assert str(mock_user.id) not in manager._memory_maintenance_registry.tasks
+    assert "Timed out" in caplog.text
+
+
 # ---------------------------------------------------------------------------
 # prepare_pre_turn tests
 # ---------------------------------------------------------------------------

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -298,6 +298,7 @@ def mock_agent_service():
     mock = AsyncMock()
     mock.process_turn_result = ("Mock response", None, "neutral")
     mock.process_turn.side_effect = lambda **_kwargs: mock.process_turn_result
+    mock.start_background_memory_maintenance = AsyncMock(return_value=True)
     mock.cancel_post_task = Mock(return_value=False)
     return mock
 

--- a/tests/api/test_chat_endpoints.py
+++ b/tests/api/test_chat_endpoints.py
@@ -174,6 +174,7 @@ async def test_clear_history_rotates_chat_id(client_with_mock_agent_service, db_
     assert after_clear["chat_id"] != old_chat_id
     assert after_clear["latest_id"] == 0
     assert after_clear["messages"] == []
+    mock_agent_service.start_background_memory_maintenance.assert_awaited_once()
 
 
 async def test_send_message_requires_authentication(client):

--- a/tests/services/test_chat_service.py
+++ b/tests/services/test_chat_service.py
@@ -18,6 +18,7 @@ def mock_agent_service():
     mock = AsyncMock()
     mock.process_turn_result = ("Björn's reply", None, "neutral")
     mock.process_turn.side_effect = lambda **_kwargs: mock.process_turn_result
+    mock.start_background_memory_maintenance = AsyncMock(return_value=True)
     return mock
 
 
@@ -263,8 +264,20 @@ async def test_clear_history(chat_service, db_with_test_user):
     chat_id = str(uuid4())
     await chat_service.repository.add_message(user.id, chat_id, "user", "Test")
     chat_service.user_service.rotate_current_chat_id = AsyncMock(return_value=str(uuid4()))
+    chat_service.user_service.get_user_by_id = AsyncMock(return_value=user)
     await chat_service.clear_history(user.id)
     chat_service.user_service.rotate_current_chat_id.assert_awaited_once_with(user.id)
+    chat_service.agent_service.start_background_memory_maintenance.assert_awaited_once_with(user)
+
+
+@pytest.mark.anyio
+async def test_start_new_chat_skips_maintenance_when_user_missing(chat_service):
+    chat_service.user_service.rotate_current_chat_id = AsyncMock(return_value=str(uuid4()))
+    chat_service.user_service.get_user_by_id = AsyncMock(return_value=None)
+
+    await chat_service.start_new_chat(user_id=123)
+
+    chat_service.agent_service.start_background_memory_maintenance.assert_not_called()
 
 
 @pytest.mark.anyio

--- a/tests/services/test_memory_item_priority.py
+++ b/tests/services/test_memory_item_priority.py
@@ -305,10 +305,10 @@ async def test_update_item_priority_permission_denied(db_with_test_user):
 
 
 async def test_update_item_priority_not_found(db_with_test_user):
-    from runestone.core.exceptions import UserNotFoundError
+    from runestone.core.exceptions import MemoryItemNotFoundError
 
     db, user = db_with_test_user
     service = _service(db)
 
-    with pytest.raises(UserNotFoundError):
+    with pytest.raises(MemoryItemNotFoundError):
         await service.update_item_priority(99999, 1, user.id)


### PR DESCRIPTION
## Summary
- add a dedicated memory_maintainer specialist and maintainer-scoped tools for startup memory maintenance
- trigger maintenance as fire-and-forget from chat reset (start_new_chat) with per-user in-memory dedupe gating
- keep memory_keeper focused on per-turn updates and document the new responsibility split
- add structured logging for maintenance outcomes and failure/timeout handling
- add/adjust tests for maintainer specialist, manager scheduling/gating, chat service scheduling, and API wiring

## Dart Follow-up
- created follow-up ticket for accepted non-blocking hardening work: https://app.dartai.com/t/7J3ERe8Rl9Dp-Harden-memory-maintainer-again

## Validation
- make check-readiness
- independent review (gpt-5.5) run; accepted known tradeoffs documented

## Known Tradeoff (Accepted)
- consolidation merge is currently non-atomic (insert + delete steps), so partial failure can temporarily leave overlap until a later maintenance run
