### PR TITLE
fix: allow gemini config without openai key

### DIFF
--- a/src/runestone/config.py
+++ b/src/runestone/config.py
@@ -44,7 +44,7 @@ class Settings(BaseSettings):
     llm_model_name: Optional[str] = None
 
     # OpenAI Configuration
-    openai_api_key: str
+    openai_api_key: Optional[str] = None
 
     # Gemini Configuration
     gemini_api_key: Optional[str] = None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -213,6 +213,25 @@ class TestSettings:
         assert test_settings.resolve_service_llm_provider() == "gemini"
         assert test_settings.resolve_service_llm_model() == DEFAULT_GEMINI_SERVICE_LLM_MODEL
 
+    def test_gemini_only_settings_do_not_require_openai_api_key(self):
+        """Gemini-first configs should validate without unrelated OpenAI credentials."""
+        test_settings = Settings(
+            llm_provider="gemini",
+            openai_api_key=None,
+            gemini_api_key="test-gemini-key",
+            allowed_origins="http://localhost:3000",
+            database_url="sqlite:///./test.db",
+            telegram_bot_token="test-token",
+            frontend_url="http://localhost:5173",
+            jwt_secret_key="secret",
+            teacher_provider="gemini",
+            teacher_model="teacher-model",
+            coordinator_model="coordinator-model",
+        )
+
+        assert test_settings.openai_api_key is None
+        assert test_settings.resolve_service_llm_provider() == "gemini"
+
     def test_ocr_service_llm_resolvers_prefer_explicit_overrides(self):
         """OCR resolver helpers should prefer OCR-specific provider/model overrides."""
         test_settings = Settings.model_construct(


### PR DESCRIPTION
## Summary
- make `openai_api_key` optional in settings so Gemini-only deployments can validate config
- add a regression test covering Gemini-first settings with no OpenAI key
- preserve existing provider-specific runtime API key validation

## Why
Commit `f0f2f78` restored direct Gemini provider support, but `Settings` still required `openai_api_key`. That caused Gemini-only environments to fail configuration validation before the new Gemini provider logic could run.

## Validation
- `UV_CACHE_DIR=.uv-cache uv run --extra dev python -m pytest tests/test_config.py -k 'gemini_only_settings_do_not_require_openai_api_key or service_llm_resolver_uses_gemini_default_model or gemini_service_provider_can_keep_ocr_on_openrouter'`

## Notes
- Frontend tests were not rerun in this automation worktree because frontend test dependencies are not installed locally (`vitest: command not found`).
