### PR TITLE
feat: refresh analyzer page UI for desktop and mobile

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import App from './App';
 import { AuthProvider } from './context/AuthContext';
@@ -68,7 +68,7 @@ describe('App', () => {
 
     expect(screen.getByText('Analyze Your Swedish Textbook Page')).toBeInTheDocument();
     expect(screen.getByText('Upload an image to get an instant analysis of the text, grammar, and vocabulary.')).toBeInTheDocument();
-    expect(screen.getByText('Drag & drop a file or click to upload')).toBeInTheDocument();
+    expect(screen.getByText('Drag and drop an image here')).toBeInTheDocument();
   });
 
   it('handles file selection and calls processImage', async () => {
@@ -89,12 +89,13 @@ describe('App', () => {
     expect(document.querySelector('header')).toBeInTheDocument();
   });
 
-  it('should call only recognizeImage when "Recognize only" is checked', async () => {
+  it('should call only recognizeImage when analysis mode is set to OCR only', async () => {
     mockRecognizeImage.mockResolvedValue({ text: 'OCR Text', character_count: 8 });
     render(<App />, { wrapper });
 
-    const recognizeOnlyCheckbox = screen.getByLabelText('Recognize only');
-    await userEvent.click(recognizeOnlyCheckbox);
+    const modeSelector = screen.getByRole('combobox');
+    fireEvent.mouseDown(modeSelector);
+    await userEvent.click(screen.getByRole('option', { name: 'OCR only' }));
 
     const file = new File(['test'], 'test.jpg', { type: 'image/jpeg' });
     const input = document.querySelector('input[type="file"]') as HTMLInputElement;
@@ -105,13 +106,9 @@ describe('App', () => {
     });
   });
 
-  it('should call both recognizeImage and analyzeText when "Recognize only" is unchecked', async () => {
+  it('should call both recognizeImage and analyzeText when full analysis mode is selected', async () => {
     mockRecognizeImage.mockResolvedValue({ text: 'OCR Text', character_count: 8 });
     render(<App />, { wrapper });
-
-    // Ensure checkbox is unchecked (default state)
-    const recognizeOnlyCheckbox = screen.getByLabelText('Recognize only');
-    expect(recognizeOnlyCheckbox).not.toBeChecked();
 
     const file = new File(['test'], 'test.jpg', { type: 'image/jpeg' });
     const input = document.querySelector('input[type="file"]') as HTMLInputElement;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,6 @@ import Register from "./components/auth/Register";
 import Profile from "./components/auth/Profile";
 import useImageProcessing from "./hooks/useImageProcessing";
 import { useState, useEffect } from "react";
-import StyledCheckbox from "./components/ui/StyledCheckbox";
 import { CustomButton } from "./components/ui";
 import { BrainCircuit } from "lucide-react";
 import { Box } from "@mui/material";
@@ -47,6 +46,7 @@ function getInitialView(): ViewType {
 function App() {
   const [currentView, setCurrentView] = useState<ViewType>(getInitialView);
   const [recognizeOnly, setRecognizeOnly] = useState(false);
+  const [lastSelectedFile, setLastSelectedFile] = useState<File | null>(null);
   const [authView, setAuthView] = useState<AuthView>("login");
   const { isAuthenticated } = useAuth();
 
@@ -63,6 +63,7 @@ function App() {
   } = useImageProcessing();
 
   const handleFileSelect = async (file: File) => {
+    setLastSelectedFile(file);
     await processImage(file, recognizeOnly);
   };
 
@@ -74,6 +75,9 @@ function App() {
 
   const isAnalyzeButtonDisabled =
     processingStep === "ANALYZING";
+  const hasAnalyzerContent = Boolean(
+    ocrResult || analysisResult || error || isProcessing
+  );
 
   // Persist view changes to localStorage
   useEffect(() => {
@@ -112,7 +116,7 @@ function App() {
   }
 
   return (
-    <div className="bg-[#1a102b] min-h-screen">
+    <div className="min-h-screen bg-[#060b26]">
       <div className="layout-container flex h-full grow flex-col">
         <Header currentView={currentView} onViewChange={setCurrentView} />
         <main className={`flex flex-1 justify-center ${currentView === "chat" ? "" : "py-4 px-2 sm:py-12 sm:px-6 lg:px-8"}`}>
@@ -121,55 +125,87 @@ function App() {
           >
             {currentView === "analyzer" ? (
               <>
-                <div className="text-center">
-                  <h2 className="text-4xl font-bold text-white tracking-tight sm:text-5xl">
+                <div className="space-y-3 text-left">
+                  <h2 className="text-4xl font-bold tracking-tight text-slate-100 sm:text-5xl">
                     Analyze Your Swedish Textbook Page
                   </h2>
-                  <p className="mt-4 text-lg leading-8 text-gray-300">
+                  <p className="max-w-3xl text-lg leading-8 text-slate-300">
                     Upload an image to get an instant analysis of the text,
                     grammar, and vocabulary.
                   </p>
                 </div>
 
-                <FileUpload
-                  onFileSelect={handleFileSelect}
-                  isProcessing={isProcessing}
-                />
-                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                  <StyledCheckbox
-                    label="Recognize only"
-                    checked={recognizeOnly}
-                    onChange={(checked: boolean) => setRecognizeOnly(checked)}
-                  />
-                  {recognizeOnly && ocrResult && (
-                    <CustomButton
-                      onClick={handleAnalyzeOcrText}
-                      disabled={isAnalyzeButtonDisabled}
+                {!hasAnalyzerContent ? (
+                  <div className="grid gap-4 lg:grid-cols-[360px_minmax(0,1fr)]">
+                    <FileUpload
+                      onFileSelect={handleFileSelect}
+                      isProcessing={isProcessing}
+                      recognizeOnly={recognizeOnly}
+                      onRecognizeOnlyChange={setRecognizeOnly}
+                      selectedFileOverride={lastSelectedFile}
+                    />
+                    <Box
                       sx={{
-                        minWidth: 0,
-                        padding: "4px 8px",
-                        fontSize: "0.75rem",
+                        display: { xs: "none", lg: "flex" },
+                        minHeight: "420px",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        borderRadius: "0.75rem",
+                        border: "1px solid rgba(99, 114, 173, 0.35)",
+                        background:
+                          "radial-gradient(circle at 20% 20%, rgba(32, 40, 95, 0.55), rgba(8, 11, 39, 0.94))",
+                        color: "#c2cee8",
+                        textAlign: "center",
+                        px: 4,
                       }}
-                      aria-label="Analyze"
                     >
-                      <BrainCircuit size={16} />
-                    </CustomButton>
-                  )}
-                </Box>
-
-                {(ocrResult ||
-                  analysisResult ||
-                  error ||
-                  isProcessing) && (
-                  <ResultsDisplay
-                    ocrResult={ocrResult}
-                    analysisResult={analysisResult}
-                    error={error}
-                    saveVocabulary={saveVocabulary}
-                    onVocabularyUpdated={onVocabularyUpdated}
-                    processingStep={processingStep}
-                    isProcessing={isProcessing}
-                  />
+                      <div className="space-y-4">
+                        <div className="text-4xl text-slate-500">⌁</div>
+                        <h3 className="text-4xl font-semibold text-slate-100">
+                          No analysis yet
+                        </h3>
+                        <p className="max-w-md text-lg text-slate-300">
+                          Upload an image of a Swedish textbook page to get
+                          started.
+                        </p>
+                      </div>
+                    </Box>
+                  </div>
+                ) : (
+                  <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
+                    <div className="lg:w-[300px] lg:shrink-0">
+                      <FileUpload
+                        onFileSelect={handleFileSelect}
+                        isProcessing={isProcessing}
+                        recognizeOnly={recognizeOnly}
+                        onRecognizeOnlyChange={setRecognizeOnly}
+                        selectedFileOverride={lastSelectedFile}
+                        compact
+                      />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      {recognizeOnly && ocrResult && !analysisResult && (
+                        <Box sx={{ mb: 2 }}>
+                          <CustomButton
+                            onClick={handleAnalyzeOcrText}
+                            disabled={isAnalyzeButtonDisabled}
+                            startIcon={<BrainCircuit size={16} />}
+                          >
+                            Analyze OCR Text
+                          </CustomButton>
+                        </Box>
+                      )}
+                      <ResultsDisplay
+                        ocrResult={ocrResult}
+                        analysisResult={analysisResult}
+                        error={error}
+                        saveVocabulary={saveVocabulary}
+                        onVocabularyUpdated={onVocabularyUpdated}
+                        processingStep={processingStep}
+                        isProcessing={isProcessing}
+                      />
+                    </div>
+                  </div>
                 )}
               </>
             ) : currentView === "vocabulary" ? (

--- a/frontend/src/components/FileUpload.test.tsx
+++ b/frontend/src/components/FileUpload.test.tsx
@@ -13,14 +13,14 @@ describe('FileUpload', () => {
   it('renders the file upload component', () => {
     render(<FileUpload onFileSelect={mockOnFileSelect} isProcessing={false} />);
 
-    expect(screen.getByText('Drag & drop a file or click to upload')).toBeInTheDocument();
-    expect(screen.getByText('Browse Files')).toBeInTheDocument();
+    expect(screen.getByText('Drag and drop an image here')).toBeInTheDocument();
+    expect(screen.getByText('Choose File')).toBeInTheDocument();
   });
 
   it('handles drag events', async () => {
     render(<FileUpload onFileSelect={mockOnFileSelect} isProcessing={false} />);
 
-    const dropzone = screen.getByText('Drag & drop a file or click to upload').closest('div');
+    const dropzone = screen.getByText('Drag and drop an image here').closest('div');
     act(() => {
       fireEvent.dragEnter(dropzone!);
     });
@@ -97,7 +97,7 @@ describe('FileUpload', () => {
 
     // Click again to zoom out
     fireEvent.click(previewImage);
-    expect(previewImage).toHaveClass('max-h-96');
+    expect(previewImage).toHaveClass('max-h-72');
   });
 
   it('cleans up object URL on unmount', async () => {

--- a/frontend/src/components/FileUpload.tsx
+++ b/frontend/src/components/FileUpload.tsx
@@ -39,10 +39,6 @@ const FileUpload: React.FC<FileUploadProps> = ({
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const applySelectedFile = (file: File) => {
-    if (previewUrl && typeof URL !== "undefined" && URL.revokeObjectURL) {
-      URL.revokeObjectURL(previewUrl);
-    }
-
     setSelectedFile(file);
     setPreviewUrl(URL.createObjectURL(file));
   };
@@ -66,15 +62,11 @@ const FileUpload: React.FC<FileUploadProps> = ({
   }, [previewUrl]);
 
   useEffect(() => {
-    if (!selectedFileOverride) return;
-    if (selectedFileOverride === selectedFile) return;
-
-    if (previewUrl && typeof URL !== "undefined" && URL.revokeObjectURL) {
-      URL.revokeObjectURL(previewUrl);
+    if (selectedFileOverride && selectedFileOverride !== selectedFile) {
+      setSelectedFile(selectedFileOverride);
+      setPreviewUrl(URL.createObjectURL(selectedFileOverride));
     }
-    setSelectedFile(selectedFileOverride);
-    setPreviewUrl(URL.createObjectURL(selectedFileOverride));
-  }, [selectedFileOverride, selectedFile, previewUrl]);
+  }, [selectedFileOverride, selectedFile]);
 
   const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files[0]) {

--- a/frontend/src/components/FileUpload.tsx
+++ b/frontend/src/components/FileUpload.tsx
@@ -1,30 +1,60 @@
-import React, { useState, useRef, useEffect } from "react";
-import { Box, Typography } from "@mui/material";
-import { Upload } from "lucide-react";
+import React, { useEffect, useRef, useState } from "react";
+import {
+  Box,
+  FormControl,
+  MenuItem,
+  Select,
+  type SelectChangeEvent,
+  Typography,
+} from "@mui/material";
+import {
+  CloudUpload,
+  LockKeyhole,
+  RefreshCw,
+  Replace,
+} from "lucide-react";
 import { CustomButton } from "./ui";
 
 interface FileUploadProps {
   onFileSelect: (file: File) => void;
   isProcessing: boolean;
+  recognizeOnly?: boolean;
+  onRecognizeOnlyChange?: (recognizeOnly: boolean) => void;
+  compact?: boolean;
+  selectedFileOverride?: File | null;
 }
 
 const FileUpload: React.FC<FileUploadProps> = ({
   onFileSelect,
   isProcessing,
+  recognizeOnly = false,
+  onRecognizeOnlyChange,
+  compact = false,
+  selectedFileOverride = null,
 }) => {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [isZoomed, setIsZoomed] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const handleFileSelect = (file: File) => {
-    if (file.type.startsWith("image/")) {
-      setSelectedFile(file);
-      setPreviewUrl(URL.createObjectURL(file));
-      onFileSelect(file);
-    } else {
-      alert("Please select an image file");
+  const applySelectedFile = (file: File) => {
+    if (previewUrl && typeof URL !== "undefined" && URL.revokeObjectURL) {
+      URL.revokeObjectURL(previewUrl);
     }
+
+    setSelectedFile(file);
+    setPreviewUrl(URL.createObjectURL(file));
+  };
+
+  const handleFileSelect = (file: File) => {
+    if (!file.type.startsWith("image/")) {
+      alert("Please select an image file");
+      return;
+    }
+
+    applySelectedFile(file);
+    onFileSelect(file);
   };
 
   useEffect(() => {
@@ -35,113 +65,310 @@ const FileUpload: React.FC<FileUploadProps> = ({
     };
   }, [previewUrl]);
 
+  useEffect(() => {
+    if (!selectedFileOverride) return;
+    if (selectedFileOverride === selectedFile) return;
+
+    if (previewUrl && typeof URL !== "undefined" && URL.revokeObjectURL) {
+      URL.revokeObjectURL(previewUrl);
+    }
+    setSelectedFile(selectedFileOverride);
+    setPreviewUrl(URL.createObjectURL(selectedFileOverride));
+  }, [selectedFileOverride, selectedFile, previewUrl]);
+
   const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files[0]) {
       handleFileSelect(e.target.files[0]);
     }
   };
 
-  const handleButtonClick = () => {
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragging(false);
+    if (isProcessing) return;
+    if (e.dataTransfer.files && e.dataTransfer.files[0]) {
+      handleFileSelect(e.dataTransfer.files[0]);
+    }
+  };
+
+  const handleModeChange = (event: SelectChangeEvent) => {
+    const mode = event.target.value;
+    onRecognizeOnlyChange?.(mode === "ocr");
+  };
+
+  const triggerFilePicker = () => {
     fileInputRef.current?.click();
   };
+
+  const triggerReanalyze = () => {
+    if (selectedFile && !isProcessing) {
+      onFileSelect(selectedFile);
+    }
+  };
+
+  const modeDescription = recognizeOnly
+    ? "OCR-only extracts text and lets you analyze later."
+    : "Full analysis extracts text, identifies grammar points, and builds vocabulary.";
+
+  if (compact) {
+    return (
+      <Box
+        sx={{
+          borderRadius: "0.75rem",
+          border: "1px solid rgba(99, 114, 173, 0.35)",
+          background:
+            "radial-gradient(circle at 8% 8%, rgba(38, 49, 113, 0.42), rgba(7, 12, 44, 0.96))",
+          p: 2,
+        }}
+      >
+        <Box sx={{ display: "flex", gap: 1.5, alignItems: "center" }}>
+          <Box
+            sx={{
+              width: 92,
+              height: 92,
+              borderRadius: "0.5rem",
+              border: "1px solid rgba(140, 160, 220, 0.35)",
+              overflow: "hidden",
+              flexShrink: 0,
+              bgcolor: "rgba(18, 24, 64, 0.75)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            {previewUrl ? (
+              <img
+                src={previewUrl}
+                alt="Preview"
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <CloudUpload size={26} color="#6d87cf" />
+            )}
+          </Box>
+          <Box sx={{ minWidth: 0 }}>
+            <Typography
+              sx={{
+                color: "#f0f4ff",
+                fontWeight: 700,
+                lineHeight: 1.3,
+                wordBreak: "break-word",
+              }}
+            >
+              {selectedFile?.name ?? "No file selected"}
+            </Typography>
+            <Typography sx={{ color: "#8ea0d0", mt: 0.6, fontSize: "0.9rem" }}>
+              {selectedFile ? "Uploaded" : "Upload a textbook page"}
+            </Typography>
+          </Box>
+        </Box>
+
+        <Box sx={{ mt: 2 }}>
+          <Typography sx={{ color: "#9fb0de", mb: 0.75, fontSize: "0.85rem" }}>
+            Analysis mode
+          </Typography>
+          <FormControl fullWidth>
+            <Select
+              value={recognizeOnly ? "ocr" : "full"}
+              onChange={handleModeChange}
+              size="small"
+              disabled={isProcessing}
+              sx={{
+                bgcolor: "rgba(9, 14, 48, 0.85)",
+                color: "#eef4ff",
+                borderRadius: "0.5rem",
+                "& .MuiOutlinedInput-notchedOutline": {
+                  borderColor: "rgba(111, 133, 192, 0.5)",
+                },
+                "& .MuiSvgIcon-root": {
+                  color: "#9fc0ff",
+                },
+              }}
+            >
+              <MenuItem value="full">Full analysis</MenuItem>
+              <MenuItem value="ocr">OCR only</MenuItem>
+            </Select>
+          </FormControl>
+        </Box>
+
+        <Box sx={{ mt: 2, display: "flex", gap: 1.5 }}>
+          <CustomButton
+            variant="secondary"
+            onClick={triggerFilePicker}
+            disabled={isProcessing}
+            startIcon={<Replace size={16} />}
+            sx={{
+              flex: 1,
+              color: "#d8e2ff",
+              border: "1px solid rgba(127, 148, 205, 0.6)",
+              borderRadius: "0.5rem",
+              "&:hover": {
+                backgroundColor: "rgba(65, 84, 142, 0.22)",
+              },
+            }}
+          >
+            Replace File
+          </CustomButton>
+          <CustomButton
+            onClick={triggerReanalyze}
+            disabled={isProcessing || !selectedFile}
+            startIcon={<RefreshCw size={16} />}
+            sx={{ flex: 1 }}
+          >
+            Re-analyze
+          </CustomButton>
+        </Box>
+
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          onChange={handleFileInputChange}
+          style={{ display: "none" }}
+          disabled={isProcessing}
+        />
+      </Box>
+    );
+  }
 
   return (
     <Box
       sx={{
-        border: "2px dashed #4d3c63",
-        borderRadius: "0.5rem",
-        p: 12,
-        textAlign: "center",
-        transition: "border-color 0.3s",
-        minHeight: "400px",
-        display: "flex",
-        flexDirection: "column",
-        "&:hover": {
-          borderColor: "var(--primary-color)",
-        },
+        borderRadius: "0.75rem",
+        border: "1px solid rgba(99, 114, 173, 0.35)",
+        background:
+          "radial-gradient(circle at 10% 8%, rgba(35, 50, 116, 0.38), rgba(7, 11, 39, 0.96))",
+        p: { xs: 2, sm: 3 },
       }}
     >
-      {selectedFile && previewUrl ? (
-        <Box
+      <Box
+        sx={{
+          border: "1px dashed rgba(111, 133, 192, 0.48)",
+          borderRadius: "0.75rem",
+          px: 2.5,
+          py: 4,
+          textAlign: "center",
+          transition: "all 0.2s ease",
+          bgcolor: isDragging ? "rgba(31, 56, 122, 0.45)" : "transparent",
+        }}
+        onDragOver={(e) => {
+          e.preventDefault();
+          setIsDragging(true);
+        }}
+        onDragLeave={() => setIsDragging(false)}
+        onDrop={handleDrop}
+      >
+        {previewUrl ? (
+          <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+            <img
+              src={previewUrl}
+              alt="Preview"
+              className={`max-w-full object-contain rounded-lg cursor-pointer transition-all duration-300 ${
+                isZoomed ? "max-h-screen" : "max-h-72"
+              }`}
+              onClick={() => setIsZoomed((prev) => !prev)}
+            />
+            <Typography
+              sx={{
+                mt: 1.5,
+                color: "#ecf2ff",
+                fontWeight: 700,
+                wordBreak: "break-word",
+              }}
+            >
+              {selectedFile?.name}
+            </Typography>
+          </Box>
+        ) : (
+          <>
+            <CloudUpload size={52} color="#31df85" />
+            <Typography
+              sx={{
+                mt: 2,
+                color: "#ecf2ff",
+                fontWeight: 600,
+                fontSize: "1.15rem",
+              }}
+            >
+              Drag and drop an image here
+            </Typography>
+            <Typography sx={{ mt: 0.8, color: "#96a6cf" }}>or</Typography>
+          </>
+        )}
+
+        <CustomButton
+          onClick={triggerFilePicker}
+          disabled={isProcessing}
           sx={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-            flex: 1,
-            width: "100%",
+            mt: 2,
+            minWidth: 150,
+            height: "2.8rem",
+            fontSize: "1rem",
           }}
         >
-          <img
-            src={previewUrl}
-            alt="Preview"
-            className={`max-w-full object-contain rounded-lg cursor-pointer transition-all duration-300 ${
-              isZoomed ? "max-h-screen" : "max-h-96"
-            }`}
-            onClick={() => setIsZoomed(!isZoomed)}
-          />
-          <Typography
-            variant="body1"
+          Choose File
+        </CustomButton>
+      </Box>
+
+      <Box sx={{ mt: 2 }}>
+        <Typography sx={{ color: "#9fb0de", mb: 0.75, fontSize: "0.85rem" }}>
+          Analysis mode
+        </Typography>
+        <FormControl fullWidth>
+          <Select
+            value={recognizeOnly ? "ocr" : "full"}
+            onChange={handleModeChange}
+            size="small"
+            disabled={isProcessing}
             sx={{
-              mt: 4,
-              fontSize: "1.125rem",
-              fontWeight: 600,
-              color: "white",
-              textAlign: "center",
+              bgcolor: "rgba(9, 14, 48, 0.85)",
+              color: "#eef4ff",
+              borderRadius: "0.5rem",
+              "& .MuiOutlinedInput-notchedOutline": {
+                borderColor: "rgba(111, 133, 192, 0.5)",
+              },
+              "& .MuiSvgIcon-root": {
+                color: "#9fc0ff",
+              },
             }}
           >
-            {selectedFile.name}
-          </Typography>
-        </Box>
-      ) : (
-        <>
-          <Box
-            sx={{
-              display: "flex",
-              justifyContent: "center",
-              mb: 2,
-            }}
-          >
-            <Upload
-              size={64}
-              color="#6b7280"
-            />
-          </Box>
-          <Typography
-            variant="body1"
-            sx={{
-              fontSize: "1.125rem",
-              fontWeight: 600,
-              color: "white",
-              mb: 2,
-            }}
-          >
-            Drag & drop a file or click to upload
-          </Typography>
-          <Typography
-            variant="body2"
-            sx={{
-              color: "#9ca3af",
-              mb: 2,
-            }}
-          >
-            PNG, JPG, or GIF up to 10MB
-          </Typography>
-        </>
-      )}
+            <MenuItem value="full">Full analysis</MenuItem>
+            <MenuItem value="ocr">OCR only</MenuItem>
+          </Select>
+        </FormControl>
+
+        <Typography sx={{ mt: 1, color: "#95a7d5", fontSize: "0.92rem" }}>
+          {modeDescription}
+        </Typography>
+      </Box>
+
       <CustomButton
-        onClick={handleButtonClick}
-        disabled={isProcessing}
+        onClick={triggerReanalyze}
+        disabled={isProcessing || !selectedFile}
+        startIcon={<RefreshCw size={16} />}
+        fullWidth
+        sx={{ mt: 2, height: "2.9rem", fontSize: "1.05rem", fontWeight: 600 }}
+      >
+        Analyze Page
+      </CustomButton>
+
+      <Box
         sx={{
-          mt: 2,
-          alignSelf: "center",
-          width: "auto",
-          maxWidth: "200px",
-          height: "2rem",
+          mt: 2.5,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 0.75,
+          color: "#8ea0d1",
+          textAlign: "center",
+          fontSize: "0.9rem",
+          px: 1,
         }}
       >
-        Browse Files
-      </CustomButton>
+        <LockKeyhole size={14} />
+        <span>Your files are processed securely and never stored permanently.</span>
+      </Box>
+
       <input
         ref={fileInputRef}
         type="file"

--- a/frontend/src/components/ResultsDisplay.test.tsx
+++ b/frontend/src/components/ResultsDisplay.test.tsx
@@ -48,6 +48,17 @@ const mockAnalysisResult = {
   core_topics: [],
 };
 
+const createMatchMedia = (matches: boolean) => (query: string) => ({
+  matches,
+  media: query,
+  onchange: null,
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+});
+
 
 describe("ResultsDisplay", () => {
   it("renders error state when error is provided and no results", () => {
@@ -819,6 +830,59 @@ describe("ResultsDisplay", () => {
     });
   });
 
+  it("shows mobile vocabulary select-all and applies it to visible words only", async () => {
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation(createMatchMedia(true)),
+    });
+
+    const mockClipboard = {
+      writeText: vi.fn().mockResolvedValue(undefined),
+    };
+    Object.assign(navigator, { clipboard: mockClipboard });
+
+    try {
+      render(
+        <ResultsDisplay
+          ocrResult={mockOcrResult}
+          analysisResult={mockAnalysisResult}
+          error={null}
+          saveVocabulary={vi.fn()}
+          processingStep="IDLE"
+          isProcessing={false}
+        />
+      );
+
+      const vocabularyTab = screen.getByText("Vocabulary");
+      fireEvent.click(vocabularyTab);
+
+      const hideKnownCheckbox = document.getElementById(
+        "hide-known-words-checkbox"
+      );
+      fireEvent.click(hideKnownCheckbox!);
+
+      const masterCheckbox = document.getElementById(
+        "vocabulary-master-checkbox"
+      );
+      expect(masterCheckbox).toBeInTheDocument();
+
+      fireEvent.click(masterCheckbox!);
+      fireEvent.click(screen.getByText("Copy"));
+
+      await waitFor(() => {
+        expect(mockClipboard.writeText).toHaveBeenCalledWith(
+          "hej - hello\nhus - house"
+        );
+      });
+    } finally {
+      Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        value: originalMatchMedia,
+      });
+    }
+  });
+
   describe("UUID Generation", () => {
     it("should generate UUIDs for vocabulary items without IDs", () => {
       const mockVocabulary = [
@@ -1088,6 +1152,26 @@ describe("ResultsDisplay", () => {
       // The actual text depends on ProcessingStatus implementation
       // We just verify the component renders when isProcessing is true
       expect(screen.queryByText("Analysis")).not.toBeInTheDocument();
+    });
+
+    it("does not show mobile tap-for-details helper text", () => {
+      render(
+        <ResultsDisplay
+          ocrResult={mockOcrResult}
+          analysisResult={mockAnalysisResult}
+          error={null}
+          saveVocabulary={vi.fn()}
+          processingStep="IDLE"
+          isProcessing={false}
+        />
+      );
+
+      const vocabularyTab = screen.getByText("Vocabulary");
+      fireEvent.click(vocabularyTab);
+
+      expect(
+        screen.queryByText("Tap a row to see more details and examples.")
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/ResultsDisplay.tsx
+++ b/frontend/src/components/ResultsDisplay.tsx
@@ -1,5 +1,11 @@
 import React, { useState, useEffect, useMemo } from "react";
-import { Box, Typography, Snackbar, Alert, IconButton } from "@mui/material";
+import {
+  Box,
+  Typography,
+  Snackbar,
+  Alert,
+  IconButton,
+} from "@mui/material";
 import type { AlertColor } from "@mui/material";
 import { Copy, Save } from "lucide-react";
 import { ContentCopy } from "@mui/icons-material";
@@ -283,7 +289,14 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
   ].filter(Boolean) as { id: string; label: string }[];
 
   return (
-    <Box sx={{ py: 8 }}>
+    <Box
+      sx={{
+        borderRadius: "0.8rem",
+        border: "1px solid rgba(99, 114, 173, 0.35)",
+        background:
+          "radial-gradient(circle at 14% 10%, rgba(34, 48, 112, 0.36), rgba(6, 11, 42, 0.96))",
+      }}
+    >
       {isProcessing && (
         <ProcessingStatus
           isProcessing={isProcessing}
@@ -301,9 +314,12 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
         tabs={tabs}
         activeTab={activeTab}
         onTabChange={setActiveTab}
+        containerSx={{ px: { xs: 1.5, md: 2.5 }, borderColor: "rgba(106, 120, 178, 0.4)" }}
+        tabsSx={{ gap: { xs: 1, md: 4 } }}
+        buttonSx={{ px: { xs: 1.2, md: 2 }, py: 1.1, fontSize: { xs: "1rem", md: "1.05rem" } }}
       />
 
-      <Box sx={{ pt: 6 }}>
+      <Box sx={{ px: { xs: 1.5, md: 2.5 }, pt: 2.5, pb: 2.5 }}>
         {activeTab === "ocr" && (
           <Box>
             {ocrResult && (
@@ -416,8 +432,10 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
               sx={{
                 display: "flex",
                 justifyContent: "space-between",
-                alignItems: "center",
-                mb: 4,
+                alignItems: "flex-start",
+                gap: 2,
+                flexDirection: { xs: "column", md: "row" },
+                mb: 2.2,
               }}
             >
               <SectionTitle>Vocabulary Analysis</SectionTitle>
@@ -426,15 +444,17 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
                   sx={{
                     display: "flex",
                     flexDirection: "column",
-                    alignItems: "flex-end",
-                    gap: 1,
+                    alignItems: { xs: "stretch", md: "flex-end" },
+                    gap: 1.2,
+                    width: { xs: "100%", md: "auto" },
                   }}
                 >
-                  <Box sx={{ display: "flex", gap: 2 }}>
+                  <Box sx={{ display: "flex", gap: 1.2, flexWrap: "wrap" }}>
                     <CustomButton
                       variant="primary"
                       onClick={handleSaveVocabulary}
                       startIcon={<Save size={16} />}
+                      sx={{ minWidth: { xs: "100%", md: 0 } }}
                     >
                       Save to Database
                     </CustomButton>
@@ -442,6 +462,7 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
                       variant="primary"
                       onClick={handleCopyVocabulary}
                       startIcon={<Copy size={16} />}
+                      sx={{ minWidth: { xs: "100%", md: 0 } }}
                     >
                       Copy
                     </CustomButton>
@@ -449,9 +470,8 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
                   <Box
                     sx={{
                       display: "flex",
-                      alignItems: "center",
+                      alignItems: "flex-start",
                       gap: 1,
-                      mt: 2,
                     }}
                   >
                     <StyledCheckbox
@@ -463,13 +483,11 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
                       Enrich with grammar info
                     </Typography>
                   </Box>
-                  {/* New checkbox for hiding known words */}
                   <Box
                     sx={{
                       display: "flex",
-                      alignItems: "center",
+                      alignItems: "flex-start",
                       gap: 1,
-                      mt: 1,
                     }}
                   >
                     <StyledCheckbox
@@ -503,6 +521,7 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
                     },
                   ]}
                   data={filteredVocabulary}
+                  mobileVariant="vocabulary"
                 />
               </Box>
             )}

--- a/frontend/src/components/ResultsDisplay.tsx
+++ b/frontend/src/components/ResultsDisplay.tsx
@@ -521,7 +521,57 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
                     },
                   ]}
                   data={filteredVocabulary}
-                  mobileVariant="vocabulary"
+                  renderMobileRow={(row, _index, checkbox) => (
+                    <Box
+                      key={row.id}
+                      sx={{
+                        backgroundColor: "rgba(34, 44, 95, 0.7)",
+                        border: "1px solid rgba(106, 121, 181, 0.5)",
+                        borderRadius: "0.65rem",
+                        p: 1.4,
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 1.5,
+                      }}
+                    >
+                      {checkbox}
+                      <Box sx={{ minWidth: 0, flex: "0 0 30%" }}>
+                        <Typography
+                          sx={{
+                            color: "#f4f7ff",
+                            fontWeight: 700,
+                            lineHeight: 1.25,
+                            fontSize: "1.05rem",
+                            wordBreak: "break-word",
+                          }}
+                        >
+                          {String(row.swedish || "—")}
+                        </Typography>
+                        <Typography
+                          sx={{
+                            color: "#adbce4",
+                            fontSize: "0.95rem",
+                            lineHeight: 1.2,
+                            mt: 0.25,
+                          }}
+                        >
+                          {String(row.english || "—")}
+                        </Typography>
+                      </Box>
+                      <Typography
+                        sx={{
+                          color: "#d0d9ef",
+                          flex: 1,
+                          fontSize: "1rem",
+                          lineHeight: 1.3,
+                          whiteSpace: "normal",
+                          wordBreak: "break-word",
+                        }}
+                      >
+                        {String(row.example_phrase || "—")}
+                      </Typography>
+                    </Box>
+                  )}
                 />
               </Box>
             )}

--- a/frontend/src/components/ui/DataTable.tsx
+++ b/frontend/src/components/ui/DataTable.tsx
@@ -13,7 +13,6 @@ import {
   useMediaQuery,
 } from '@mui/material';
 import type { SxProps, Theme } from '@mui/material';
-import { ChevronRight } from 'lucide-react';
 import StyledCheckbox from './StyledCheckbox';
 
 interface Column<T> {
@@ -34,7 +33,11 @@ interface DataTableProps<T extends { id: string }> {
   masterCheckboxId?: string;
   rowCheckboxIdPrefix?: string;
   sx?: SxProps<Theme>;
-  mobileVariant?: 'default' | 'vocabulary';
+  renderMobileRow?: (
+    row: T,
+    index: number,
+    checkbox: React.ReactNode
+  ) => React.ReactNode;
 }
 
 function DataTable<T extends { id: string } & Record<string, unknown>>({
@@ -48,7 +51,7 @@ function DataTable<T extends { id: string } & Record<string, unknown>>({
   masterCheckboxId,
   rowCheckboxIdPrefix,
   sx = {},
-  mobileVariant = 'default',
+  renderMobileRow,
 }: DataTableProps<T>) {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -62,7 +65,7 @@ function DataTable<T extends { id: string } & Record<string, unknown>>({
   };
 
   if (isMobile) {
-    if (mobileVariant === 'vocabulary') {
+    if (renderMobileRow) {
       return (
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, ...sx }}>
           {selectable && (
@@ -88,78 +91,23 @@ function DataTable<T extends { id: string } & Record<string, unknown>>({
             </Box>
           )}
           {data.map((row, index) => {
-            const swedish = String(row.swedish || '—');
-            const english = String(row.english || '—');
-            const examplePhrase = String(row.example_phrase || '—');
+            const checkbox = selectable ? (
+              <Box
+                onClick={(e) => e.stopPropagation()}
+                sx={{ display: 'flex', alignItems: 'center' }}
+              >
+                <StyledCheckbox
+                  id={rowCheckboxIdPrefix ? `${rowCheckboxIdPrefix}-${row.id}` : undefined}
+                  checked={selectedItems.get(row.id) || false}
+                  onChange={(checked) => onSelectionChange?.(row.id, checked)}
+                />
+              </Box>
+            ) : null;
 
             return (
-              <Paper
-                key={row.id}
-                elevation={0}
-                onClick={() => onRowClick?.(row, index)}
-                sx={{
-                  backgroundColor: 'rgba(34, 44, 95, 0.7)',
-                  border: '1px solid rgba(106, 121, 181, 0.5)',
-                  borderRadius: '0.65rem',
-                  p: 1.4,
-                  cursor: onRowClick ? 'pointer' : 'default',
-                  '&:hover': {
-                    backgroundColor: 'rgba(43, 57, 118, 0.75)',
-                  },
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 1.5,
-                }}
-              >
-                {selectable && (
-                  <Box
-                    onClick={(e) => e.stopPropagation()}
-                    sx={{ display: 'flex', alignItems: 'center' }}
-                  >
-                    <StyledCheckbox
-                      id={rowCheckboxIdPrefix ? `${rowCheckboxIdPrefix}-${row.id}` : undefined}
-                      checked={selectedItems.get(row.id) || false}
-                      onChange={(checked) => onSelectionChange?.(row.id, checked)}
-                    />
-                  </Box>
-                )}
-                <Box sx={{ minWidth: 0, flex: '0 0 30%' }}>
-                  <Typography
-                    sx={{
-                      color: '#f4f7ff',
-                      fontWeight: 700,
-                      lineHeight: 1.25,
-                      fontSize: '1.05rem',
-                      wordBreak: 'break-word',
-                    }}
-                  >
-                    {swedish}
-                  </Typography>
-                  <Typography
-                    sx={{
-                      color: '#adbce4',
-                      fontSize: '0.95rem',
-                      lineHeight: 1.2,
-                      mt: 0.25,
-                    }}
-                  >
-                    {english}
-                  </Typography>
-                </Box>
-                <Typography
-                  sx={{
-                    color: '#d0d9ef',
-                    flex: 1,
-                    fontSize: '1rem',
-                    lineHeight: 1.3,
-                    whiteSpace: 'normal',
-                    wordBreak: 'break-word',
-                  }}
-                >
-                  {examplePhrase}
-                </Typography>
-                <ChevronRight size={18} color="#bec8e6" />
-              </Paper>
+              <React.Fragment key={row.id}>
+                {renderMobileRow(row, index, checkbox)}
+              </React.Fragment>
             );
           })}
         </Box>

--- a/frontend/src/components/ui/DataTable.tsx
+++ b/frontend/src/components/ui/DataTable.tsx
@@ -13,6 +13,7 @@ import {
   useMediaQuery,
 } from '@mui/material';
 import type { SxProps, Theme } from '@mui/material';
+import { ChevronRight } from 'lucide-react';
 import StyledCheckbox from './StyledCheckbox';
 
 interface Column<T> {
@@ -33,6 +34,7 @@ interface DataTableProps<T extends { id: string }> {
   masterCheckboxId?: string;
   rowCheckboxIdPrefix?: string;
   sx?: SxProps<Theme>;
+  mobileVariant?: 'default' | 'vocabulary';
 }
 
 function DataTable<T extends { id: string } & Record<string, unknown>>({
@@ -46,6 +48,7 @@ function DataTable<T extends { id: string } & Record<string, unknown>>({
   masterCheckboxId,
   rowCheckboxIdPrefix,
   sx = {},
+  mobileVariant = 'default',
 }: DataTableProps<T>) {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -59,6 +62,110 @@ function DataTable<T extends { id: string } & Record<string, unknown>>({
   };
 
   if (isMobile) {
+    if (mobileVariant === 'vocabulary') {
+      return (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, ...sx }}>
+          {selectable && (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                p: 1.2,
+                backgroundColor: 'rgba(34, 44, 95, 0.7)',
+                border: '1px solid rgba(106, 121, 181, 0.5)',
+                borderRadius: '0.65rem',
+              }}
+            >
+              <StyledCheckbox
+                id={masterCheckboxId}
+                checked={allSelected}
+                indeterminate={someSelected}
+                onChange={handleSelectAll}
+              />
+              <Typography sx={{ ml: 0.75, color: '#d8e2ff', fontWeight: 700 }}>
+                Select All
+              </Typography>
+            </Box>
+          )}
+          {data.map((row, index) => {
+            const swedish = String(row.swedish || '—');
+            const english = String(row.english || '—');
+            const examplePhrase = String(row.example_phrase || '—');
+
+            return (
+              <Paper
+                key={row.id}
+                elevation={0}
+                onClick={() => onRowClick?.(row, index)}
+                sx={{
+                  backgroundColor: 'rgba(34, 44, 95, 0.7)',
+                  border: '1px solid rgba(106, 121, 181, 0.5)',
+                  borderRadius: '0.65rem',
+                  p: 1.4,
+                  cursor: onRowClick ? 'pointer' : 'default',
+                  '&:hover': {
+                    backgroundColor: 'rgba(43, 57, 118, 0.75)',
+                  },
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1.5,
+                }}
+              >
+                {selectable && (
+                  <Box
+                    onClick={(e) => e.stopPropagation()}
+                    sx={{ display: 'flex', alignItems: 'center' }}
+                  >
+                    <StyledCheckbox
+                      id={rowCheckboxIdPrefix ? `${rowCheckboxIdPrefix}-${row.id}` : undefined}
+                      checked={selectedItems.get(row.id) || false}
+                      onChange={(checked) => onSelectionChange?.(row.id, checked)}
+                    />
+                  </Box>
+                )}
+                <Box sx={{ minWidth: 0, flex: '0 0 30%' }}>
+                  <Typography
+                    sx={{
+                      color: '#f4f7ff',
+                      fontWeight: 700,
+                      lineHeight: 1.25,
+                      fontSize: '1.05rem',
+                      wordBreak: 'break-word',
+                    }}
+                  >
+                    {swedish}
+                  </Typography>
+                  <Typography
+                    sx={{
+                      color: '#adbce4',
+                      fontSize: '0.95rem',
+                      lineHeight: 1.2,
+                      mt: 0.25,
+                    }}
+                  >
+                    {english}
+                  </Typography>
+                </Box>
+                <Typography
+                  sx={{
+                    color: '#d0d9ef',
+                    flex: 1,
+                    fontSize: '1rem',
+                    lineHeight: 1.3,
+                    whiteSpace: 'normal',
+                    wordBreak: 'break-word',
+                  }}
+                >
+                  {examplePhrase}
+                </Typography>
+                <ChevronRight size={18} color="#bec8e6" />
+              </Paper>
+            );
+          })}
+        </Box>
+      );
+    }
+
     return (
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, ...sx }}>
          {selectable && (


### PR DESCRIPTION
## Summary
- redesign the analyzer page to match provided desktop/mobile drafts with two visual states (pre-upload and results)
- rebuild upload controls with analysis mode selection and compact uploaded-file controls
- refresh results panel layout and mobile vocabulary presentation
- resolve independent review findings by restoring mobile select-all and removing misleading tap-for-details behavior

## Validation
- npm run test:run -- src/App.test.tsx src/components/FileUpload.test.tsx src/components/ResultsDisplay.test.tsx
- npm run build

## Notes
- changes are scoped to analyzer UI and related tests only