### PR TITLE
Polish analyzer workspace states and UI structure

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,6 @@ import Register from "./components/auth/Register";
 import Profile from "./components/auth/Profile";
 import useImageProcessing from "./hooks/useImageProcessing";
 import { useState, useEffect } from "react";
-import { CustomButton } from "./components/ui";
 import { BrainCircuit } from "lucide-react";
 import { Box } from "@mui/material";
 import { useAuth } from "./context/AuthContext";
@@ -136,7 +135,7 @@ function App() {
                 </div>
 
                 {!hasAnalyzerContent ? (
-                  <div className="grid gap-4 lg:grid-cols-[360px_minmax(0,1fr)]">
+                  <div className="grid gap-5 lg:grid-cols-[360px_minmax(0,1fr)] xl:gap-7">
                     <FileUpload
                       onFileSelect={handleFileSelect}
                       isProcessing={isProcessing}
@@ -150,21 +149,32 @@ function App() {
                         minHeight: "420px",
                         alignItems: "center",
                         justifyContent: "center",
-                        borderRadius: "0.75rem",
+                        borderRadius: "1rem",
                         border: "1px solid rgba(99, 114, 173, 0.35)",
                         background:
-                          "radial-gradient(circle at 20% 20%, rgba(32, 40, 95, 0.55), rgba(8, 11, 39, 0.94))",
+                          "radial-gradient(circle at 18% 16%, rgba(37, 48, 116, 0.52), rgba(7, 11, 41, 0.97))",
                         color: "#c2cee8",
                         textAlign: "center",
-                        px: 4,
+                        px: 5,
+                        position: "relative",
+                        overflow: "hidden",
+                        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.04)",
+                        "&::before": {
+                          content: '""',
+                          position: "absolute",
+                          inset: 0,
+                          background:
+                            "linear-gradient(135deg, rgba(124, 148, 224, 0.08), transparent 30%, transparent 70%, rgba(34, 223, 132, 0.05))",
+                          pointerEvents: "none",
+                        },
                       }}
                     >
-                      <div className="space-y-4">
-                        <div className="text-4xl text-slate-500">⌁</div>
+                      <div className="relative z-10 space-y-4">
+                        <div className="text-5xl text-slate-500">⌁</div>
                         <h3 className="text-4xl font-semibold text-slate-100">
                           No analysis yet
                         </h3>
-                        <p className="max-w-md text-lg text-slate-300">
+                        <p className="mx-auto max-w-md text-lg leading-8 text-slate-300">
                           Upload an image of a Swedish textbook page to get
                           started.
                         </p>
@@ -172,8 +182,8 @@ function App() {
                     </Box>
                   </div>
                 ) : (
-                  <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
-                    <div className="lg:w-[300px] lg:shrink-0">
+                  <div className="grid gap-5 lg:grid-cols-[300px_minmax(0,1fr)] xl:gap-7">
+                    <div className="lg:sticky lg:top-24 lg:self-start">
                       <FileUpload
                         onFileSelect={handleFileSelect}
                         isProcessing={isProcessing}
@@ -183,18 +193,7 @@ function App() {
                         compact
                       />
                     </div>
-                    <div className="min-w-0 flex-1">
-                      {recognizeOnly && ocrResult && !analysisResult && (
-                        <Box sx={{ mb: 2 }}>
-                          <CustomButton
-                            onClick={handleAnalyzeOcrText}
-                            disabled={isAnalyzeButtonDisabled}
-                            startIcon={<BrainCircuit size={16} />}
-                          >
-                            Analyze OCR Text
-                          </CustomButton>
-                        </Box>
-                      )}
+                    <div className="min-w-0">
                       <ResultsDisplay
                         ocrResult={ocrResult}
                         analysisResult={analysisResult}
@@ -203,6 +202,12 @@ function App() {
                         onVocabularyUpdated={onVocabularyUpdated}
                         processingStep={processingStep}
                         isProcessing={isProcessing}
+                        onAnalyzeOcrText={handleAnalyzeOcrText}
+                        showAnalyzeOcrAction={
+                          recognizeOnly && Boolean(ocrResult) && !analysisResult
+                        }
+                        isAnalyzeOcrDisabled={isAnalyzeButtonDisabled}
+                        analyzeOcrButtonIcon={<BrainCircuit size={16} />}
                       />
                     </div>
                   </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { useState, useEffect } from "react";
 import { BrainCircuit } from "lucide-react";
 import { Box } from "@mui/material";
 import { useAuth } from "./context/AuthContext";
+import { analyzerShellGradients, buildAnalyzerShellSx } from "./components/ui";
 
 type AuthView = "login" | "register";
 type ViewType = "analyzer" | "vocabulary" | "grammar" | "chat" | "profile";
@@ -149,16 +150,11 @@ function App() {
                         minHeight: "420px",
                         alignItems: "center",
                         justifyContent: "center",
-                        borderRadius: "1rem",
-                        border: "1px solid rgba(99, 114, 173, 0.35)",
-                        background:
-                          "radial-gradient(circle at 18% 16%, rgba(37, 48, 116, 0.52), rgba(7, 11, 41, 0.97))",
                         color: "#c2cee8",
                         textAlign: "center",
                         px: 5,
                         position: "relative",
                         overflow: "hidden",
-                        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.04)",
                         "&::before": {
                           content: '""',
                           position: "absolute",
@@ -167,6 +163,7 @@ function App() {
                             "linear-gradient(135deg, rgba(124, 148, 224, 0.08), transparent 30%, transparent 70%, rgba(34, 223, 132, 0.05))",
                           pointerEvents: "none",
                         },
+                        ...buildAnalyzerShellSx(analyzerShellGradients.emptyState),
                       }}
                     >
                       <div className="relative z-10 space-y-4">

--- a/frontend/src/components/FileUpload.test.tsx
+++ b/frontend/src/components/FileUpload.test.tsx
@@ -58,6 +58,19 @@ describe('FileUpload', () => {
     expect(input).toBeDisabled();
   });
 
+  it('shows a compact processing overlay while working', () => {
+    render(
+      <FileUpload
+        onFileSelect={mockOnFileSelect}
+        isProcessing={true}
+        compact
+        selectedFileOverride={new File(['test'], 'test.jpg', { type: 'image/jpeg' })}
+      />
+    );
+
+    expect(screen.getByTestId('compact-processing-overlay')).toBeInTheDocument();
+  });
+
   it('shows file preview when file is selected', async () => {
     render(<FileUpload onFileSelect={mockOnFileSelect} isProcessing={false} />);
 

--- a/frontend/src/components/FileUpload.tsx
+++ b/frontend/src/components/FileUpload.tsx
@@ -15,6 +15,29 @@ import {
 } from "lucide-react";
 import { CustomButton } from "./ui";
 
+interface DimmedContentProps {
+  children: React.ReactNode;
+  isDimmed: boolean;
+  sx?: React.ComponentProps<typeof Box>["sx"];
+}
+
+const DimmedContent: React.FC<DimmedContentProps> = ({
+  children,
+  isDimmed,
+  sx,
+}) => (
+  <Box
+    sx={{
+      filter: isDimmed ? "blur(1.5px)" : "none",
+      opacity: isDimmed ? 0.45 : 1,
+      transition: "filter 0.2s ease, opacity 0.2s ease",
+      ...(sx || {}),
+    }}
+  >
+    {children}
+  </Box>
+);
+
 interface FileUploadProps {
   onFileSelect: (file: File) => void;
   isProcessing: boolean;
@@ -106,19 +129,29 @@ const FileUpload: React.FC<FileUploadProps> = ({
     return (
       <Box
         sx={{
-          borderRadius: "0.75rem",
+          position: "relative",
+          borderRadius: "1rem",
           border: "1px solid rgba(99, 114, 173, 0.35)",
           background:
-            "radial-gradient(circle at 8% 8%, rgba(38, 49, 113, 0.42), rgba(7, 12, 44, 0.96))",
-          p: 2,
+            "radial-gradient(circle at 12% 10%, rgba(36, 48, 114, 0.44), rgba(7, 12, 44, 0.97))",
+          p: { xs: 2, md: 2.25 },
+          boxShadow: "inset 0 1px 0 rgba(255,255,255,0.04)",
+          overflow: "hidden",
         }}
       >
-        <Box sx={{ display: "flex", gap: 1.5, alignItems: "center" }}>
+        <DimmedContent
+          isDimmed={isProcessing}
+          sx={{
+            display: "flex",
+            gap: 1.5,
+            alignItems: "center",
+          }}
+        >
           <Box
             sx={{
-              width: 92,
-              height: 92,
-              borderRadius: "0.5rem",
+              width: 98,
+              height: 98,
+              borderRadius: "0.9rem",
               border: "1px solid rgba(140, 160, 220, 0.35)",
               overflow: "hidden",
               flexShrink: 0,
@@ -142,8 +175,9 @@ const FileUpload: React.FC<FileUploadProps> = ({
             <Typography
               sx={{
                 color: "#f0f4ff",
-                fontWeight: 700,
-                lineHeight: 1.3,
+                fontWeight: 800,
+                lineHeight: 1.25,
+                fontSize: "1rem",
                 wordBreak: "break-word",
               }}
             >
@@ -153,9 +187,14 @@ const FileUpload: React.FC<FileUploadProps> = ({
               {selectedFile ? "Uploaded" : "Upload a textbook page"}
             </Typography>
           </Box>
-        </Box>
+        </DimmedContent>
 
-        <Box sx={{ mt: 2 }}>
+        <DimmedContent
+          isDimmed={isProcessing}
+          sx={{
+            mt: 2.25,
+          }}
+        >
           <Typography sx={{ color: "#9fb0de", mb: 0.75, fontSize: "0.85rem" }}>
             Analysis mode
           </Typography>
@@ -181,9 +220,16 @@ const FileUpload: React.FC<FileUploadProps> = ({
               <MenuItem value="ocr">OCR only</MenuItem>
             </Select>
           </FormControl>
-        </Box>
+        </DimmedContent>
 
-        <Box sx={{ mt: 2, display: "flex", gap: 1.5 }}>
+        <DimmedContent
+          isDimmed={isProcessing}
+          sx={{
+            mt: 2,
+            display: "flex",
+            gap: 1.5,
+          }}
+        >
           <CustomButton
             variant="secondary"
             onClick={triggerFilePicker}
@@ -191,9 +237,10 @@ const FileUpload: React.FC<FileUploadProps> = ({
             startIcon={<Replace size={16} />}
             sx={{
               flex: 1,
+              minHeight: "3.6rem",
               color: "#d8e2ff",
               border: "1px solid rgba(127, 148, 205, 0.6)",
-              borderRadius: "0.5rem",
+              borderRadius: "0.85rem",
               "&:hover": {
                 backgroundColor: "rgba(65, 84, 142, 0.22)",
               },
@@ -205,11 +252,25 @@ const FileUpload: React.FC<FileUploadProps> = ({
             onClick={triggerReanalyze}
             disabled={isProcessing || !selectedFile}
             startIcon={<RefreshCw size={16} />}
-            sx={{ flex: 1 }}
+            sx={{ flex: 1, minHeight: "3.6rem", borderRadius: "0.85rem" }}
           >
             Re-analyze
           </CustomButton>
-        </Box>
+        </DimmedContent>
+
+        {isProcessing && (
+          <Box
+            data-testid="compact-processing-overlay"
+            sx={{
+              position: "absolute",
+              inset: 0,
+              background:
+                "linear-gradient(180deg, rgba(9, 14, 48, 0.18), rgba(9, 14, 48, 0.52))",
+              backdropFilter: "blur(6px)",
+              pointerEvents: "auto",
+            }}
+          />
+        )}
 
         <input
           ref={fileInputRef}
@@ -226,17 +287,18 @@ const FileUpload: React.FC<FileUploadProps> = ({
   return (
     <Box
       sx={{
-        borderRadius: "0.75rem",
+        borderRadius: "1rem",
         border: "1px solid rgba(99, 114, 173, 0.35)",
         background:
-          "radial-gradient(circle at 10% 8%, rgba(35, 50, 116, 0.38), rgba(7, 11, 39, 0.96))",
+          "radial-gradient(circle at 10% 8%, rgba(35, 50, 116, 0.42), rgba(7, 11, 39, 0.97))",
         p: { xs: 2, sm: 3 },
+        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.04)",
       }}
     >
       <Box
         sx={{
           border: "1px dashed rgba(111, 133, 192, 0.48)",
-          borderRadius: "0.75rem",
+          borderRadius: "1rem",
           px: 2.5,
           py: 4,
           textAlign: "center",
@@ -294,8 +356,9 @@ const FileUpload: React.FC<FileUploadProps> = ({
           sx={{
             mt: 2,
             minWidth: 150,
-            height: "2.8rem",
+            height: "3rem",
             fontSize: "1rem",
+            borderRadius: "0.85rem",
           }}
         >
           Choose File
@@ -339,7 +402,13 @@ const FileUpload: React.FC<FileUploadProps> = ({
         disabled={isProcessing || !selectedFile}
         startIcon={<RefreshCw size={16} />}
         fullWidth
-        sx={{ mt: 2, height: "2.9rem", fontSize: "1.05rem", fontWeight: 600 }}
+        sx={{
+          mt: 2,
+          height: "3.1rem",
+          fontSize: "1.05rem",
+          fontWeight: 700,
+          borderRadius: "0.85rem",
+        }}
       >
         Analyze Page
       </CustomButton>

--- a/frontend/src/components/FileUpload.tsx
+++ b/frontend/src/components/FileUpload.tsx
@@ -13,7 +13,11 @@ import {
   RefreshCw,
   Replace,
 } from "lucide-react";
-import { CustomButton } from "./ui";
+import {
+  CustomButton,
+  analyzerShellGradients,
+  buildAnalyzerShellSx,
+} from "./ui";
 
 interface DimmedContentProps {
   children: React.ReactNode;
@@ -130,13 +134,9 @@ const FileUpload: React.FC<FileUploadProps> = ({
       <Box
         sx={{
           position: "relative",
-          borderRadius: "1rem",
-          border: "1px solid rgba(99, 114, 173, 0.35)",
-          background:
-            "radial-gradient(circle at 12% 10%, rgba(36, 48, 114, 0.44), rgba(7, 12, 44, 0.97))",
           p: { xs: 2, md: 2.25 },
-          boxShadow: "inset 0 1px 0 rgba(255,255,255,0.04)",
           overflow: "hidden",
+          ...buildAnalyzerShellSx(analyzerShellGradients.uploadCompact),
         }}
       >
         <DimmedContent
@@ -287,12 +287,8 @@ const FileUpload: React.FC<FileUploadProps> = ({
   return (
     <Box
       sx={{
-        borderRadius: "1rem",
-        border: "1px solid rgba(99, 114, 173, 0.35)",
-        background:
-          "radial-gradient(circle at 10% 8%, rgba(35, 50, 116, 0.42), rgba(7, 11, 39, 0.97))",
         p: { xs: 2, sm: 3 },
-        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.04)",
+        ...buildAnalyzerShellSx(analyzerShellGradients.uploadFull),
       }}
     >
       <Box

--- a/frontend/src/components/ResultsDisplay.test.tsx
+++ b/frontend/src/components/ResultsDisplay.test.tsx
@@ -168,6 +168,64 @@ describe("ResultsDisplay", () => {
     expect(screen.getByText("Jag mår bra idag.")).toBeInTheDocument();
   });
 
+  it("falls back to the OCR tab when analysis tabs disappear after rerender", () => {
+    const { rerender } = render(
+      <ResultsDisplay
+        ocrResult={mockOcrResult}
+        analysisResult={mockAnalysisResult}
+        error={null}
+        saveVocabulary={vi.fn()}
+        processingStep="IDLE"
+        isProcessing={false}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Vocabulary"));
+    expect(
+      screen.getByText(
+        "Select words to copy or save, then refine the list with the filters on the right."
+      )
+    ).toBeInTheDocument();
+
+    rerender(
+      <ResultsDisplay
+        ocrResult={mockOcrResult}
+        analysisResult={null}
+        error={null}
+        saveVocabulary={vi.fn()}
+        processingStep="IDLE"
+        isProcessing={false}
+      />
+    );
+
+    expect(screen.getByText("Recognized text")).toBeInTheDocument();
+    expect(screen.getByText(mockOcrResult.text)).toBeInTheDocument();
+    expect(screen.queryByText("Vocabulary")).not.toBeInTheDocument();
+  });
+
+  it("renders OCR text through sanitized markdown output", () => {
+    render(
+      <ResultsDisplay
+        ocrResult={{
+          text: `Safe text\n\n<script>alert("xss")</script>\n\n[link](https://example.com)`,
+          character_count: 18,
+        }}
+        analysisResult={null}
+        error={null}
+        saveVocabulary={vi.fn()}
+        processingStep="IDLE"
+        isProcessing={false}
+      />
+    );
+
+    expect(screen.getByText("Safe text")).toBeInTheDocument();
+    expect(document.querySelector("script")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "link" })).toHaveAttribute(
+      "href",
+      "https://example.com"
+    );
+  });
+
   it("copies all vocabulary to clipboard when all items are selected and copy button is clicked", async () => {
     const mockClipboard = {
       writeText: vi.fn().mockResolvedValue(undefined),

--- a/frontend/src/components/ResultsDisplay.test.tsx
+++ b/frontend/src/components/ResultsDisplay.test.tsx
@@ -129,7 +129,7 @@ describe("ResultsDisplay", () => {
     const grammarTab = screen.getByText("Grammar");
     fireEvent.click(grammarTab);
 
-    expect(screen.getByText("Grammar Analysis")).toBeInTheDocument();
+    expect(screen.getByText("Grammar focus")).toBeInTheDocument();
     expect(screen.getByText("Topic:")).toBeInTheDocument();
     expect(
       screen.getByText(mockAnalysisResult.grammar_focus.topic)
@@ -157,7 +157,9 @@ describe("ResultsDisplay", () => {
     const vocabularyTab = screen.getByText("Vocabulary");
     fireEvent.click(vocabularyTab);
 
-    expect(screen.getByText("Vocabulary Analysis")).toBeInTheDocument();
+    expect(
+      screen.getByText("Select words to copy or save, then refine the list with the filters on the right.")
+    ).toBeInTheDocument();
     expect(screen.getByText("hej")).toBeInTheDocument();
     expect(screen.getByText("hello")).toBeInTheDocument();
     expect(screen.getByText("bra")).toBeInTheDocument();
@@ -1148,10 +1150,31 @@ describe("ResultsDisplay", () => {
         />
       );
 
-      // ProcessingStatus component should be rendered
-      // The actual text depends on ProcessingStatus implementation
-      // We just verify the component renders when isProcessing is true
-      expect(screen.queryByText("Analysis")).not.toBeInTheDocument();
+      expect(screen.getByText("Reading the textbook page")).toBeInTheDocument();
+    });
+
+    it("keeps an analyzing status visible after OCR completes but before analysis results arrive", () => {
+      render(
+        <ResultsDisplay
+          ocrResult={mockOcrResult}
+          analysisResult={null}
+          error={null}
+          saveVocabulary={vi.fn()}
+          processingStep="ANALYZING"
+          isProcessing={true}
+        />
+      );
+
+      expect(
+        screen.getByText("Building grammar and vocabulary insights")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "OCR is ready. We are turning it into the final analysis now."
+        )
+      ).toBeInTheDocument();
+      expect(screen.getByText("Recognized text")).toBeInTheDocument();
+      expect(screen.getByText(mockOcrResult.text)).toBeInTheDocument();
     });
 
     it("does not show mobile tap-for-details helper text", () => {

--- a/frontend/src/components/ResultsDisplay.tsx
+++ b/frontend/src/components/ResultsDisplay.tsx
@@ -18,6 +18,9 @@ import {
   TabNavigation,
   StyledCheckbox,
   DataTable,
+  analyzerShellGradients,
+  analyzerSurfaceCardSx,
+  buildAnalyzerShellSx,
 } from "./ui";
 import { parseMarkdown } from "../utils/markdownParser";
 import type {
@@ -318,16 +321,12 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
       <Box
         sx={{
           minHeight: { xs: 320, lg: 420 },
-          borderRadius: "1rem",
-          border: "1px solid rgba(99, 114, 173, 0.35)",
-          background:
-            "radial-gradient(circle at 18% 16%, rgba(35, 49, 116, 0.5), rgba(7, 12, 43, 0.97))",
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
           px: { xs: 3, md: 5 },
           textAlign: "center",
-          boxShadow: "inset 0 1px 0 rgba(255,255,255,0.04)",
+          ...buildAnalyzerShellSx(analyzerShellGradients.processing),
         }}
       >
         <Box sx={{ maxWidth: 520 }}>
@@ -376,12 +375,8 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
   return (
     <Box
       sx={{
-        borderRadius: "1rem",
-        border: "1px solid rgba(99, 114, 173, 0.35)",
-        background:
-          "radial-gradient(circle at 14% 10%, rgba(34, 48, 112, 0.4), rgba(6, 11, 42, 0.97))",
         overflow: "hidden",
-        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.04)",
+        ...buildAnalyzerShellSx(analyzerShellGradients.results),
       }}
     >
       {error && (
@@ -736,9 +731,7 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
                   masterCheckboxId="vocabulary-master-checkbox"
                   rowCheckboxIdPrefix="vocabulary-item"
                   sx={{
-                    backgroundColor: "rgba(40, 29, 56, 0.92)",
-                    borderRadius: "0.9rem",
-                    border: "1px solid rgba(95, 76, 123, 0.82)",
+                    ...analyzerSurfaceCardSx,
                   }}
                   columns={[
                     { key: "swedish", label: "Swedish" },

--- a/frontend/src/components/ResultsDisplay.tsx
+++ b/frontend/src/components/ResultsDisplay.tsx
@@ -67,11 +67,13 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
   isAnalyzeOcrDisabled = false,
   analyzeOcrButtonIcon,
 }) => {
-  const availableTabs = [
-    ocrResult && "ocr",
-    analysisResult && "grammar",
-    analysisResult && "vocabulary",
-  ].filter(Boolean) as string[];
+  const availableTabs = useMemo(
+    () =>
+      [ocrResult && "ocr", analysisResult && "grammar", analysisResult && "vocabulary"].filter(
+        Boolean
+      ) as string[],
+    [ocrResult, analysisResult]
+  );
   const [activeTab, setActiveTab] = useState(availableTabs[0] || "ocr");
   const [snackbar, setSnackbar] = useState<{
     open: boolean;
@@ -93,10 +95,12 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
   >([]);
 
   useEffect(() => {
-    if (availableTabs.length > 0 && !availableTabs.includes(activeTab)) {
-      setActiveTab(availableTabs[0]);
+    if (availableTabs.length > 0) {
+      setActiveTab((currentTab) =>
+        availableTabs.includes(currentTab) ? currentTab : availableTabs[0]
+      );
     }
-  }, [activeTab, availableTabs]);
+  }, [availableTabs]);
 
   useEffect(() => {
     if (analysisResult?.vocabulary) {
@@ -119,6 +123,10 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
   const filteredVocabulary = useMemo(
     () => enrichedVocabulary.filter((item) => !hideKnown || !item.known),
     [enrichedVocabulary, hideKnown]
+  );
+  const renderedOcrHtml = useMemo(
+    () => parseMarkdown(ocrResult?.text ?? ""),
+    [ocrResult?.text]
   );
 
   if (!ocrResult && !analysisResult && !isProcessing) {
@@ -510,7 +518,7 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
                 sx={{ color: "white" }}
                 className="markdown-content"
                 dangerouslySetInnerHTML={{
-                  __html: parseMarkdown(ocrResult.text),
+                  __html: renderedOcrHtml,
                 }}
               />
             </SurfaceCard>

--- a/frontend/src/components/ResultsDisplay.tsx
+++ b/frontend/src/components/ResultsDisplay.tsx
@@ -8,7 +8,6 @@ import {
   CircularProgress,
 } from "@mui/material";
 import type { AlertColor } from "@mui/material";
-import { ContentCopy } from "@mui/icons-material";
 import { ArrowRight, Copy, Save, Sparkles } from "lucide-react";
 import { v4 as uuidv4 } from "uuid";
 import {
@@ -427,7 +426,7 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
               <Typography
                 sx={{ color: "#edf4ff", fontWeight: 700, lineHeight: 1.25 }}
               >
-                Building grammar and vocabulary insights
+                {processingHeadline}
               </Typography>
               <Typography
                 sx={{ color: "#9fb0d9", fontSize: "0.94rem", mt: 0.35 }}
@@ -504,7 +503,7 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
                   }}
                   title={copyButtonText}
                 >
-                  <ContentCopy />
+                  <Copy size={20} />
                 </IconButton>
               </Box>
             </Box>
@@ -747,9 +746,7 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
                     <Box
                       key={row.id}
                       sx={{
-                        backgroundColor: "rgba(34, 44, 95, 0.74)",
-                        border: "1px solid rgba(106, 121, 181, 0.5)",
-                        borderRadius: "0.85rem",
+                        ...analyzerSurfaceCardSx,
                         p: 1.35,
                         display: "flex",
                         alignItems: "center",

--- a/frontend/src/components/ResultsDisplay.tsx
+++ b/frontend/src/components/ResultsDisplay.tsx
@@ -5,52 +5,53 @@ import {
   Snackbar,
   Alert,
   IconButton,
+  CircularProgress,
 } from "@mui/material";
 import type { AlertColor } from "@mui/material";
-import { Copy, Save } from "lucide-react";
 import { ContentCopy } from "@mui/icons-material";
-import { v4 as uuidv4 } from "uuid"; // Import uuid
+import { ArrowRight, Copy, Save, Sparkles } from "lucide-react";
+import { v4 as uuidv4 } from "uuid";
 import {
   CustomButton,
-  ContentCard,
   ErrorAlert,
-  SectionTitle,
+  SurfaceCard,
   TabNavigation,
   StyledCheckbox,
   DataTable,
 } from "./ui";
-import ProcessingStatus from "./ProcessingStatus"; // Import ProcessingStatus
 import { parseMarkdown } from "../utils/markdownParser";
 import type {
   OCRResult,
   VocabularyItem,
   EnrichedVocabularyItem,
   ContentAnalysis,
-  ProcessingStep, // Import ProcessingStep
+  ProcessingStep,
 } from "../hooks/useImageProcessing";
 
-// Helper function to enrich vocabulary items with a unique ID
 const enrichVocabularyItems = (
   vocabulary: VocabularyItem[]
 ): EnrichedVocabularyItem[] => {
   return vocabulary.map((item) => ({
     ...item,
-    id: item.id || uuidv4(), // Use existing ID or generate a new one
+    id: item.id || uuidv4(),
   }));
 };
-
 
 interface ResultsDisplayProps {
   ocrResult: OCRResult | null;
   analysisResult: ContentAnalysis | null;
   error: string | null;
   saveVocabulary: (
-    vocabulary: EnrichedVocabularyItem[], // Use EnrichedVocabularyItem
+    vocabulary: EnrichedVocabularyItem[],
     enrich: boolean
   ) => Promise<void>;
-  onVocabularyUpdated?: (updatedVocabulary: EnrichedVocabularyItem[]) => void; // Optional callback
-  processingStep: ProcessingStep; // New prop
-  isProcessing: boolean; // New prop
+  onVocabularyUpdated?: (updatedVocabulary: EnrichedVocabularyItem[]) => void;
+  processingStep: ProcessingStep;
+  isProcessing: boolean;
+  onAnalyzeOcrText?: () => Promise<void> | void;
+  showAnalyzeOcrAction?: boolean;
+  isAnalyzeOcrDisabled?: boolean;
+  analyzeOcrButtonIcon?: React.ReactNode;
 }
 
 const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
@@ -61,6 +62,10 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
   onVocabularyUpdated,
   processingStep,
   isProcessing,
+  onAnalyzeOcrText,
+  showAnalyzeOcrAction = false,
+  isAnalyzeOcrDisabled = false,
+  analyzeOcrButtonIcon,
 }) => {
   const availableTabs = [
     ocrResult && "ocr",
@@ -81,11 +86,17 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
     () => new Map()
   );
   const [enrichVocabulary, setEnrichVocabulary] = useState(true);
-  const [hideKnown, setHideKnown] = useState(false); // New state variable
+  const [hideKnown, setHideKnown] = useState(false);
   const [copyButtonText, setCopyButtonText] = useState("Copy");
   const [enrichedVocabulary, setEnrichedVocabulary] = useState<
     EnrichedVocabularyItem[]
   >([]);
+
+  useEffect(() => {
+    if (availableTabs.length > 0 && !availableTabs.includes(activeTab)) {
+      setActiveTab(availableTabs[0]);
+    }
+  }, [activeTab, availableTabs]);
 
   useEffect(() => {
     if (analysisResult?.vocabulary) {
@@ -105,7 +116,6 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
     }
   }, [analysisResult]);
 
-  // Memoized filtered vocabulary list
   const filteredVocabulary = useMemo(
     () => enrichedVocabulary.filter((item) => !hideKnown || !item.known),
     [enrichedVocabulary, hideKnown]
@@ -142,9 +152,7 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
       .join("\n");
 
     try {
-      // Check if clipboard API is available
       if (!navigator.clipboard) {
-        // Fallback for older browsers
         const textArea = document.createElement("textarea");
         textArea.value = vocabText;
         document.body.appendChild(textArea);
@@ -218,16 +226,12 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
         severity: "success",
       });
 
-      // Update the local state for known items
       const updatedVocabulary = enrichedVocabulary.map((item) =>
         checkedItems.get(item.id) ? { ...item, known: true } : item
       );
       setEnrichedVocabulary(updatedVocabulary);
-
-      // Clear checked items after saving
       setCheckedItems(new Map());
 
-      // Call the optional callback to update parent component's state
       if (onVocabularyUpdated) {
         onVocabularyUpdated(updatedVocabulary);
       }
@@ -245,9 +249,7 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
     if (!ocrResult) return;
 
     try {
-      // Check if clipboard API is available
       if (!navigator.clipboard) {
-        // Fallback for older browsers or non-HTTPS contexts
         const textArea = document.createElement("textarea");
         textArea.value = ocrResult.text;
         document.body.appendChild(textArea);
@@ -288,141 +290,316 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
     analysisResult && { id: "vocabulary", label: "Vocabulary" },
   ].filter(Boolean) as { id: string; label: string }[];
 
+  const processingHeadline =
+    processingStep === "ANALYZING"
+      ? "Building grammar and vocabulary insights"
+      : "Reading the textbook page";
+  const processingBody =
+    processingStep === "ANALYZING"
+      ? "The OCR text is ready. We are extracting the key grammar focus and vocabulary now."
+      : "We are extracting the text from your image and preparing the analysis workspace.";
+  const showInlineProcessingNotice =
+    isProcessing &&
+    processingStep === "ANALYZING" &&
+    Boolean(ocrResult) &&
+    !analysisResult &&
+    !error;
+
+  if (isProcessing && !ocrResult && !analysisResult && !error) {
+    return (
+      <Box
+        sx={{
+          minHeight: { xs: 320, lg: 420 },
+          borderRadius: "1rem",
+          border: "1px solid rgba(99, 114, 173, 0.35)",
+          background:
+            "radial-gradient(circle at 18% 16%, rgba(35, 49, 116, 0.5), rgba(7, 12, 43, 0.97))",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          px: { xs: 3, md: 5 },
+          textAlign: "center",
+          boxShadow: "inset 0 1px 0 rgba(255,255,255,0.04)",
+        }}
+      >
+        <Box sx={{ maxWidth: 520 }}>
+          <Box
+            sx={{
+              mx: "auto",
+              mb: 2.5,
+              width: 76,
+              height: 76,
+              borderRadius: "999px",
+              border: "1px solid rgba(129, 149, 218, 0.38)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              background: "rgba(14, 21, 64, 0.7)",
+              boxShadow: "0 0 0 10px rgba(50, 69, 145, 0.12)",
+            }}
+          >
+            <CircularProgress size={32} sx={{ color: "var(--primary-color)" }} />
+          </Box>
+          <Typography
+            sx={{
+              color: "#f4f7ff",
+              fontWeight: 800,
+              fontSize: { xs: "1.6rem", md: "2rem" },
+              lineHeight: 1.15,
+              mb: 1.25,
+            }}
+          >
+            {processingHeadline}
+          </Typography>
+          <Typography
+            sx={{
+              color: "#bcc8e7",
+              fontSize: { xs: "1rem", md: "1.1rem" },
+              lineHeight: 1.75,
+            }}
+          >
+            {processingBody}
+          </Typography>
+        </Box>
+      </Box>
+    );
+  }
+
   return (
     <Box
       sx={{
-        borderRadius: "0.8rem",
+        borderRadius: "1rem",
         border: "1px solid rgba(99, 114, 173, 0.35)",
         background:
-          "radial-gradient(circle at 14% 10%, rgba(34, 48, 112, 0.36), rgba(6, 11, 42, 0.96))",
+          "radial-gradient(circle at 14% 10%, rgba(34, 48, 112, 0.4), rgba(6, 11, 42, 0.97))",
+        overflow: "hidden",
+        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.04)",
       }}
     >
-      {isProcessing && (
-        <ProcessingStatus
-          isProcessing={isProcessing}
-          processingStep={processingStep}
-        />
-      )}
-
       {error && (
-        <Box sx={{ mb: 4 }}>
+        <Box sx={{ p: { xs: 1.5, md: 2 } }}>
           <ErrorAlert message={error} />
         </Box>
       )}
 
-      <TabNavigation
-        tabs={tabs}
-        activeTab={activeTab}
-        onTabChange={setActiveTab}
-        containerSx={{ px: { xs: 1.5, md: 2.5 }, borderColor: "rgba(106, 120, 178, 0.4)" }}
-        tabsSx={{ gap: { xs: 1, md: 4 } }}
-        buttonSx={{ px: { xs: 1.2, md: 2 }, py: 1.1, fontSize: { xs: "1rem", md: "1.05rem" } }}
-      />
+      {tabs.length > 0 && (
+        <TabNavigation
+          tabs={tabs}
+          activeTab={activeTab}
+          onTabChange={setActiveTab}
+          containerSx={{
+            px: { xs: 1.5, md: 2.5 },
+            borderColor: "rgba(106, 120, 178, 0.4)",
+          }}
+          tabsSx={{ gap: { xs: 0.75, md: 3.5 } }}
+          buttonSx={{
+            px: { xs: 1.2, md: 2.25 },
+            py: 1.25,
+            fontSize: { xs: "0.98rem", md: "1.05rem" },
+          }}
+        />
+      )}
 
       <Box sx={{ px: { xs: 1.5, md: 2.5 }, pt: 2.5, pb: 2.5 }}>
-        {activeTab === "ocr" && (
-          <Box>
-            {ocrResult && (
-              <Box>
-                <Box
-                  sx={{ display: "flex", justifyContent: "flex-end", mb: 2 }}
-                >
-                  <IconButton
-                    onClick={handleCopyOCRText}
-                    sx={{
-                      color: "var(--primary-color)",
-                      "&:hover": {
-                        backgroundColor: "rgba(255, 255, 255, 0.1)",
-                      },
-                    }}
-                    title={copyButtonText}
-                  >
-                    <ContentCopy />
-                  </IconButton>
-                </Box>
-                <ContentCard>
-                  <Box
-                    sx={{ color: "white" }}
-                    className="markdown-content"
-                    dangerouslySetInnerHTML={{
-                      __html: parseMarkdown(ocrResult.text),
-                    }}
-                  />
-                </ContentCard>
-              </Box>
-            )}
+        {showInlineProcessingNotice && (
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: { xs: "flex-start", sm: "center" },
+              gap: 1.25,
+              mb: 2.5,
+              px: 1.5,
+              py: 1.25,
+              borderRadius: "0.9rem",
+              border: "1px solid rgba(93, 210, 137, 0.22)",
+              background: "rgba(25, 38, 88, 0.56)",
+              boxShadow: "inset 0 1px 0 rgba(255,255,255,0.03)",
+            }}
+          >
+            <CircularProgress
+              size={20}
+              sx={{ color: "var(--primary-color)", flexShrink: 0, mt: { xs: 0.2, sm: 0 } }}
+            />
+            <Box>
+              <Typography
+                sx={{ color: "#edf4ff", fontWeight: 700, lineHeight: 1.25 }}
+              >
+                Building grammar and vocabulary insights
+              </Typography>
+              <Typography
+                sx={{ color: "#9fb0d9", fontSize: "0.94rem", mt: 0.35 }}
+              >
+                OCR is ready. We are turning it into the final analysis now.
+              </Typography>
+            </Box>
           </Box>
         )}
 
-        {activeTab === "grammar" && (
+        {activeTab === "ocr" && ocrResult && (
           <Box>
-            <SectionTitle>Grammar Analysis</SectionTitle>
-            {analysisResult && (
-              <Box
-                sx={{ mt: 4, display: "flex", flexDirection: "column", gap: 4 }}
-              >
-                <ContentCard>
-                  <Typography
-                    sx={{
-                      color: "var(--primary-color)",
-                      fontWeight: "bold",
-                      mb: 1,
-                    }}
-                  >
-                    Topic:
-                  </Typography>
-                  <Typography sx={{ color: "white" }}>
-                    {analysisResult.grammar_focus.topic}
-                  </Typography>
-                </ContentCard>
-                <ContentCard>
-                  <Typography
-                    sx={{
-                      color: "var(--primary-color)",
-                      fontWeight: "bold",
-                      mb: 1,
-                    }}
-                  >
-                    Explanation:
-                  </Typography>
-                  <Typography sx={{ color: "white" }}>
-                    {analysisResult.grammar_focus.explanation}
-                  </Typography>
-                </ContentCard>
-                {analysisResult.grammar_focus.rules && (
-                  <ContentCard>
-                    <Typography
-                      sx={{
-                        color: "var(--primary-color)",
-                        fontWeight: "bold",
-                        mb: 1,
-                      }}
-                    >
-                      Rules:
-                    </Typography>
-                    <Typography sx={{ color: "white", whiteSpace: "pre-wrap" }}>
-                      {analysisResult.grammar_focus.rules}
-                    </Typography>
-                  </ContentCard>
-                )}
-                <ContentCard>
-                  <Typography
-                    sx={{
-                      color: "var(--primary-color)",
-                      fontWeight: "bold",
-                      mb: 1,
-                    }}
-                  >
-                    Has Explicit Rules:
-                  </Typography>
-                  <Typography sx={{ color: "white" }}>
-                    {analysisResult.grammar_focus.has_explicit_rules
-                      ? "Yes"
-                      : "No"}
-                  </Typography>
-                </ContentCard>
+            <Box
+              sx={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: { xs: "stretch", sm: "center" },
+                gap: 1.5,
+                flexDirection: { xs: "column", sm: "row" },
+                mb: 2,
+              }}
+            >
+              <Box>
+                <Typography
+                  sx={{
+                    color: "#f0f4ff",
+                    fontWeight: 700,
+                    fontSize: { xs: "1.15rem", md: "1.25rem" },
+                  }}
+                >
+                  Recognized text
+                </Typography>
+                <Typography
+                  sx={{ color: "#92a5d6", fontSize: "0.92rem", mt: 0.5 }}
+                >
+                  Review the OCR output or continue into grammar and vocabulary
+                  analysis.
+                </Typography>
               </Box>
-            )}
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: { xs: "space-between", sm: "flex-end" },
+                  gap: 1,
+                  width: { xs: "100%", sm: "auto" },
+                }}
+              >
+                {showAnalyzeOcrAction && (
+                  <CustomButton
+                    onClick={() => onAnalyzeOcrText?.()}
+                    disabled={isAnalyzeOcrDisabled}
+                    startIcon={analyzeOcrButtonIcon ?? <Sparkles size={16} />}
+                    endIcon={<ArrowRight size={16} />}
+                    sx={{
+                      minHeight: "3rem",
+                      borderRadius: "0.85rem",
+                      px: 2.25,
+                      fontWeight: 700,
+                    }}
+                  >
+                    Analyze OCR Text
+                  </CustomButton>
+                )}
+                <IconButton
+                  onClick={handleCopyOCRText}
+                  sx={{
+                    color: "var(--primary-color)",
+                    border: "1px solid rgba(93, 210, 137, 0.32)",
+                    borderRadius: "0.8rem",
+                    "&:hover": {
+                      backgroundColor: "rgba(61, 221, 136, 0.08)",
+                    },
+                  }}
+                  title={copyButtonText}
+                >
+                  <ContentCopy />
+                </IconButton>
+              </Box>
+            </Box>
+            <SurfaceCard sx={{ minHeight: 240 }}>
+              <Box
+                sx={{ color: "white" }}
+                className="markdown-content"
+                dangerouslySetInnerHTML={{
+                  __html: parseMarkdown(ocrResult.text),
+                }}
+              />
+            </SurfaceCard>
+          </Box>
+        )}
+
+        {activeTab === "grammar" && analysisResult && (
+          <Box>
+            <Box sx={{ mb: 2.5 }}>
+              <Typography
+                sx={{
+                  color: "#f0f4ff",
+                  fontWeight: 800,
+                  fontSize: { xs: "1.35rem", md: "1.6rem" },
+                }}
+              >
+                Grammar focus
+              </Typography>
+              <Typography sx={{ color: "#94a7d7", mt: 0.5 }}>
+                Key concept, explanation, and support notes from the analyzed
+                page.
+              </Typography>
+            </Box>
+
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+              <SurfaceCard>
+                <Typography
+                  sx={{
+                    color: "var(--primary-color)",
+                    fontWeight: "bold",
+                    mb: 1,
+                  }}
+                >
+                  Topic:
+                </Typography>
+                <Typography sx={{ color: "white" }}>
+                  {analysisResult.grammar_focus.topic}
+                </Typography>
+              </SurfaceCard>
+
+              <SurfaceCard>
+                <Typography
+                  sx={{
+                    color: "var(--primary-color)",
+                    fontWeight: "bold",
+                    mb: 1,
+                  }}
+                >
+                  Explanation:
+                </Typography>
+                <Typography sx={{ color: "white" }}>
+                  {analysisResult.grammar_focus.explanation}
+                </Typography>
+              </SurfaceCard>
+
+              {analysisResult.grammar_focus.rules && (
+                <SurfaceCard>
+                  <Typography
+                    sx={{
+                      color: "var(--primary-color)",
+                      fontWeight: "bold",
+                      mb: 1,
+                    }}
+                  >
+                    Rules:
+                  </Typography>
+                  <Typography sx={{ color: "white", whiteSpace: "pre-wrap" }}>
+                    {analysisResult.grammar_focus.rules}
+                  </Typography>
+                </SurfaceCard>
+              )}
+
+              <SurfaceCard>
+                <Typography
+                  sx={{
+                    color: "var(--primary-color)",
+                    fontWeight: "bold",
+                    mb: 1,
+                  }}
+                >
+                  Has Explicit Rules:
+                </Typography>
+                <Typography sx={{ color: "white" }}>
+                  {analysisResult.grammar_focus.has_explicit_rules
+                    ? "Yes"
+                    : "No"}
+                </Typography>
+              </SurfaceCard>
+            </Box>
           </Box>
         )}
 
@@ -435,26 +612,54 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
                 alignItems: "flex-start",
                 gap: 2,
                 flexDirection: { xs: "column", md: "row" },
-                mb: 2.2,
+                mb: 2.5,
               }}
             >
-              <SectionTitle>Vocabulary Analysis</SectionTitle>
+              <Box>
+                <Typography
+                  sx={{
+                    color: "#f0f4ff",
+                    fontWeight: 800,
+                    fontSize: { xs: "1.4rem", md: "1.75rem" },
+                  }}
+                >
+                  Vocabulary
+                </Typography>
+                <Typography sx={{ color: "#94a7d7", mt: 0.5 }}>
+                  Select words to copy or save, then refine the list with the
+                  filters on the right.
+                </Typography>
+              </Box>
+
               {analysisResult && enrichedVocabulary.length > 0 && (
                 <Box
                   sx={{
                     display: "flex",
                     flexDirection: "column",
-                    alignItems: { xs: "stretch", md: "flex-end" },
-                    gap: 1.2,
+                    alignItems: { xs: "stretch", lg: "flex-end" },
+                    gap: 1.4,
                     width: { xs: "100%", md: "auto" },
                   }}
                 >
-                  <Box sx={{ display: "flex", gap: 1.2, flexWrap: "wrap" }}>
+                  <Box
+                    sx={{
+                      display: "flex",
+                      gap: 1.2,
+                      flexWrap: "wrap",
+                      width: { xs: "100%", lg: "auto" },
+                    }}
+                  >
                     <CustomButton
                       variant="primary"
                       onClick={handleSaveVocabulary}
                       startIcon={<Save size={16} />}
-                      sx={{ minWidth: { xs: "100%", md: 0 } }}
+                      sx={{
+                        minWidth: { xs: "100%", sm: 0 },
+                        minHeight: "3rem",
+                        borderRadius: "0.85rem",
+                        px: 2.4,
+                        fontWeight: 700,
+                      }}
                     >
                       Save to Database
                     </CustomButton>
@@ -462,48 +667,59 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
                       variant="primary"
                       onClick={handleCopyVocabulary}
                       startIcon={<Copy size={16} />}
-                      sx={{ minWidth: { xs: "100%", md: 0 } }}
+                      sx={{
+                        minWidth: { xs: "100%", sm: 0 },
+                        minHeight: "3rem",
+                        borderRadius: "0.85rem",
+                        px: 2.4,
+                        fontWeight: 700,
+                      }}
                     >
                       Copy
                     </CustomButton>
                   </Box>
+
                   <Box
                     sx={{
                       display: "flex",
-                      alignItems: "flex-start",
-                      gap: 1,
+                      alignItems: { xs: "stretch", lg: "center" },
+                      justifyContent: { xs: "space-between", lg: "flex-end" },
+                      flexDirection: { xs: "column", sm: "row" },
+                      gap: 1.5,
+                      borderLeft: {
+                        xs: "none",
+                        lg: "1px solid rgba(106, 120, 178, 0.28)",
+                      },
+                      pl: { xs: 0, lg: 2 },
                     }}
                   >
-                    <StyledCheckbox
-                      id="enrich-grammar-checkbox"
-                      checked={enrichVocabulary}
-                      onChange={(checked) => setEnrichVocabulary(checked)}
-                    />
-                    <Typography sx={{ color: "white" }}>
-                      Enrich with grammar info
-                    </Typography>
-                  </Box>
-                  <Box
-                    sx={{
-                      display: "flex",
-                      alignItems: "flex-start",
-                      gap: 1,
-                    }}
-                  >
-                    <StyledCheckbox
-                      id="hide-known-words-checkbox"
-                      checked={hideKnown}
-                      onChange={(checked) => setHideKnown(checked)}
-                    />
-                    <Typography sx={{ color: "white" }}>
-                      Hide known words
-                    </Typography>
+                    <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1 }}>
+                      <StyledCheckbox
+                        id="enrich-grammar-checkbox"
+                        checked={enrichVocabulary}
+                        onChange={(checked) => setEnrichVocabulary(checked)}
+                      />
+                      <Typography sx={{ color: "white", lineHeight: 1.4 }}>
+                        Enrich with grammar info
+                      </Typography>
+                    </Box>
+                    <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1 }}>
+                      <StyledCheckbox
+                        id="hide-known-words-checkbox"
+                        checked={hideKnown}
+                        onChange={(checked) => setHideKnown(checked)}
+                      />
+                      <Typography sx={{ color: "white", lineHeight: 1.4 }}>
+                        Hide known words
+                      </Typography>
+                    </Box>
                   </Box>
                 </Box>
               )}
             </Box>
+
             {analysisResult && (
-              <Box sx={{ mt: 4 }}>
+              <Box sx={{ mt: 3 }}>
                 <DataTable
                   selectable={true}
                   selectedItems={checkedItems}
@@ -511,6 +727,11 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
                   onSelectAll={handleCheckAll}
                   masterCheckboxId="vocabulary-master-checkbox"
                   rowCheckboxIdPrefix="vocabulary-item"
+                  sx={{
+                    backgroundColor: "rgba(40, 29, 56, 0.92)",
+                    borderRadius: "0.9rem",
+                    border: "1px solid rgba(95, 76, 123, 0.82)",
+                  }}
                   columns={[
                     { key: "swedish", label: "Swedish" },
                     { key: "english", label: "English" },
@@ -525,10 +746,10 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
                     <Box
                       key={row.id}
                       sx={{
-                        backgroundColor: "rgba(34, 44, 95, 0.7)",
+                        backgroundColor: "rgba(34, 44, 95, 0.74)",
                         border: "1px solid rgba(106, 121, 181, 0.5)",
-                        borderRadius: "0.65rem",
-                        p: 1.4,
+                        borderRadius: "0.85rem",
+                        p: 1.35,
                         display: "flex",
                         alignItems: "center",
                         gap: 1.5,
@@ -577,8 +798,8 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
             )}
           </Box>
         )}
-
       </Box>
+
       <Snackbar
         open={snackbar.open}
         autoHideDuration={6000}

--- a/frontend/src/components/ui/ContentCard.tsx
+++ b/frontend/src/components/ui/ContentCard.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Box } from '@mui/material';
 import type { SxProps, Theme } from '@mui/material';
+import type { ResponsiveStyleValue } from '@mui/system';
 
 interface ContentCardProps {
   children: React.ReactNode;
-  padding?: number | string;
+  padding?: ResponsiveStyleValue<number | string>;
   backgroundColor?: string;
   borderRadius?: string;
   sx?: SxProps<Theme>;

--- a/frontend/src/components/ui/ContentCard.tsx
+++ b/frontend/src/components/ui/ContentCard.tsx
@@ -18,15 +18,17 @@ const ContentCard: React.FC<ContentCardProps> = ({
   borderRadius = '0.5rem',
   sx = {},
 }) => {
+  const mergedSx: SxProps<Theme> = [
+    {
+      p: padding,
+      backgroundColor,
+      borderRadius,
+    },
+    ...(Array.isArray(sx) ? sx : [sx]),
+  ];
+
   return (
-    <Box
-      sx={{
-        p: padding,
-        backgroundColor,
-        borderRadius,
-        ...sx,
-      }}
-    >
+    <Box sx={mergedSx}>
       {children}
     </Box>
   );

--- a/frontend/src/components/ui/SurfaceCard.tsx
+++ b/frontend/src/components/ui/SurfaceCard.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import type { SxProps, Theme } from "@mui/material";
 import ContentCard from "./ContentCard";
+import {
+  analyzerSurfaceBackground,
+  analyzerSurfaceCardSx,
+  analyzerSurfaceRadius,
+} from "./analyzerStyles";
 
 interface SurfaceCardProps {
   children: React.ReactNode;
@@ -13,15 +18,17 @@ const SurfaceCard: React.FC<SurfaceCardProps> = ({
   padding = { xs: 2, md: 4 },
   sx = {},
 }) => {
+  const mergedSx: SxProps<Theme> = [
+    analyzerSurfaceCardSx,
+    ...(Array.isArray(sx) ? sx : [sx]),
+  ];
+
   return (
     <ContentCard
       padding={padding}
-      backgroundColor="rgba(40, 29, 56, 0.92)"
-      borderRadius="0.9rem"
-      sx={{
-        border: "1px solid rgba(95, 76, 123, 0.82)",
-        ...sx,
-      }}
+      backgroundColor={analyzerSurfaceBackground}
+      borderRadius={analyzerSurfaceRadius}
+      sx={mergedSx}
     >
       {children}
     </ContentCard>

--- a/frontend/src/components/ui/SurfaceCard.tsx
+++ b/frontend/src/components/ui/SurfaceCard.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import type { SxProps, Theme } from "@mui/material";
+import ContentCard from "./ContentCard";
+
+interface SurfaceCardProps {
+  children: React.ReactNode;
+  padding?: number | string;
+  sx?: SxProps<Theme>;
+}
+
+const SurfaceCard: React.FC<SurfaceCardProps> = ({
+  children,
+  padding = { xs: 2, md: 4 },
+  sx = {},
+}) => {
+  return (
+    <ContentCard
+      padding={padding}
+      backgroundColor="rgba(40, 29, 56, 0.92)"
+      borderRadius="0.9rem"
+      sx={{
+        border: "1px solid rgba(95, 76, 123, 0.82)",
+        ...sx,
+      }}
+    >
+      {children}
+    </ContentCard>
+  );
+};
+
+export default SurfaceCard;

--- a/frontend/src/components/ui/analyzerStyles.ts
+++ b/frontend/src/components/ui/analyzerStyles.ts
@@ -1,0 +1,39 @@
+import type { SxProps, Theme } from "@mui/material";
+
+export const analyzerShellBorder = "1px solid rgba(99, 114, 173, 0.35)";
+export const analyzerShellShadow = "inset 0 1px 0 rgba(255,255,255,0.04)";
+export const analyzerShellRadius = "1rem";
+
+export const analyzerShellGradients = {
+  emptyState:
+    "radial-gradient(circle at 18% 16%, rgba(37, 48, 116, 0.52), rgba(7, 11, 41, 0.97))",
+  processing:
+    "radial-gradient(circle at 18% 16%, rgba(35, 49, 116, 0.5), rgba(7, 12, 43, 0.97))",
+  results:
+    "radial-gradient(circle at 14% 10%, rgba(34, 48, 112, 0.4), rgba(6, 11, 42, 0.97))",
+  uploadCompact:
+    "radial-gradient(circle at 12% 10%, rgba(36, 48, 114, 0.44), rgba(7, 12, 44, 0.97))",
+  uploadFull:
+    "radial-gradient(circle at 10% 8%, rgba(35, 50, 116, 0.42), rgba(7, 11, 39, 0.97))",
+} as const;
+
+export const analyzerSurfaceBackground = "rgba(40, 29, 56, 0.92)";
+export const analyzerSurfaceBorder = "1px solid rgba(95, 76, 123, 0.82)";
+export const analyzerSurfaceRadius = "0.9rem";
+
+export const analyzerSurfaceCardSx: SxProps<Theme> = {
+  backgroundColor: analyzerSurfaceBackground,
+  borderRadius: analyzerSurfaceRadius,
+  border: analyzerSurfaceBorder,
+};
+
+export const buildAnalyzerShellSx = (
+  background: string,
+  sx: SxProps<Theme> = {}
+): SxProps<Theme> => ({
+  borderRadius: analyzerShellRadius,
+  border: analyzerShellBorder,
+  background,
+  boxShadow: analyzerShellShadow,
+  ...sx,
+});

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -11,6 +11,11 @@ export { default as SearchInput } from './SearchInput';
 export { default as MarkdownDisplay } from './MarkdownDisplay';
 export { default as Snackbar } from './Snackbar';
 export { default as ImageUploadButton } from './ImageUploadButton';
+export {
+  analyzerShellGradients,
+  analyzerSurfaceCardSx,
+  buildAnalyzerShellSx,
+} from './analyzerStyles';
 export { ChatMessageBubble } from './ChatMessageBubble';
 export { ChatEmptyState } from './ChatEmptyState';
 export { ChatLoadingIndicator } from './ChatLoadingIndicator';

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -1,5 +1,6 @@
 export { default as CustomButton } from './CustomButton';
 export { default as ContentCard } from './ContentCard';
+export { default as SurfaceCard } from './SurfaceCard';
 export { default as LoadingSpinner } from './LoadingSpinner';
 export { default as ErrorAlert } from './ErrorAlert';
 export { default as SectionTitle } from './SectionTitle';


### PR DESCRIPTION
## Summary
- align the analyzer tab states more closely with the target desktop and mobile designs
- improve upload, processing, OCR-only, and final analysis states and simplify the compact processing overlay
- extract reusable analyzer surface styling into a shared `SurfaceCard` UI component

## Testing
- make frontend-lint
- make frontend-test
- cd frontend && npm run build

## Notes
- `make check-readiness` is currently blocked by an unrelated existing import-order lint issue in `src/runestone/services/vocabulary_service.py`
- independent `dev-independent-code-review` completed and approved; it surfaced one low-severity processing-state visibility gap, which is fixed in this branch
