### PR TITLE
Improve logging readability and align tests

### DIFF
--- a/src/runestone/agents/manager.py
+++ b/src/runestone/agents/manager.py
@@ -43,7 +43,7 @@ class AgentsManager:
     """
     Service for managing chat agent interactions using specialist agents.
 
-    All log lines should be prefixed with `[agents:manager]` for consistency.
+    Logs are emitted from a single manager producer and include per-event context fields.
     """
 
     COORDINATOR_MAX_HISTORY_MESSAGES = 5
@@ -82,12 +82,12 @@ class AgentsManager:
         self._post_task_registry = BackgroundTaskRegistry(logger=logger, key_name="chat_id")
         self._memory_maintenance_registry = BackgroundTaskRegistry(
             logger=logger,
-            log_prefix="[agents:memory-maintenance]",
+            log_prefix="memory-maintenance",
             key_name="user_id",
         )
 
         logger.info(
-            "[agents:manager] Initialized AgentsManager with provider=%s, model=%s, persona=%s",
+            "agents manager initialized provider=%s model=%s persona=%s",
             settings.teacher_provider,
             settings.teacher_model,
             settings.agent_persona,
@@ -101,7 +101,7 @@ class AgentsManager:
                 if app_parsed.port:
                     self.allowed_ports.add(app_parsed.port)
         except (ValueError, AttributeError) as e:
-            logger.warning("[agents:manager] Configuration issue with allowed_origins: %s", e)
+            logger.warning("allowed_origins configuration issue: %s", e)
 
     # ------------------------------------------------------------------
     # Phase methods (public, individually testable)
@@ -132,14 +132,12 @@ class AgentsManager:
                 )
                 if deleted_count:
                     logger.info(
-                        "[agents:manager] Cleaned up %s old mastered memory items for user %s",
+                        "old mastered memory items cleaned up count=%s user_id=%s",
                         deleted_count,
                         user.id,
                     )
             except (SQLAlchemyError, ValueError, RuntimeError) as e:
-                logger.warning(
-                    "[agents:manager] Failed to cleanup old mastered memory items for user %s: %s", user.id, e
-                )
+                logger.warning("old mastered memory cleanup failed user_id=%s error=%s", user.id, e)
             try:
                 starter_items = await memory_item_service.list_start_student_info_items(
                     user.id,
@@ -149,13 +147,13 @@ class AgentsManager:
                 if starter_items:
                     starter_memory = serialize_memory_items(starter_items)
             except (SQLAlchemyError, ValueError, RuntimeError) as e:
-                logger.warning("[agents:manager] Failed to load starter memory for user %s: %s", user.id, e)
+                logger.warning("starter memory load failed user_id=%s error=%s", user.id, e)
             current_recall_words = self._load_current_recall_words(user)
 
         coordinator_history = history[-self.COORDINATOR_MAX_HISTORY_MESSAGES :] if history else []
         if history and len(history) > self.COORDINATOR_MAX_HISTORY_MESSAGES:
             logger.warning(
-                "[agents:manager] Truncated coordinator history from %s to %s messages",
+                "coordinator history truncated from=%s to=%s",
                 len(history),
                 len(coordinator_history),
             )
@@ -167,7 +165,7 @@ class AgentsManager:
                 available_specialists=[name for name in self.registry.list_names() if name != "teacher"],
             )
         except (RunestoneError, ValueError, RuntimeError) as e:
-            logger.error("[agents:manager] Coordinator failed, falling back to teacher only: %s", e)
+            logger.error("coordinator failed, falling back to teacher only: %s", e)
 
         if plan is None:
             plan = CoordinatorPlan(
@@ -176,7 +174,7 @@ class AgentsManager:
                 audit={"fallback": "coordinator_error"},
             )
         logger.info(
-            "[agents:manager] Pre-phase selection: user_id=%s specialists=%s",
+            "pre-phase selection user_id=%s specialists=%s",
             user.id,
             ",".join([item.name for item in plan.pre_response]) if plan.pre_response else "none",
         )
@@ -218,7 +216,7 @@ class AgentsManager:
                 current_recall_words=current_recall_words or [],
             )
         except (RunestoneError, ValueError, RuntimeError) as e:
-            logger.error("[agents:manager] Error generating response: %s", e)
+            logger.error("teacher response generation failed: %s", e)
             raise
 
         sources = self._extract_sources(
@@ -329,7 +327,7 @@ class AgentsManager:
             )
             if not persisted:
                 logger.warning(
-                    "[agents:manager] Skipped stale post-turn persistence: user_id=%s chat_id=%s row_id=%s",
+                    "stale post-turn persistence skipped user_id=%s chat_id=%s row_id=%s",
                     user.id,
                     chat_id,
                     coordinator_row_id,
@@ -342,7 +340,7 @@ class AgentsManager:
                     chat_id=chat_id,
                 )
                 logger.warning(
-                    "[agents:manager] Post-turn completed with coordinator failure: user_id=%s chat_id=%s",
+                    "post-turn completed with coordinator failure user_id=%s chat_id=%s",
                     user.id,
                     chat_id,
                 )
@@ -352,9 +350,9 @@ class AgentsManager:
                 user_id=user.id,
                 chat_id=chat_id,
             )
-            logger.info("[agents:manager] Post-turn completed: user_id=%s chat_id=%s", user.id, chat_id)
+            logger.info("post-turn completed user_id=%s chat_id=%s", user.id, chat_id)
         except Exception:
