### PR TITLE
feat: simplify memorykeeper append-first flow

### DIFF
--- a/docs/agent-swarm-architecture.md
+++ b/docs/agent-swarm-architecture.md
@@ -200,15 +200,19 @@ flowchart TD
     A["User turn arrives"] --> B["TeacherAgent"]
     B --> C{"Needs learner memory?"}
     C -- No --> D["Continue response generation"]
-    C -- Yes --> E["read_active_learning_focus (read-only)"]
+    C -- Yes --> E["read_active_learning_focus (read-only, includes item ids)"]
     E --> D
-    D --> F["Teacher response returned to user"]
+    D --> F["Teacher response returned to user (may temporarily include [memory:ID] tags)"]
     F --> G["Post-response coordinator"]
     G --> H{"Memory maintenance needed?"}
     H -- No --> I["No memory change"]
     H -- Yes --> J["MemoryKeeper"]
-    J --> K["Read relevant memory"]
-    K --> L["Create, update, or correct durable memory"]
+    J --> K{"Which case?"}
+    K -- "Case A: student edit" --> L["Read relevant memory, then write/delete"]
+    K -- "Case B: teacher new issue" --> M["Append directly with fresh key (no pre-read)"]
+    K -- "Case C: teacher status/priority change" --> N{"[memory:ID] tag present?"}
+    N -- Yes --> O["Write directly using id"]
+    N -- No --> P["Targeted read to locate id, then write"]
 ```
 
 #### Teacher-side memory reads
@@ -239,13 +243,21 @@ Principles:
 - Use the actual `teacher_response` as the strongest teacher-driven signal for durable updates.
 - Allow explicit student memory-edit instructions from the current turn to trigger maintenance as well.
 - Default to `no_action`; avoid additive or corrective writes without clear evidence.
-- Read relevant memory before writing so updates can correct stale state instead of blindly appending more notes.
+- Use a three-case execution model instead of a universal read-before-write:
+  - **Case A (student edit):** read the relevant category first, then write/delete as instructed.
+  - **Case B (teacher new issue):** append directly using a fresh descriptive key; no pre-read required.
+  - **Case C (teacher status/priority change):** if the teacher embedded a `[memory:ID]` tag, write
+    directly; otherwise do one targeted category-scoped read to locate the item id, then write.
+- The `[memory:ID]` tag is a temporary bridge carried in the visible teacher reply text until
+  the structured-output follow-up replaces this mechanism.
+- Temporary duplicate `area_to_improve` items from append-first writes are an accepted tradeoff;
+  broad duplicate cleanup belongs to `memory_maintainer`.
 
 Scope of maintenance:
 
 - create a new durable memory item when the turn reveals a recurring issue or stable fact worth storing
 - update `area_to_improve` content, status, and priority when the turn shows progress or regression
-- delete or correct memory only when the student explicitly asks or confirms an existing item is wrong
+- delete or correct memory when the student explicitly asks or confirms an existing item is wrong
 
 Area-to-improve review rules:
 

--- a/docs/todo/teacher-memory-read-slimdown.md
+++ b/docs/todo/teacher-memory-read-slimdown.md
@@ -123,13 +123,15 @@ Implementation status:
 
 Implementation status:
 
-- not implemented in this change set
-- the current code changes are intentionally limited to Teacher, shared backend
-  memory filtering, and the MemoryMaintainer single-read path
-- the three-case `MemoryKeeper` simplification below remains planned follow-up
-  work
+- implemented
+- `MemoryKeeper` now uses a three-case split instead of a universal read-before-write
+- `delete_memory_item` is exposed alongside the existing memory tools
+- the `[memory:ID]` tag convention is documented in the Teacher prompt so Teacher can
+  annotate its durable-signal sentences with the relevant memory item id
+- that `[memory:ID]` tag is temporarily exposed in visible chat text as a bridge until
+  structured teacher-side memory signaling lands in the follow-up task below
 
-`MemoryKeeper` should move to a three-case split.
+`MemoryKeeper` has moved to a three-case split.
 
 ### Case A: student explicitly asks to edit memory
 
@@ -148,9 +150,8 @@ Behavior:
 
 Implementation status:
 
-- not implemented in this change set
-- current `MemoryKeeper` behavior has not been refactored to explicitly model
-  this case split yet
+- implemented
+- `delete_memory_item` is now available in this path for explicit forget/remove requests
 
 ### Case B: teacher explicitly points out a new durable issue
 
@@ -162,7 +163,7 @@ Examples:
 Behavior:
 
 - do **not** require memory inspection first
-- just append/create the new memory item
+- just append/create the new memory item using a fresh descriptive English key
 
 Reason:
 
@@ -171,28 +172,32 @@ Reason:
 
 Implementation status:
 
-- not implemented in this change set
-- current `MemoryKeeper` has not been simplified to append/create without a
-  required pre-read for this case
+- implemented
+- `MemoryKeeper` now appends/creates directly without a required pre-read for this case
 
 ### Case C: teacher explicitly signals improvement/mastery/replacement/priority change
 
 Behavior:
 
-- allow append/write behavior without forcing a pre-read in this change set
-- do not block this simplification on perfect update targeting right now
+- if `teacher_response` contains a `[memory:ID]` tag, write directly using that id
+  (no pre-read required)
+- if no `[memory:ID]` tag is present, do a single targeted `read_memory` with a
+  category filter to locate the item id, then write
+- temporary duplicates are acceptable if the narrow read fails; `memory_maintainer`
+  handles cleanup
 
 Note:
 
-- this is intentionally a pragmatic "stop the fire first" decision
-- follow-up cleanup and consolidation quality will rely more heavily on
-  `MemoryMaintainer`
+- `[memory:ID]` tags are emitted by Teacher when an item id is known from starter
+  memory or `read_active_learning_focus` context (which now includes `id=` fields)
+- this tag is temporarily present in the visible chat reply so `MemoryKeeper` can target
+  the right item before structured signaling is implemented
+- follow-up task: `BOyvak7z5hfl` (`feat: Make teacher express ...`) will move this
+  signal out of visible reply text and into structured output
 
 Implementation status:
 
-- not implemented in this change set
-- current `MemoryKeeper` has not yet been simplified to allow this append/write
-  path without a forced pre-read
+- implemented
 
 ## Important Caveat
 
@@ -204,15 +209,15 @@ Known tradeoff:
 - append-first MemoryKeeper behavior can increase duplicate or overlapping
   `area_to_improve` items until `MemoryMaintainer` cleanup is improved and
   re-enabled confidently
+- the `[memory:ID]` tag mechanism mitigates this for Case C when the Teacher
+  has seen the item in context, but Case B always appends fresh
 
-That tradeoff is accepted for now as the next-step work will focus on
-stabilizing and trusting `MemoryMaintainer`.
+That tradeoff is accepted.
 
 Implementation status:
 
-- pending follow-up
-- the tradeoff is documented, but the underlying append-first `MemoryKeeper`
-  simplification has not landed yet
+- implemented
+- the append-first `MemoryKeeper` simplification has landed
 
 ## Double-Check: critical user facts already provided outside memory
 

--- a/src/runestone/agents/coordinator.py
+++ b/src/runestone/agents/coordinator.py
@@ -139,6 +139,8 @@ Examples that should NOT route:
 - Teacher: "Good job."
 - Teacher: "Write one more sentence with these words."
 - Teacher: "There is no such word as 'varen'; use 'våren' for spring."
+
+Set `chat_history_size` to `0` for `memory_keeper`.
 """
 )
 

--- a/src/runestone/agents/coordinator.py
+++ b/src/runestone/agents/coordinator.py
@@ -105,6 +105,8 @@ COORDINATOR_POST_RESPONSE_PROMPT = (
 - Use `teacher_response` as the primary routing signal.
 - If `teacher_response` is absent, do not route any teacher-dependent specialists.
 - Specialists here run after the teacher reply (persistence, follow-up analysis).
+- Post-phase memory routing is history-free: decide from the current student `message`
+  and current `teacher_response` only.
 
 ## Specialist Routing Rules
 
@@ -120,7 +122,6 @@ COORDINATOR_POST_RESPONSE_PROMPT = (
 
 **Do NOT route when:**
 - The student only hints at a fact or preference without explicitly asking to change memory.
-- The request existed only in older `history` rather than the current student `message`.
 - The teacher response is routine praise, a normal correction, a drill prompt, or a generic explanation
   without an explicit durable signal.
 - The teacher only says a student-written word is misspelled, invalid, nonexistent, or should be replaced

--- a/src/runestone/agents/manager.py
+++ b/src/runestone/agents/manager.py
@@ -51,6 +51,7 @@ class AgentsManager:
     MEMORY_MAINTENANCE_TIMEOUT_SECONDS = 35
     STARTER_MEMORY_PERSONAL_LIMIT = 50
     STARTER_MEMORY_AREA_LIMIT = 5
+    NO_CHAT_HISTORY_SPECIALISTS = frozenset({"word_keeper", "memory_keeper"})
 
     def __init__(
         self,
@@ -102,6 +103,22 @@ class AgentsManager:
                     self.allowed_ports.add(app_parsed.port)
         except (ValueError, AttributeError) as e:
             logger.warning("allowed_origins configuration issue: %s", e)
+
+    @classmethod
+    def _effective_specialist_history_size(cls, specialist_name: str, requested_history_size: int) -> int:
+        """
+        Apply manager-owned history-window overrides for specialists.
+
+        Some post/pre specialists should never receive raw chat history because their
+        trigger inputs are already passed through dedicated context fields:
+        - `word_keeper` uses the current save request plus the immediately previous
+          teacher message when needed.
+        - `memory_keeper` should act only on the current student message and the
+          current turn's teacher response, not on older teacher durability signals.
+        """
+        if specialist_name in cls.NO_CHAT_HISTORY_SPECIALISTS:
+            return 0
+        return requested_history_size
 
     # ------------------------------------------------------------------
     # Phase methods (public, individually testable)
@@ -655,9 +672,10 @@ class AgentsManager:
 
         async def _invoke(item, specialist):
             started = time.monotonic()
-            effective_history_size = item.chat_history_size
-            if item.name in {"word_keeper", "memory_keeper"}:
-                effective_history_size = 0
+            effective_history_size = self._effective_specialist_history_size(
+                item.name,
+                item.chat_history_size,
+            )
 
             history_window = history[-effective_history_size:] if effective_history_size else []
             if effective_history_size and len(history) > effective_history_size:

--- a/src/runestone/agents/manager.py
+++ b/src/runestone/agents/manager.py
@@ -656,7 +656,7 @@ class AgentsManager:
         async def _invoke(item, specialist):
             started = time.monotonic()
             effective_history_size = item.chat_history_size
-            if item.name == "word_keeper":
+            if item.name in {"word_keeper", "memory_keeper"}:
                 effective_history_size = 0
 
             history_window = history[-effective_history_size:] if effective_history_size else []

--- a/src/runestone/agents/manager.py
+++ b/src/runestone/agents/manager.py
@@ -393,17 +393,9 @@ class AgentsManager:
         )
 
         async def _coordinator_branch() -> list[dict]:
-            coordinator_history = history[-self.COORDINATOR_MAX_HISTORY_MESSAGES :] if history else []
-            if history and len(history) > self.COORDINATOR_MAX_HISTORY_MESSAGES:
-                logger.warning(
-                    "coordinator history truncated from=%s to=%s",
-                    len(history),
-                    len(coordinator_history),
-                )
-
             plan = await self.coordinator.plan_post_turn(
                 message=message,
-                history=coordinator_history,
+                history=[],
                 teacher_response=teacher_response,
                 available_specialists=[
                     name for name in self.registry.list_names() if name not in {"teacher", "word_keeper"}

--- a/src/runestone/agents/specialists/memory_keeper.py
+++ b/src/runestone/agents/specialists/memory_keeper.py
@@ -36,7 +36,6 @@ whether memory tools should be called.
 ## Input Format
 - `teacher_response`: the Teacher's message this turn
 - `student_message`: the student's message this turn
-- `history`: prior turns for context only — never a trigger for memory actions
 
 ## Trigger Rules
 1. **Teacher-driven**: act when `teacher_response` explicitly identifies a durable learning signal
@@ -44,7 +43,6 @@ whether memory tools should be called.
 2. **Student-driven**: act when `student_message` contains an explicit memory instruction
    (e.g., "remember that...", "forget my...", "change my goal to...").
 3. **Conflict**: if teacher and student signals conflict, the student's explicit correction wins.
-4. **History**: treat `history` as read-only context. Never act on older student turns.
 
 ## Three-Case Execution Model
 
@@ -199,10 +197,7 @@ class MemoryKeeperSpecialist(BaseSpecialist):
     async def run(self, context: SpecialistContext) -> SpecialistResult:
         payload = {
             "student_message": context.message,
-            "history": [msg.model_dump(mode="json") for msg in context.history],
             "teacher_response": context.teacher_response,
-            "routing_reason": context.routing_reason,
-            "phase": "post_response",
         }
 
         try:

--- a/src/runestone/agents/specialists/memory_keeper.py
+++ b/src/runestone/agents/specialists/memory_keeper.py
@@ -16,7 +16,13 @@ from runestone.agents.specialists.base import (
     parse_specialist_result,
 )
 from runestone.agents.tools.context import AgentContext
-from runestone.agents.tools.memory import read_memory, update_memory_priority, update_memory_status, upsert_memory_item
+from runestone.agents.tools.memory import (
+    delete_memory_item,
+    read_memory,
+    update_memory_priority,
+    update_memory_status,
+    upsert_memory_item,
+)
 from runestone.config import Settings
 
 logger = logging.getLogger(__name__)
@@ -40,20 +46,51 @@ whether memory tools should be called.
 3. **Conflict**: if teacher and student signals conflict, the student's explicit correction wins.
 4. **History**: treat `history` as read-only context. Never act on older student turns.
 
-## Mandatory Execution Pipeline
-When a trigger is detected, you MUST complete ALL steps below in order.
-Do not stop after reading.
-Step 1 — READ:   Call read_memory with a category filter scoped to the relevant category.
-Step 2 — DECIDE: Compare results against the incoming signal. Choose the correct write tool if changes are needed.
-Step 3 — WRITE:  Call the write tool (upsert_memory_item, update_memory_status,
-update_memory_priority) only for the specific memory item(s) directly implicated by this turn.
+## Three-Case Execution Model
 
+When a trigger is detected, apply one of the three cases below.
 If no trigger is detected → return `no_action` immediately. Do not call any tools.
+
+### Case A — Student explicitly asks to edit memory
+
+Examples: remember, forget, remove, correct, change goal, reprioritize, mark mastered.
+
+Execution:
+1. READ: Call `read_memory` with a category filter scoped to the relevant category.
+2. DECIDE: Compare results against the student's instruction.
+3. WRITE: Call the correct write tool for the specific item(s):
+   - `upsert_memory_item` for new or corrected facts
+   - `update_memory_status` for mastery or outdating
+   - `update_memory_priority` for explicit reprioritization
+   - `delete_memory_item` for explicit forget/remove requests
+
+Do not stop after reading. Always complete the write step.
+
+### Case B — Teacher explicitly points out a new durable issue
+
+Examples: a new recurring struggle, a newly named durable weakness.
+
+Execution:
+- Do NOT call `read_memory` first.
+- Call `upsert_memory_item` directly using a fresh descriptive English key.
+- Temporary duplicate items are an accepted tradeoff; `memory_maintainer` handles cleanup.
+
+### Case C — Teacher explicitly signals improvement, mastery, replacement, or priority change
+
+Examples: "You are improving with X", "You have now mastered Y", "You are still struggling with Z".
+
+Execution:
+- If `teacher_response` contains a `[memory:ID]` tag, use that numeric ID directly:
+  call `update_memory_status` or `update_memory_priority` without a pre-read.
+- If no `[memory:ID]` tag is present, do a single targeted `read_memory` with a category
+  filter to locate the item ID, then write. Do not perform a broad unsorted scan.
+- Prefer one targeted read over creating a duplicate.
+- Temporary duplicates are still acceptable if a narrow read fails to find the item;
+  `memory_maintainer` handles cleanup.
 
 ## Conservative Bias
 - Default to `no_action`. Only proceed when the signal is explicit and durable.
 - Do not infer facts, mastery, or preferences from weak or indirect signals.
-- Prefer updating an existing item over creating a duplicate (that's what Step 1 is for).
 - Broad start-of-session consolidation, duplicate cleanup, and routine reprioritization sweeps
   are handled by a separate `memory_maintainer`. Do not perform those sweeps unless the
   current turn explicitly requires a memory change.
@@ -62,6 +99,7 @@ If no trigger is detected → return `no_action` immediately. Do not call any to
   - Improvement, degradation, mastery, or outdating of an existing item → `update_memory_status`
   - Explicit importance/urgency signal such as a repeated recurring error or a clearly elevated priority
     from the Teacher → `update_memory_priority`
+  - Explicit student forget/remove request about a specific item → `delete_memory_item`
 - Do not use both `update_memory_status` and `update_memory_priority` on the same item in the same turn
   unless the signal explicitly requires both status and urgency to change.
 - Use `update_memory_priority` only for narrow, turn-local reprioritization of directly implicated item(s).
@@ -70,7 +108,7 @@ If no trigger is detected → return `no_action` immediately. Do not call any to
 - Never use priority changes to rebalance unrelated items or tidy the broader memory set; leave
   that work to `memory_maintainer`.
 - Never call `read_memory` without filters unless a broad inspection is explicitly required.
-- Never call `read_memory` as a standalone action — it is always a precursor to a write.
+- Never call `read_memory` as a standalone action — it must be followed by a write.
 - Treat spelling corrections, nonexistent-word feedback, and one-off wrong vocabulary forms as
   vocabulary events, not durable memory. Do not create `area_to_improve` items for misspelled
   or invalid word forms such as "no such word", "that word is wrong", or "use X instead of Y".
@@ -81,15 +119,15 @@ If no trigger is detected → return `no_action` immediately. Do not call any to
 
 | Category | Allowed write operations | Trigger condition |
 |----------|--------------------------|-------------------|
-| `area_to_improve` | create, update, change status/priority | explicit learning signal or student instruction |
-| `personal_info` | create, update, outdate | explicit durable fact or student correction |
+| `area_to_improve` | create, update, delete, change status/priority | explicit learning signal or student instruction |
+| `personal_info` | create, update, outdate, delete | explicit durable fact or student correction |
 
 Use `area_to_improve` with status `mastered` for topics the student has resolved or learned.
 Do not create a separate strength item.
 
 ## Allowed Tools
 `read_memory`, `upsert_memory_item`, `update_memory_status`,
-`update_memory_priority`
+`update_memory_priority`, `delete_memory_item`
 
 ## Output Contract
 Return valid JSON matching this exact shape and nothing else:
@@ -107,11 +145,13 @@ Return valid JSON matching this exact shape and nothing else:
 
 **Act on these (explicit memory instructions):**
 - "remember that my native language is Finnish"
-- "forget my old goal" → outdate or update the relevant item
-- "that memory is wrong, it should be X"
-- "change my goal to speaking practice"
-- "mark this topic as mastered"
-- Teacher: "student has now mastered the present perfect"
+- "forget my old goal" → Case A: read first, then delete or outdate
+- "that memory is wrong, it should be X" → Case A: read first, then correct
+- "change my goal to speaking practice" → Case A: read first, then upsert
+- "mark this topic as mastered" → Case A: read first, then update status
+- Teacher: "This is a recurring issue to remember: articles" → Case B: append directly
+- Teacher: "You are improving with articles. [memory:42]" → Case C: update status for id=42 directly
+- Teacher: "You have now mastered verb conjugation" (no id) → Case C: targeted read, then update
 
 **Do NOT act on these (not memory instructions):**
 - Student practicing sentences → ordinary interaction, no durable signal
@@ -149,6 +189,7 @@ class MemoryKeeperSpecialist(BaseSpecialist):
                 upsert_memory_item,
                 update_memory_status,
                 update_memory_priority,
+                delete_memory_item,
             ],
             system_prompt=MEMORY_KEEPER_SYSTEM_PROMPT,
             response_format=SpecialistResult,

--- a/src/runestone/agents/specialists/teacher.py
+++ b/src/runestone/agents/specialists/teacher.py
@@ -322,6 +322,18 @@ If you want post-phase memory maintenance to happen from your reply, use explici
 - "You have now mastered ..."
 - "This should replace the earlier note about ..."
 
+**Memory item IDs for updates:**
+When your active learning focus context (from starter memory or on-demand memory lookup)
+includes an `id=` field for an item, and your reply signals a status or priority change for
+that specific item, append a temporary machine-readable tag `[memory:ID]` at the end of the durable signal
+sentence, where ID is the numeric id value.
+- Example: "You are improving with articles. [memory:42]"
+- Example: "You have now mastered verb conjugation. [memory:17]"
+- Use this tag only when you are confident the id matches the item you are signalling about.
+- Omit the tag when you are creating a new memory item or when no id is available.
+- For now this tag is temporarily exposed in the visible reply text so post-phase maintenance can read it.
+- Do not explain the tag or call attention to it unless the student explicitly asks.
+
 Do NOT expect post-phase memory maintenance to trigger from vague wording like:
 - "Good job"
 - "Let's keep practicing"

--- a/src/runestone/agents/tools/utils.py
+++ b/src/runestone/agents/tools/utils.py
@@ -54,6 +54,7 @@ def serialize_active_learning_focus(items: Sequence[MemoryItemResponse]) -> str:
         priority = item.priority if item.priority is not None else 9
         lines.append(
             "- "
+            f"id={item.id} "
             f"key={json.dumps(item.key, ensure_ascii=False)} "
             f"content={json.dumps(content, ensure_ascii=False)} "
             f"status={json.dumps(item.status, ensure_ascii=False)} "

--- a/tests/agents/specialists/test_memory_keeper.py
+++ b/tests/agents/specialists/test_memory_keeper.py
@@ -6,6 +6,7 @@ from langchain_core.messages import AIMessage
 
 from runestone.agents.specialists.base import SpecialistContext, SpecialistResult, parse_specialist_result
 from runestone.agents.specialists.memory_keeper import MEMORY_KEEPER_SYSTEM_PROMPT, MemoryKeeperSpecialist
+from runestone.agents.tools.memory import delete_memory_item
 
 
 @pytest.fixture
@@ -197,6 +198,26 @@ def test_memory_keeper_prompt_uses_mastered_area_items_without_promotion():
     )
 
 
+def test_memory_keeper_prompt_three_case_model():
+    """Prompt must describe all three cases without a universal mandatory read-before-write."""
+    assert "Three-Case Execution Model" in MEMORY_KEEPER_SYSTEM_PROMPT
+    assert "Case A" in MEMORY_KEEPER_SYSTEM_PROMPT
+    assert "Case B" in MEMORY_KEEPER_SYSTEM_PROMPT
+    assert "Case C" in MEMORY_KEEPER_SYSTEM_PROMPT
+    # No universal "MUST complete ALL steps" read-first mandate
+    assert "Mandatory Execution Pipeline" not in MEMORY_KEEPER_SYSTEM_PROMPT
+    # Case B: teacher-driven new issue must say no pre-read required
+    assert "Do NOT call `read_memory` first" in MEMORY_KEEPER_SYSTEM_PROMPT
+    # Case C: [memory:ID] tag path
+    assert "[memory:ID]" in MEMORY_KEEPER_SYSTEM_PROMPT
+
+
+def test_memory_keeper_prompt_delete_tool_in_case_a():
+    """Case A (student edit) must expose delete_memory_item for forget/remove."""
+    assert "`delete_memory_item` for explicit forget/remove requests" in MEMORY_KEEPER_SYSTEM_PROMPT
+    assert "delete_memory_item" in MEMORY_KEEPER_SYSTEM_PROMPT
+
+
 def test_memory_keeper_prompt_rejects_misspelled_word_pollution():
     assert "Treat spelling corrections, nonexistent-word feedback" in MEMORY_KEEPER_SYSTEM_PROMPT
     assert "Do not create `area_to_improve` items for misspelled" in MEMORY_KEEPER_SYSTEM_PROMPT
@@ -220,7 +241,7 @@ def test_memory_keeper_prompt_separates_status_and_priority_roles():
     )
 
 
-def test_memory_keeper_builds_agent_with_priority_tool(mock_settings):
+def test_memory_keeper_builds_agent_with_expected_tools(mock_settings):
     with patch("runestone.agents.specialists.memory_keeper.build_chat_model", return_value=MagicMock()):
         with patch("runestone.agents.specialists.memory_keeper.create_agent") as create_agent_mock:
             MemoryKeeperSpecialist(mock_settings)
@@ -231,7 +252,13 @@ def test_memory_keeper_builds_agent_with_priority_tool(mock_settings):
         "upsert_memory_item",
         "update_memory_status",
         "update_memory_priority",
+        "delete_memory_item",
     ]
+
+
+def test_delete_memory_item_tool_is_accessible():
+    """delete_memory_item must exist at the tool layer and be wired into MemoryKeeper."""
+    assert delete_memory_item.name == "delete_memory_item"
 
 
 @pytest.mark.anyio

--- a/tests/agents/specialists/test_memory_keeper.py
+++ b/tests/agents/specialists/test_memory_keeper.py
@@ -89,6 +89,10 @@ async def test_memory_keeper_uses_current_student_message_for_payload(specialist
     args, kwargs = specialist.agent.ainvoke.call_args
     payload_json = args[0]["messages"][0].content
     payload = json.loads(payload_json)
+    assert payload == {
+        "student_message": "Forget my old goal.",
+        "teacher_response": "Let's keep practicing.",
+    }
     assert payload["student_message"] == "Forget my old goal."
     assert "message" not in payload
     assert kwargs["context"].user == mock_user

--- a/tests/agents/test_coordinator.py
+++ b/tests/agents/test_coordinator.py
@@ -89,7 +89,7 @@ def test_memory_reader_is_absent_from_pre_prompt():
 
 def test_memory_keeper_prompt_mentions_student_driven_memory_requests():
     assert "latest student `message` explicitly asks to change memory" in COORDINATOR_POST_RESPONSE_PROMPT
-    assert "older `history`" in COORDINATOR_POST_RESPONSE_PROMPT
+    assert "history-free" in COORDINATOR_POST_RESPONSE_PROMPT
     assert 'Student: "Forget my old goal."' in COORDINATOR_POST_RESPONSE_PROMPT
     assert 'Teacher: "You have now clearly mastered this tense."' in COORDINATOR_POST_RESPONSE_PROMPT
     assert "misspelled, invalid, nonexistent" in COORDINATOR_POST_RESPONSE_PROMPT

--- a/tests/agents/test_coordinator.py
+++ b/tests/agents/test_coordinator.py
@@ -94,6 +94,7 @@ def test_memory_keeper_prompt_mentions_student_driven_memory_requests():
     assert 'Teacher: "You have now clearly mastered this tense."' in COORDINATOR_POST_RESPONSE_PROMPT
     assert "misspelled, invalid, nonexistent" in COORDINATOR_POST_RESPONSE_PROMPT
     assert "That is a vocabulary correction, not a durable memory update." in COORDINATOR_POST_RESPONSE_PROMPT
+    assert "Set `chat_history_size` to `0` for `memory_keeper`." in COORDINATOR_POST_RESPONSE_PROMPT
 
 
 def test_news_prompt_requires_known_topic():

--- a/tests/agents/test_manager.py
+++ b/tests/agents/test_manager.py
@@ -1055,6 +1055,7 @@ async def test_run_post_turn_excludes_word_keeper_from_coordinator_available_spe
     _args, kwargs = manager.coordinator.plan_post_turn.call_args
     assert "word_keeper" not in kwargs["available_specialists"]
     assert "memory_keeper" in kwargs["available_specialists"]
+    assert kwargs["history"] == []
 
 
 @pytest.mark.anyio

--- a/tests/agents/test_manager.py
+++ b/tests/agents/test_manager.py
@@ -1157,6 +1157,43 @@ async def test_run_post_turn_persists_coordinator_and_direct_word_keeper_results
 
 
 @pytest.mark.anyio
+async def test_run_post_turn_forces_memory_keeper_history_to_zero(mock_settings, mock_user, mock_side_effect_service):
+    manager = _make_manager(mock_settings)
+
+    class _MemoryKeeperCaptureSpecialist(BaseSpecialist):
+        def __init__(self):
+            super().__init__(name="memory_keeper")
+            self.seen_history = None
+
+        async def run(self, context: SpecialistContext) -> SpecialistResult:
+            self.seen_history = context.history
+            return SpecialistResult(status="no_action")
+
+    capture = _MemoryKeeperCaptureSpecialist()
+    manager.registry.register(capture, overwrite=True)
+    manager.coordinator.plan_post_turn = AsyncMock(
+        return_value=_make_plan(post=[RoutingItem(name="memory_keeper", reason="memory", chat_history_size=2)])
+    )
+
+    await manager.run_post_turn(
+        message="Ok",
+        chat_id="chat-1",
+        history=[
+            ChatMessage(role="assistant", content="You have now mastered this tense. [memory:137]"),
+            ChatMessage(role="user", content="Thanks"),
+        ],
+        user=mock_user,
+        teacher_response="Good job, let's continue.",
+        vocabulary_candidates=[],
+        pre_results=[],
+        side_effect_service=mock_side_effect_service,
+        coordinator_row_id=99,
+    )
+
+    assert capture.seen_history == []
+
+
+@pytest.mark.anyio
 async def test_run_post_turn_does_not_route_word_keeper_without_candidates(
     mock_settings, mock_user, mock_side_effect_service
 ):

--- a/tests/agents/test_memory_tools.py
+++ b/tests/agents/test_memory_tools.py
@@ -81,6 +81,7 @@ async def test_read_active_learning_focus_uses_single_scoped_query_and_compact_o
         offset=0,
     )
     assert result.startswith("UNTRUSTED_ACTIVE_LEARNING_FOCUS")
+    assert "id=7" in result
     assert 'key="word_order"' in result
     assert 'status="struggling"' in result
     assert "priority=1" in result


### PR DESCRIPTION
## Summary
- switch MemoryKeeper from a universal read-before-write flow to an explicit three-case model
- expose delete support for explicit student memory edits and add item ids to teacher memory focus output
- document the temporary visible  bridge for Case C until structured signaling lands

## Testing
- 
- 
- 
- 

## Notes
- 🔍 Checking code formatting and linting... still reports an unrelated import-sorting failure in , which is outside this change set.
- Independent GPT-5.5 review findings were fixed before finalizing this branch.