-            logger.error("[agents:manager] Post-turn failed: user_id=%s chat_id=%s", user.id, chat_id, exc_info=True)
+            logger.error("post-turn failed user_id=%s chat_id=%s", user.id, chat_id, exc_info=True)
             await side_effect_service.mark_coordinator_failed_if_current(
                 row_id=coordinator_row_id,
                 user_id=user.id,
@@ -381,7 +379,7 @@ class AgentsManager:
             coordinator_history = history[-self.COORDINATOR_MAX_HISTORY_MESSAGES :] if history else []
             if history and len(history) > self.COORDINATOR_MAX_HISTORY_MESSAGES:
                 logger.warning(
-                    "[agents:manager] Truncated coordinator history from %s to %s messages",
+                    "coordinator history truncated from=%s to=%s",
                     len(history),
                     len(coordinator_history),
                 )
@@ -396,7 +394,7 @@ class AgentsManager:
             )
             post_items = [item for item in plan.post_response if item.name != "word_keeper"]
             logger.info(
-                "[agents:manager] Post-phase selection: user_id=%s specialists=%s",
+                "Post-phase selection: user_id=%s specialists=%s",
                 user.id,
                 ",".join([item.name for item in post_items]) if post_items else "none",
             )
@@ -439,7 +437,7 @@ class AgentsManager:
         if isinstance(coordinator_results, Exception):
             coordinator_failed = True
             logger.error(
-                "[agents:manager] Coordinator post branch failed",
+                "coordinator post branch failed",
                 exc_info=(type(coordinator_results), coordinator_results, coordinator_results.__traceback__),
             )
         else:
@@ -447,7 +445,7 @@ class AgentsManager:
 
         if isinstance(word_keeper_results, Exception):
             logger.error(
-                "[agents:manager] Direct WordKeeper post branch failed",
+                "direct word keeper post branch failed",
                 exc_info=(type(word_keeper_results), word_keeper_results, word_keeper_results.__traceback__),
             )
         else:
@@ -480,7 +478,7 @@ class AgentsManager:
         existing_task = self._memory_maintenance_registry.tasks.get(user_key)
         if existing_task and not existing_task.done():
             logger.info(
-                "[agents:memory-maintenance] Skipping schedule because maintenance is already running: user_id=%s",
+                "memory maintenance schedule skipped; already running user_id=%s",
                 user.id,
             )
             return False
@@ -493,7 +491,7 @@ class AgentsManager:
                 )
                 artifacts = result.artifacts if isinstance(result.artifacts, dict) else {}
                 logger.info(
-                    "[agents:memory-maintenance] Completed: user_id=%s status=%s actions=%s reviewed=%s merged=%s "
+                    "memory maintenance completed user_id=%s status=%s actions=%s reviewed=%s merged=%s "
                     "priority_updates=%s",
                     user.id,
                     result.status,
@@ -508,13 +506,13 @@ class AgentsManager:
                 )
             except asyncio.TimeoutError:
                 logger.error(
-                    "[agents:memory-maintenance] Timed out after %ss: user_id=%s",
+                    "memory maintenance timed out timeout_s=%s user_id=%s",
                     self.MEMORY_MAINTENANCE_TIMEOUT_SECONDS,
                     user.id,
                 )
             except Exception:
                 logger.error(
-                    "[agents:memory-maintenance] Failed: user_id=%s",
+                    "memory maintenance failed user_id=%s",
                     user.id,
                     exc_info=True,
                 )
@@ -523,7 +521,7 @@ class AgentsManager:
 
         task = asyncio.create_task(_run())
         self._memory_maintenance_registry.register(user_key, task)
-        logger.info("[agents:memory-maintenance] Background task started: user_id=%s", user.id)
+        logger.info("memory maintenance background task started user_id=%s", user.id)
         return True
 
     async def run_memory_maintenance(self, user: User) -> SpecialistResult:
@@ -572,7 +570,7 @@ class AgentsManager:
                         )
                     except asyncio.TimeoutError:
                         logger.error(
-                            "[agents:post-task] Post task timed out after %ss: chat_id=%s",
+                            "post task timed out timeout_s=%s chat_id=%s",
                             self.POST_TASK_TIMEOUT_SECONDS,
                             chat_id,
                         )
@@ -582,7 +580,7 @@ class AgentsManager:
                             chat_id=chat_id,
                         )
                     except asyncio.CancelledError:
-                        logger.info("[agents:post-task] Post task cancelled: chat_id=%s", chat_id)
+                        logger.info("post task cancelled chat_id=%s", chat_id)
                         await background_side_effect_service.mark_coordinator_failed_if_current(
                             row_id=coordinator_row_id,
                             user_id=user.id,
@@ -594,7 +592,7 @@ class AgentsManager:
         task = asyncio.create_task(_run())
         self._register_post_task(chat_id, task)
         logger.info(
-            "[agents:post-task] Background task started: chat_id=%s timeout=%ss",
+            "post task background task started chat_id=%s timeout_s=%s",
             chat_id,
             self.POST_TASK_TIMEOUT_SECONDS,
         )
@@ -615,7 +613,7 @@ class AgentsManager:
             return
 
         logger.warning(
-            "[agents:post-task] Stale post coordinator row detected: chat_id=%s status=%s — cancelling",
+            "stale post coordinator row detected chat_id=%s status=%s; cancelling",
             chat_id,
             coordinator_row.status,
         )
@@ -630,7 +628,7 @@ class AgentsManager:
             )
         except Exception:
             logger.warning(
-                "[agents:post-task] Failed to mark stale coordinator row as failed: chat_id=%s",
+                "failed to mark stale coordinator row as failed chat_id=%s",
                 chat_id,
                 exc_info=True,
             )
@@ -664,7 +662,7 @@ class AgentsManager:
             history_window = history[-effective_history_size:] if effective_history_size else []
             if effective_history_size and len(history) > effective_history_size:
                 logger.warning(
-                    "[agents:manager] Truncated specialist history for '%s' from %s to %s messages",
+                    "specialist history truncated specialist=%s from=%s to=%s",
                     item.name,
                     len(history),
                     len(history_window),
@@ -687,7 +685,7 @@ class AgentsManager:
                 result = await specialist.run(context)
                 latency_ms = elapsed_ms_since(started)
                 logger.info(
-                    "[agents:%s] Result: status=%s latency_ms=%s",
+                    "specialist=%s status=%s latency_ms=%s",
                     item.name,
                     result.status,
                     latency_ms,
@@ -697,7 +695,7 @@ class AgentsManager:
                         artifacts_json = json.dumps(result.artifacts, ensure_ascii=False, default=str)
                     except (TypeError, ValueError):
                         artifacts_json = repr(result.artifacts)
-                    logger.info("[agents:%s] Artifacts: %s", item.name, artifacts_json)
+                    logger.info("specialist=%s artifacts=%s", item.name, artifacts_json)
                 return {
                     "name": item.name,
                     "result": result.model_dump(),
@@ -706,7 +704,7 @@ class AgentsManager:
                 }
             except Exception:
                 latency_ms = elapsed_ms_since(started)
-                logger.warning("[agents:manager] Specialist '%s' failed", item.name, exc_info=True)
+                logger.warning("specialist failed name=%s", item.name, exc_info=True)
                 return {
                     "name": item.name,
                     # Avoid feeding verbose/technical error details back into the teacher context.
@@ -719,9 +717,9 @@ class AgentsManager:
         for item in routing_items:
             specialist = self.registry.get(item.name)
             if specialist is None:
-                logger.info("[agents:manager] Missing specialist '%s' - skipping", item.name)
+                logger.info("specialist missing; skipping name=%s", item.name)
                 continue
-            logger.info("[agents:manager] Running specialist '%s' reason=%s", item.name, item.reason)
+            logger.info("running specialist name=%s reason=%s", item.name, item.reason)
             tasks.append(_invoke(item, specialist))
 
         if not tasks:
@@ -742,7 +740,7 @@ class AgentsManager:
                 return []
             if user_data.db_user_id != user.id:
                 logger.warning(
-                    "[agents:manager] Recall state user mismatch for user %s: state db_user_id=%s",
+                    "recall state user mismatch user_id=%s state_db_user_id=%s",
                     user.id,
                     user_data.db_user_id,
                 )
@@ -752,7 +750,7 @@ class AgentsManager:
             return words
         except Exception as e:
             logger.warning(
-                "[agents:manager] Failed to load current recall words for user %s: %s",
+                "current recall words load failed user_id=%s error=%s",
                 user.id,
                 e,
             )
@@ -886,13 +884,13 @@ class AgentsManager:
         sources: list[dict[str, str]] = []
         for url in grammar_source_urls:
             if url not in allowed_urls:
-                logger.info("[agents:manager] Rejected grammar source URL (not returned by search_grammar): %s", url)
+                logger.info("grammar source url rejected reason=not_returned_by_search_grammar url=%s", url)
                 continue
             if url in seen_urls:
-                logger.info("[agents:manager] Rejected grammar source URL (duplicate): %s", url)
+                logger.info("grammar source url rejected reason=duplicate url=%s", url)
                 continue
             if not self._is_safe_url(url):
-                logger.info("[agents:manager] Rejected grammar source URL (unsafe): %s", url)
+                logger.info("grammar source url rejected reason=unsafe url=%s", url)
                 continue
             sources.append({"title": self._format_grammar_source_title(url), "url": url, "date": ""})
             seen_urls.add(url)
@@ -962,24 +960,24 @@ class AgentsManager:
         try:
             parsed = urlparse(url)
         except ValueError:
-            logger.info("[agents:manager] Rejected source URL (parse error): %s", url)
+            logger.info("source url rejected reason=parse_error url=%s", url)
             return False
         if parsed.username or parsed.password:
-            logger.info("[agents:manager] Rejected source URL (credentials not allowed): %s", url)
+            logger.info("source url rejected reason=credentials_not_allowed url=%s", url)
             return False
         try:
             port = parsed.port
         except ValueError:
-            logger.info("[agents:manager] Rejected source URL (invalid port): %s", url)
+            logger.info("source url rejected reason=invalid_port url=%s", url)
             return False
         if parsed.scheme not in {"http", "https"}:
-            logger.info("[agents:manager] Rejected source URL (scheme not allowed): %s", url)
+            logger.info("source url rejected reason=scheme_not_allowed url=%s", url)
             return False
 
         if port is not None and port not in self.allowed_ports:
-            logger.info("[agents:manager] Rejected source URL (port not allowed): %s", url)
+            logger.info("source url rejected reason=port_not_allowed url=%s", url)
             return False
         if not parsed.netloc:
-            logger.info("[agents:manager] Rejected source URL (missing netloc): %s", url)
+            logger.info("source url rejected reason=missing_netloc url=%s", url)
             return False
         return True

--- a/src/runestone/agents/manager.py
+++ b/src/runestone/agents/manager.py
@@ -394,7 +394,7 @@ class AgentsManager:
             )
             post_items = [item for item in plan.post_response if item.name != "word_keeper"]
             logger.info(
-                "Post-phase selection: user_id=%s specialists=%s",
+                "post-phase selection user_id=%s specialists=%s",
                 user.id,
                 ",".join([item.name for item in post_items]) if post_items else "none",
             )

--- a/src/runestone/api/chat_endpoints.py
+++ b/src/runestone/api/chat_endpoints.py
@@ -59,19 +59,19 @@ async def send_message(
     History is now managed on the backend.
     """
     try:
-        logger.info(f"User {current_user.email} sent message: {request.message[:50]}...")
+        logger.info("chat message received user_id=%s message_length=%s", current_user.id, len(request.message))
 
         # Generate response using the chat service which handles persistence
         response_message, sources, teacher_emotion = await chat_service.process_message(
             current_user.id, request.message, tts_expected=request.tts_expected, speed=request.speed
         )
 
-        logger.info(f"Generated response for user {current_user.email}")
+        logger.info("chat response generated user_id=%s", current_user.id)
 
         return ChatResponse(message=response_message, sources=sources, teacher_emotion=teacher_emotion)
 
     except Exception as e:
-        logger.error(f"Error generating chat response: {e}", exc_info=True)
+        logger.error("chat response generation failed: %s", e, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to generate response. Please try again."
         )
@@ -96,7 +96,7 @@ async def get_history(
             client_chat_id=client_chat_id,
         )
     except Exception as e:
-        logger.error(f"Error fetching chat history: {e}", exc_info=True)
+        logger.error("chat history fetch failed: %s", e, exc_info=True)
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to fetch chat history.")
 
 
@@ -114,7 +114,7 @@ async def send_image(
     """
     # Validate file type
     if not file.content_type or not file.content_type.startswith("image/"):
-        logger.warning(f"Invalid file type: {file.content_type}")
+        logger.warning("invalid image content type: %s", file.content_type)
         raise HTTPException(
             status_code=400,
             detail="Invalid file type. Please upload an image file.",
@@ -133,13 +133,13 @@ async def send_image(
 
     try:
         start_time = time.time()
-        logger.info(f"[IMAGE_UPLOAD] User {current_user.email} uploaded image ({file_size} bytes), starting OCR")
+        logger.info("image upload received user_id=%s file_size_bytes=%s", current_user.id, file_size)
 
         # Process OCR text through agent for translation
         response_message, teacher_emotion = await chat_service.process_image_message(current_user.id, content)
 
         elapsed = time.time() - start_time
-        logger.info(f"[IMAGE_UPLOAD] Image processing completed for user {current_user.email} in {elapsed:.3f}s")
+        logger.info("image processing completed user_id=%s latency_s=%.3f", current_user.id, elapsed)
 
         return ImageChatResponse(message=response_message, teacher_emotion=teacher_emotion)
 
@@ -147,13 +147,13 @@ async def send_image(
         # Re-raise HTTP exceptions as-is
         raise
     except RunestoneError as e:
-        logger.error(f"OCR error: {e}", exc_info=True)
+        logger.error("image OCR failed: %s", e, exc_info=True)
         raise HTTPException(
             status_code=400,
             detail="Could not recognize text from image",
         )
     except Exception as e:
-        logger.error(f"Error processing image: {e}", exc_info=True)
+        logger.error("image processing failed: %s", e, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to process image. Please try again.",
@@ -189,7 +189,7 @@ async def start_new_chat(
         await chat_service.start_new_chat(current_user.id)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     except Exception as e:
-        logger.error(f"Error starting new chat session: {e}", exc_info=True)
+        logger.error("start new chat failed user_id=%s: %s", current_user.id, e, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to start new chat session."
         )
@@ -213,7 +213,7 @@ async def transcribe_voice(
     """
     # Validate file type
     if not file.content_type or not file.content_type.startswith("audio/"):
-        logger.warning(f"Invalid file type for voice transcription: {file.content_type}")
+        logger.warning("invalid voice content type: %s", file.content_type)
         raise HTTPException(
             status_code=400,
             detail="Invalid file type. Please upload an audio file.",
@@ -244,23 +244,23 @@ async def transcribe_voice(
         )
 
     try:
-        logger.info(f"User {current_user.email} requested voice transcription (improve={improve})")
+        logger.info("voice transcription requested user_id=%s improve=%s", current_user.id, improve)
         transcribed_text = await voice_service.process_voice_input(
             content, improve=improve, language=transcription_language
         )
 
-        logger.info(f"Voice transcription completed for user {current_user.email}")
+        logger.info("voice transcription completed user_id=%s", current_user.id)
 
         return VoiceTranscriptionResponse(text=transcribed_text)
 
     except RunestoneError as e:
-        logger.error(f"Transcription error: {e}", exc_info=True)
+        logger.error("voice transcription failed: %s", e, exc_info=True)
         raise HTTPException(
             status_code=400,
             detail=str(e),
         )
     except Exception as e:
-        logger.error(f"Error processing voice: {e}", exc_info=True)
+        logger.error("voice processing failed: %s", e, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to transcribe voice. Please try again.",

--- a/src/runestone/api/endpoints.py
+++ b/src/runestone/api/endpoints.py
@@ -77,7 +77,7 @@ async def process_ocr(
     """
     # Validate file type
     if not file.content_type or not file.content_type.startswith("image/"):
-        logger.warning(f"[API] Invalid file type: {file.content_type}")
+        logger.warning("invalid image content type: %s", file.content_type)
         raise HTTPException(
             status_code=400,
             detail="Invalid file type. Please upload an image file.",
@@ -99,19 +99,19 @@ async def process_ocr(
 
         # OCRResult object - return directly (unified schema)
         stats = ocr_result.recognition_statistics
-        logger.debug(f"[API] Result stats: {stats.successfully_transcribed}/{stats.total_elements} elements")
+        logger.debug("ocr result stats transcribed=%s total=%s", stats.successfully_transcribed, stats.total_elements)
         return ocr_result
 
     except RunestoneError as e:
-        logger.error(f"[API] RunestoneError: {type(e).__name__}: {str(e)}")
-        logger.debug("[API] Full exception traceback:", exc_info=True)
+        logger.error("ocr failed error_type=%s error=%s", type(e).__name__, str(e))
+        logger.debug("ocr traceback", exc_info=True)
         raise HTTPException(
             status_code=500,
             detail=f"OCR failed: {str(e)}",
         )
     except Exception as e:
-        logger.error(f"[API] Unexpected error: {type(e).__name__}: {str(e)}")
-        logger.debug("[API] Full exception traceback:", exc_info=True)
+        logger.error("ocr failed unexpectedly error_type=%s error=%s", type(e).__name__, str(e))
+        logger.debug("ocr traceback", exc_info=True)
         raise HTTPException(
             status_code=500,
             detail=f"Unexpected error: {type(e).__name__}: {str(e)}",
@@ -148,7 +148,7 @@ async def analyze_content(
     Raises:
         HTTPException: For various error conditions
     """
-    logger.info(f"[API] Analysis request received: text_length={len(request.text)} chars")
+    logger.info("analysis request received text_length=%s", len(request.text))
 
     try:
         # Run content analysis
@@ -156,20 +156,20 @@ async def analyze_content(
 
         # ContentAnalysis object - return directly (unified schema)
         vocab_count = len(analysis_result.vocabulary)
-        logger.debug(f"[API] Found {vocab_count} vocabulary items")
+        logger.debug("analysis vocabulary count=%s", vocab_count)
 
         return analysis_result
 
     except RunestoneError as e:
-        logger.error(f"[API] RunestoneError during analysis: {type(e).__name__}: {str(e)}")
-        logger.debug("[API] Full exception traceback:", exc_info=True)
+        logger.error("analysis failed error_type=%s error=%s", type(e).__name__, str(e))
+        logger.debug("analysis traceback", exc_info=True)
         raise HTTPException(
             status_code=500,
             detail=f"Analysis failed: {str(e)}",
         )
     except Exception as e:
-        logger.error(f"[API] Unexpected error during analysis: {type(e).__name__}: {str(e)}")
-        logger.debug("[API] Full exception traceback:", exc_info=True)
+        logger.error("analysis failed unexpectedly error_type=%s error=%s", type(e).__name__, str(e))
+        logger.debug("analysis traceback", exc_info=True)
         raise HTTPException(
             status_code=500,
             detail=f"Unexpected error: {type(e).__name__}: {str(e)}",
@@ -210,7 +210,7 @@ async def save_vocabulary(
         return await service.save_vocabulary(request.items, current_user.id, request.enrich)
 
     except Exception:
-        logger.exception("Failed to save vocabulary items")
+        logger.exception("save vocabulary items failed")
         raise HTTPException(
             status_code=500,
             detail="An error occurred while saving vocabulary items. Please try again later.",
@@ -257,7 +257,7 @@ async def save_vocabulary_item(
             detail=str(e),
         )
     except Exception:
-        logger.exception("Failed to save single vocabulary item")
+        logger.exception("save single vocabulary item failed")
         raise HTTPException(
             status_code=500,
             detail="An error occurred while saving the vocabulary item. Please try again later.",
@@ -280,7 +280,7 @@ async def get_vocabulary_stats(
     try:
         return await service.get_vocabulary_stats(current_user.id)
     except Exception:
-        logger.exception("Failed to retrieve vocabulary stats")
+        logger.exception("retrieve vocabulary stats failed")
         raise HTTPException(
             status_code=500,
             detail="An error occurred while retrieving vocabulary stats. Please try again later.",
@@ -342,7 +342,7 @@ async def get_vocabulary(
     except HTTPException:
         raise
     except Exception:
-        logger.exception("Failed to retrieve vocabulary")
+        logger.exception("retrieve vocabulary failed")
         raise HTTPException(
             status_code=500,
             detail="An error occurred while retrieving vocabulary. Please try again later.",
@@ -398,7 +398,7 @@ async def update_vocabulary(
         )
 
     except Exception as exc:
-        logger.exception(f"Failed to update vocabulary item {item_id}")
+        logger.exception("failed to update vocabulary item_id=%s", item_id)
         # Check for specific database integrity errors
         error_str = str(exc).lower()
         if "unique" in error_str or "duplicate" in error_str:
@@ -464,7 +464,7 @@ async def delete_vocabulary(
             detail=str(e),
         )
     except Exception:
-        logger.exception(f"Failed to delete vocabulary item {item_id}")
+        logger.exception("failed to delete vocabulary item_id=%s", item_id)
         raise HTTPException(
             status_code=500,
             detail="An error occurred while deleting the vocabulary item. Please try again later.",
@@ -507,7 +507,7 @@ async def improve_vocabulary(
         return result
 
     except Exception:
-        logger.exception("Failed to improve vocabulary")
+        logger.exception("improve vocabulary failed")
         raise HTTPException(
             status_code=500,
             detail="An internal error occurred while improving vocabulary.",
@@ -564,7 +564,7 @@ async def search_grammar_cheatsheets(
         result_items = await service.search_cheatsheets_async(grammar_index, query, top_k)
         return GrammarSearchResponse(results=[GrammarSearchResult(**item) for item in result_items])
     except Exception:
-        logger.exception("Failed to search grammar cheatsheets")
+        logger.exception("search grammar cheatsheets failed")
         raise HTTPException(
             status_code=500,
             detail="Failed to search grammar cheatsheets",
@@ -597,7 +597,7 @@ async def list_cheatsheets(
         cheatsheets = service.list_cheatsheets()
         return [CheatsheetInfo(**cs) for cs in cheatsheets]
     except Exception as e:
-        logger.error(f"Failed to list cheatsheets: {e}")
+        logger.error("list cheatsheets failed: %s", e)
         raise HTTPException(
             status_code=500,
             detail="Failed to retrieve cheatsheets",
@@ -645,7 +645,7 @@ async def get_cheatsheet_content(
             detail=str(e),
         )
     except Exception as e:
-        logger.error(f"Failed to get cheatsheet content for {filepath}: {e}")
+        logger.error("get cheatsheet content failed filepath=%s error=%s", filepath, e)
         raise HTTPException(
             status_code=500,
             detail="Failed to retrieve cheatsheet content",

--- a/src/runestone/core/logging_config.py
+++ b/src/runestone/core/logging_config.py
@@ -6,8 +6,51 @@ for consistent logging across the application.
 """
 
 import logging
+import os
+import re
 import sys
 from typing import Optional
+
+from rich.console import Console
+from rich.logging import RichHandler
+
+_LEADING_TAG_RE = re.compile(r"^\[[^\]]+\]\s*")
+
+
+class RunestoneLogFilter(logging.Filter):
+    """Attach derived display fields used by the log formatter."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.producer = _derive_producer(record.name)
+        if isinstance(record.msg, str):
+            record.msg = _LEADING_TAG_RE.sub("", record.msg)
+        return True
+
+
+def _derive_producer(logger_name: str) -> str:
+    """Build a compact, human-readable producer label from logger name."""
+    parts = logger_name.split(".")
+    if len(parts) >= 3 and parts[0] == "runestone":
+        return ".".join(parts[-2:])
+    if len(parts) >= 2:
+        return ".".join(parts[-2:])
+    return logger_name
+
+
+def _resolve_color_setting() -> bool | None:
+    """Resolve whether ANSI colors should be enabled for log output.
+
+    Returns:
+        True: force colors on
+        False: force colors off
+        None: auto-detect from output environment
+    """
+    setting = os.getenv("RUNESTONE_LOG_COLOR", "auto").strip().lower()
+    if setting in {"1", "true", "yes", "on"}:
+        return True
+    if setting in {"0", "false", "no", "off"}:
+        return False
+    return None
 
 
 def setup_logging(level: str = "INFO", format_string: Optional[str] = None, verbose: bool = False) -> None:
@@ -20,18 +63,49 @@ def setup_logging(level: str = "INFO", format_string: Optional[str] = None, verb
         verbose: If True, set log level to DEBUG for detailed logging
     """
     if format_string is None:
-        format_string = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        format_string = "%(asctime)s | %(levelname)-8s | %(producer)-22s | %(message)s"
 
     # Use DEBUG level if verbose mode is enabled
     if verbose:
         level = "DEBUG"
 
-    # Configure root logger
-    logging.basicConfig(
-        level=getattr(logging, level.upper()),
-        format=format_string,
-        stream=sys.stdout,
-    )
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+    root_logger.setLevel(getattr(logging, level.upper()))
+
+    log_filter = RunestoneLogFilter()
+    date_format = "%Y-%m-%d %H:%M:%S"
+    show_color = _resolve_color_setting()
+
+    if show_color is True:
+        force_terminal = True if show_color else None
+        handler = RichHandler(
+            console=Console(file=sys.stdout, force_terminal=force_terminal),
+            rich_tracebacks=True,
+            show_time=False,
+            show_level=False,
+            show_path=False,
+            markup=False,
+            log_time_format=date_format,
+        )
+        handler.setFormatter(logging.Formatter(format_string, datefmt=date_format))
+    elif show_color is None and sys.stdout.isatty():
+        handler = RichHandler(
+            console=Console(file=sys.stdout),
+            rich_tracebacks=True,
+            show_time=False,
+            show_level=False,
+            show_path=False,
+            markup=False,
+            log_time_format=date_format,
+        )
+        handler.setFormatter(logging.Formatter(format_string, datefmt=date_format))
+    else:
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(logging.Formatter(format_string, datefmt=date_format))
+
+    handler.addFilter(log_filter)
+    root_logger.addHandler(handler)
 
     # Set specific loggers if needed
     # Suppress noisy loggers from third-party libraries

--- a/src/runestone/core/logging_config.py
+++ b/src/runestone/core/logging_config.py
@@ -77,10 +77,9 @@ def setup_logging(level: str = "INFO", format_string: Optional[str] = None, verb
     date_format = "%Y-%m-%d %H:%M:%S"
     show_color = _resolve_color_setting()
 
-    if show_color is True:
-        force_terminal = True if show_color else None
+    if show_color is True or (show_color is None and sys.stdout.isatty()):
         handler = RichHandler(
-            console=Console(file=sys.stdout, force_terminal=force_terminal),
+            console=Console(file=sys.stdout, force_terminal=show_color),
             rich_tracebacks=True,
             show_time=False,
             show_level=False,
@@ -88,21 +87,10 @@ def setup_logging(level: str = "INFO", format_string: Optional[str] = None, verb
             markup=False,
             log_time_format=date_format,
         )
-        handler.setFormatter(logging.Formatter(format_string, datefmt=date_format))
-    elif show_color is None and sys.stdout.isatty():
-        handler = RichHandler(
-            console=Console(file=sys.stdout),
-            rich_tracebacks=True,
-            show_time=False,
-            show_level=False,
-            show_path=False,
-            markup=False,
-            log_time_format=date_format,
-        )
-        handler.setFormatter(logging.Formatter(format_string, datefmt=date_format))
     else:
         handler = logging.StreamHandler(sys.stdout)
-        handler.setFormatter(logging.Formatter(format_string, datefmt=date_format))
+
+    handler.setFormatter(logging.Formatter(format_string, datefmt=date_format))
 
     handler.addFilter(log_filter)
     root_logger.addHandler(handler)

--- a/src/runestone/core/ocr.py
+++ b/src/runestone/core/ocr.py
@@ -214,7 +214,7 @@ class OCRProcessor:
 
             image_data_url = self._image_to_data_url(preprocessed_image)
             self.logger.info(
-                "Extracting text with provider=%s model=%s",
+                "extracting text provider=%s model=%s",
                 self.settings.resolve_ocr_llm_provider(),
                 self.settings.resolve_ocr_llm_model(),
             )

--- a/src/runestone/core/ocr.py
+++ b/src/runestone/core/ocr.py
@@ -134,23 +134,23 @@ class OCRProcessor:
             Preprocessed PIL Image object with minimal adjustments
         """
         try:
-            self.logger.debug(f"Starting minimal image preprocessing: mode={image.mode}, size={image.size}")
+            self.logger.debug(f"minimal image preprocessing started mode={image.mode} size={image.size}")
 
             # Only ensure RGB format for LLM compatibility - no aggressive preprocessing
             # Based on user feedback: preprocessing causes more harm than good for accuracy
             if image.mode != "RGB":
                 final_image = image.convert("RGB")
-                self.logger.debug("Converted image to RGB format for LLM compatibility")
+                self.logger.debug("image converted to RGB for llm compatibility")
             else:
                 final_image = image
 
-            self.logger.debug(f"Minimal preprocessing complete: mode={final_image.mode}, size={final_image.size}")
+            self.logger.debug(f"minimal preprocessing completed mode={final_image.mode} size={final_image.size}")
 
             return final_image
 
         except (AttributeError, TypeError) as e:
             # Handle cases where we might be working with a mock object during testing
-            self.logger.warning(f"Image preprocessing failed ({str(e)}), using original image")
+            self.logger.warning("image preprocessing failed error=%s; using original image", str(e))
 
             # Return original image if preprocessing fails (e.g., during testing with mocks)
             # Ensure it's in RGB format for LLM processing
@@ -183,38 +183,38 @@ class OCRProcessor:
         start_time = time.time()
         try:
             # Log original image characteristics for debugging
-            self.logger.debug(f"[OCRProcessor] Starting text extraction: mode={image.mode}, size={image.size}")
+            self.logger.debug(f"text extraction started mode={image.mode} size={image.size}")
 
             # Basic validation and size adjustment
             if image.mode not in ["RGB", "RGBA", "L"]:
-                self.logger.debug(f"[OCRProcessor] Converting image from {image.mode} to RGB")
+                self.logger.debug(f"image converting to RGB from_mode={image.mode}")
                 image = image.convert("RGB")
 
             # Check image size (basic validation)
             width, height = image.size
             if width < 100 or height < 100:
-                self.logger.error(f"[OCRProcessor] Image too small: {width}x{height}")
+                self.logger.error(f"image too small width={width} height={height}")
                 raise ImageProcessingError("Image is too small (minimum 100x100 pixels)")
 
             if width > 4096 or height > 4096:
                 # Resize large images to prevent API issues
-                self.logger.debug(f"[OCRProcessor] Resizing large image from {image.size}")
+                self.logger.debug(f"large image resizing from_size={image.size}")
                 image.thumbnail((4096, 4096), Image.Resampling.LANCZOS)
-                self.logger.debug(f"[OCRProcessor] Resized to {image.size}")
+                self.logger.debug(f"large image resized to_size={image.size}")
 
             # ENHANCEMENT: Apply preprocessing for better light-blue text detection
-            self.logger.debug("[OCRProcessor] Applying image preprocessing...")
+            self.logger.debug("image preprocessing started")
             preprocessed_image = self._preprocess_image_for_ocr(image)
-            self.logger.debug("[OCRProcessor] Preprocessing complete")
+            self.logger.debug("image preprocessing completed")
 
             # Build OCR prompt using PromptBuilder
-            self.logger.debug("[OCRProcessor] Building OCR prompt...")
+            self.logger.debug("ocr prompt build started")
             ocr_prompt = self.builder.build_ocr_prompt()
-            self.logger.debug(f"[OCRProcessor] Prompt built, length: {len(ocr_prompt)} chars")
+            self.logger.debug("ocr prompt built length=%s", len(ocr_prompt))
 
             image_data_url = self._image_to_data_url(preprocessed_image)
             self.logger.info(
-                "[OCRProcessor] Extracting text with provider=%s model=%s",
+                "Extracting text with provider=%s model=%s",
                 self.settings.resolve_ocr_llm_provider(),
                 self.settings.resolve_ocr_llm_model(),
             )
@@ -240,39 +240,33 @@ class OCRProcessor:
 
             # Check if we got a valid response
             if not extracted_text:
-                self.logger.error("[OCRProcessor] No text returned from OCR processing")
+                self.logger.error("ocr returned no text")
                 raise OCRError("No text returned from OCR processing")
 
-            self.logger.debug(f"[OCRProcessor] Received response, length: {len(extracted_text)} chars")
+            self.logger.debug("ocr response received length=%s", len(extracted_text))
 
             # Parse and analyze recognition statistics
-            self.logger.debug("[OCRProcessor] Parsing and validating OCR response...")
+            self.logger.debug("ocr response parsing and validation started")
             ocr_response = self._parse_and_analyze_recognition_stats(extracted_text)
             stats = ocr_response.recognition_statistics
-            self.logger.debug(
-                f"[OCRProcessor] Recognition stats: {stats.successfully_transcribed}/{stats.total_elements} elements"
-            )
+            self.logger.debug(f"Recognition stats: {stats.successfully_transcribed}/{stats.total_elements} elements")
 
             # Check if extracted text is too short
             if len(ocr_response.transcribed_text) < 10:
-                self.logger.error(
-                    f"[OCRProcessor] Extracted text too short: {len(ocr_response.transcribed_text)} chars"
-                )
+                self.logger.error("ocr text too short length=%s", len(ocr_response.transcribed_text))
                 raise OCRError("Extracted text is too short - may not be a valid textbook page")
 
-            self.logger.debug(
-                f"[OCRProcessor] OCR extraction successful: {len(ocr_response.transcribed_text)} characters extracted"
-            )
+            self.logger.debug("ocr extraction successful characters=%s", len(ocr_response.transcribed_text))
 
             processing_time = time.time() - start_time
-            self.logger.info(f"[OCRProcessor] OCR processing completed in {processing_time:.2f} seconds")
+            self.logger.info("ocr processing completed latency_s=%.2f", processing_time)
 
             return ocr_response
 
         except OCRError:
-            self.logger.error("[OCRProcessor] OCRError caught, re-raising")
+            self.logger.error("ocr error raised; re-raising")
             raise
         except Exception as e:
-            self.logger.error(f"[OCRProcessor] Unexpected error type: {type(e).__name__}")
-            self.logger.error(f"[OCRProcessor] Error message: {str(e)}")
+            self.logger.error("ocr unexpected error type=%s", type(e).__name__)
+            self.logger.error("ocr unexpected error message=%s", str(e))
             raise OCRError(f"OCR processing failed: {type(e).__name__}: {str(e)}")

--- a/tests/agents/test_manager.py
+++ b/tests/agents/test_manager.py
@@ -255,7 +255,7 @@ async def test_start_background_memory_maintenance_clears_registry_on_failure(mo
         await task
 
     assert str(mock_user.id) not in manager._memory_maintenance_registry.tasks
-    assert "Failed: user_id=1" in caplog.text
+    assert "memory maintenance failed user_id=1" in caplog.text
 
 
 @pytest.mark.anyio
@@ -275,7 +275,7 @@ async def test_start_background_memory_maintenance_clears_registry_on_timeout(mo
         await task
 
     assert str(mock_user.id) not in manager._memory_maintenance_registry.tasks
-    assert "Timed out" in caplog.text
+    assert "memory maintenance timed out" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -411,7 +411,7 @@ async def test_coordinator_history_truncation_logs_warning(
             side_effect_service=mock_side_effect_service,
         )
 
-    assert "Truncated coordinator history" in caplog.text
+    assert "coordinator history truncated from=10 to=5" in caplog.text
 
 
 @pytest.mark.anyio
@@ -1608,7 +1608,7 @@ async def test_specialist_history_truncation_logs_warning(mock_settings, mock_us
             side_effect_service=side_effect_service,
         )
 
-    assert "Truncated specialist history for 'capture_history'" in caplog.text
+    assert "specialist history truncated specialist=capture_history" in caplog.text
 
 
 @pytest.mark.anyio

--- a/tests/core/test_logging_config.py
+++ b/tests/core/test_logging_config.py
@@ -1,0 +1,58 @@
+import logging
+from io import StringIO
+
+from runestone.core import logging_config
+
+
+def test_resolve_color_setting_truthy(monkeypatch):
+    monkeypatch.setenv("RUNESTONE_LOG_COLOR", "on")
+    assert logging_config._resolve_color_setting() is True
+
+
+def test_resolve_color_setting_falsy(monkeypatch):
+    monkeypatch.setenv("RUNESTONE_LOG_COLOR", "off")
+    assert logging_config._resolve_color_setting() is False
+
+
+def test_resolve_color_setting_auto(monkeypatch):
+    monkeypatch.setenv("RUNESTONE_LOG_COLOR", "auto")
+    assert logging_config._resolve_color_setting() is None
+
+
+def test_log_filter_strips_leading_tag_and_sets_producer():
+    record = logging.LogRecord(
+        name="runestone.api.endpoints",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="[API] Analysis request received",
+        args=(),
+        exc_info=None,
+    )
+    log_filter = logging_config.RunestoneLogFilter()
+    accepted = log_filter.filter(record)
+
+    assert accepted is True
+    assert record.producer == "api.endpoints"
+    assert record.msg == "Analysis request received"
+
+
+def test_setup_logging_forces_color_handler_when_enabled(monkeypatch):
+    monkeypatch.setenv("RUNESTONE_LOG_COLOR", "1")
+    logging_config.setup_logging(level="INFO")
+
+    root = logging.getLogger()
+    rich_handlers = [handler for handler in root.handlers if isinstance(handler, logging_config.RichHandler)]
+    assert len(rich_handlers) == 1
+    assert rich_handlers[0].console.is_terminal is True
+
+
+def test_setup_logging_uses_stream_handler_in_auto_non_tty(monkeypatch):
+    monkeypatch.setenv("RUNESTONE_LOG_COLOR", "auto")
+    monkeypatch.setattr(logging_config.sys, "stdout", StringIO())
+    logging_config.setup_logging(level="INFO")
+
+    root = logging.getLogger()
+    assert len(root.handlers) == 1
+    assert isinstance(root.handlers[0], logging.StreamHandler)
+    assert not isinstance(root.handlers[0], logging_config.RichHandler)


### PR DESCRIPTION
## Summary
- improve centralized logging config with readable producer column, color handling, and prefix cleanup filter
- make auto color mode fall back to plain stream logs on non-TTY outputs
- normalize log message wording across manager/API/OCR paths for scanability
- reduce sensitive chat info in logs (use user_id + lengths instead of email/message snippets)
- add logging config tests and update manager log assertions for new messages

## Validation
- uv run pytest tests/core/test_logging_config.py tests/agents/test_manager.py -q
- pre-commit hooks passed on commit (black/isort/flake8)

## Notes
- make lint-check still reports an unrelated pre-existing import-order issue in src/runestone/services/vocabulary_service.py.