### PR TITLE
Allow teacher to reuse prior grammar references

### DIFF
--- a/src/runestone/agents/manager.py
+++ b/src/runestone/agents/manager.py
@@ -957,9 +957,10 @@ class AgentsManager:
     def _is_grammar_reference_url(url: str) -> bool:
         """Detect grammar reference URLs previously surfaced by the teacher."""
         parsed = urlparse(url)
-        if parse_qs(parsed.query).get("view", [""])[0] != "grammar":
+        query_params = parse_qs(parsed.query)
+        if query_params.get("view", [""])[0] != "grammar":
             return False
-        cheatsheet_paths = parse_qs(parsed.query).get("cheatsheet", [])
+        cheatsheet_paths = query_params.get("cheatsheet", [])
         return bool(cheatsheet_paths and cheatsheet_paths[0].strip())
 
     @staticmethod

--- a/src/runestone/agents/manager.py
+++ b/src/runestone/agents/manager.py
@@ -238,6 +238,7 @@ class AgentsManager:
 
         sources = self._extract_sources(
             pre_results=pre_results,
+            history=history,
             messages=generated.final_messages,
             grammar_source_urls=generated.grammar_source_urls,
         )
@@ -840,14 +841,16 @@ class AgentsManager:
         self,
         *,
         pre_results: list[dict] | None = None,
+        history: list[ChatMessage] | None = None,
         messages=None,
         grammar_source_urls: list[str] | None = None,
     ) -> Optional[list[dict[str, str]]]:
         specialist_sources = self._extract_pre_result_sources(pre_results or [])
         merged_sources: list[dict[str, str]] = specialist_sources[:] if specialist_sources else []
         seen_urls = {source["url"] for source in merged_sources}
-        grammar_result_urls = self._extract_search_grammar_result_urls(messages or [])
-        grammar_sources = self._extract_grammar_sources(grammar_source_urls or [], grammar_result_urls, seen_urls)
+        allowed_grammar_urls = self._extract_search_grammar_result_urls(messages or [])
+        allowed_grammar_urls.update(self._extract_history_grammar_source_urls(history or []))
+        grammar_sources = self._extract_grammar_sources(grammar_source_urls or [], allowed_grammar_urls, seen_urls)
         merged_sources.extend(grammar_sources)
 
         for msg in reversed(messages or []):
@@ -894,7 +897,7 @@ class AgentsManager:
         sources: list[dict[str, str]] = []
         for url in grammar_source_urls:
             if url not in allowed_urls:
-                logger.info("grammar source url rejected reason=not_returned_by_search_grammar url=%s", url)
+                logger.info("grammar source url rejected reason=not_allowed_by_search_or_history url=%s", url)
                 continue
             if url in seen_urls:
                 logger.info("grammar source url rejected reason=duplicate url=%s", url)
@@ -928,6 +931,36 @@ class AgentsManager:
                 if isinstance(raw_url, str) and raw_url:
                     urls.add(raw_url)
         return urls
+
+    def _extract_history_grammar_source_urls(self, history: list[ChatMessage]) -> set[str]:
+        """Return exact grammar URLs already shown in earlier assistant messages for this chat."""
+        urls: set[str] = set()
+        for item in history:
+            if item.role != "assistant" or not item.sources:
+                continue
+            for source in item.sources:
+                if isinstance(source, dict):
+                    data = source
+                elif hasattr(source, "model_dump"):
+                    data = source.model_dump()
+                else:
+                    continue
+                raw_url = data.get("url")
+                url = str(raw_url) if raw_url is not None else ""
+                if not url or not self._is_safe_url(url):
+                    continue
+                if self._is_grammar_reference_url(url):
+                    urls.add(url)
+        return urls
+
+    @staticmethod
+    def _is_grammar_reference_url(url: str) -> bool:
+        """Detect grammar reference URLs previously surfaced by the teacher."""
+        parsed = urlparse(url)
+        if parse_qs(parsed.query).get("view", [""])[0] != "grammar":
+            return False
+        cheatsheet_paths = parse_qs(parsed.query).get("cheatsheet", [])
+        return bool(cheatsheet_paths and cheatsheet_paths[0].strip())
 
     @staticmethod
     def _format_grammar_source_title(url: str) -> str:

--- a/src/runestone/agents/specialists/teacher.py
+++ b/src/runestone/agents/specialists/teacher.py
@@ -117,6 +117,9 @@ class TeacherAgent:
 - `grammar_source_urls` is optional. It is completely OK to leave it empty.
 - Use grammar tools only when the student made a concrete grammar mistake or explicitly asked a grammar question.
 - Do not use grammar tools for greetings, casual chat, correct Swedish, or non-grammar topics.
+- First check earlier assistant messages in this chat for clearly relevant grammar references you already found.
+- If an earlier assistant message already contains a clearly relevant grammar reference,
+  reuse that exact URL instead of searching again.
 - If you search, you may use `search_grammar` 1-2 times with focused queries.
 - `search_grammar` returns a payload with a `results` list. Each result contains `title`, `url`, and `path`.
 - Focus on the top returned results first.
@@ -124,14 +127,18 @@ class TeacherAgent:
   from `results` with `read_grammar_page(path)`.
 - If the search returns nothing or the page is not clearly relevant, stop and answer without grammar links.
 - `grammar_source_urls` may contain at most {MAX_TEACHER_GRAMMAR_SOURCE_LINKS} URLs.
-- Only include exact `url` values returned by `search_grammar` in this same reply.
+- You may include only exact `url` values returned by `search_grammar` in this reply
+  or exact grammar reference URLs that already appeared in earlier assistant messages
+  in this chat.
 - Never invent or guess URLs.
 """
 
         grammar_source_rules_prompt = """
 - `grammar_source_urls` is optional and may be empty.
 - Only include grammar URLs when they are genuinely helpful for this reply.
-- `grammar_source_urls` may contain only exact `url` values returned by the `search_grammar` tool in this same turn.
+- `grammar_source_urls` may contain only exact `url` values returned by the
+  `search_grammar` tool in this turn or exact grammar reference URLs that already
+  appeared in earlier assistant messages in this chat.
 - Never invent or guess grammar source URLs.
 - Leave `grammar_source_urls` empty when no grammar material is clearly relevant enough to show.
 """
@@ -573,7 +580,7 @@ already names a clear topic.
     def _format_sources(sources: list[dict[str, str]]) -> str:
         if not sources:
             return ""
-        lines = ["", "", "[NEWS_SOURCES]"]
+        lines = ["", "", "[REFERENCE_SOURCES]"]
         max_sources = 20
         if len(sources) > max_sources:
             logger.warning(

--- a/tests/agents/fixtures/teacher_prompt_full.txt
+++ b/tests/agents/fixtures/teacher_prompt_full.txt
@@ -25,7 +25,7 @@ Old user msg
 [AI]
 Old bot msg
 
-[NEWS_SOURCES]
+[REFERENCE_SOURCES]
 1. Nyhet (2026-02-05, example.com) - https://example.com/
 
 [HUMAN]

--- a/tests/agents/test_manager.py
+++ b/tests/agents/test_manager.py
@@ -678,7 +678,9 @@ async def test_generate_teacher_response_filters_unsafe_urls(mock_settings, mock
 
 
 @pytest.mark.anyio
-async def test_generate_teacher_response_requires_search_grammar_result_for_grammar_sources(mock_settings, mock_user):
+async def test_generate_teacher_response_rejects_grammar_sources_missing_from_search_and_history(
+    mock_settings, mock_user
+):
     manager = _make_manager(mock_settings)
     manager.teacher = AsyncMock()
     manager.teacher.generate_response.return_value = TeacherGenerationResult(
@@ -694,6 +696,50 @@ async def test_generate_teacher_response_requires_search_grammar_result_for_gram
     )
 
     assert sources is None
+
+
+@pytest.mark.anyio
+async def test_generate_teacher_response_accepts_grammar_sources_from_history(mock_settings, mock_user):
+    manager = _make_manager(mock_settings)
+    manager.teacher = AsyncMock()
+    manager.teacher.generate_response.return_value = TeacherGenerationResult(
+        message="Grammatik",
+        grammar_source_urls=[
+            "https://localhost:5173/?view=grammar&cheatsheet=word_order/huvudsats",
+        ],
+        final_messages=[],
+    )
+
+    history = [
+        ChatMessage(
+            role="assistant",
+            content="Tidigare svar",
+            sources=[
+                {
+                    "title": "Word Order / Huvudsats",
+                    "url": "https://localhost:5173/?view=grammar&cheatsheet=word_order/huvudsats",
+                    "date": "",
+                }
+            ],
+        )
+    ]
+
+    _response, sources, _teacher_emotion, _vocabulary_candidates = await manager.generate_teacher_response(
+        message="Grammatik",
+        history=history,
+        user=mock_user,
+        pre_results=[],
+        starter_memory="",
+        recent_side_effects=[],
+    )
+
+    assert sources == [
+        {
+            "title": "Word Order / Huvudsats",
+            "url": "https://localhost:5173/?view=grammar&cheatsheet=word_order/huvudsats",
+            "date": "",
+        }
+    ]
 
 
 @pytest.mark.anyio

--- a/tests/agents/test_teacher.py
+++ b/tests/agents/test_teacher.py
@@ -149,9 +149,10 @@ def test_build_agent(mock_settings, mock_chat_model):
                 call_kwargs["system_prompt"]
             )
             assert (
-                "Only include exact `url` values returned by `search_grammar` in this same reply."
+                "You may include only exact `url` values returned by `search_grammar` in this reply"
                 in call_kwargs["system_prompt"]
             )
+            assert "earlier assistant messages in this chat" in call_kwargs["system_prompt"]
             assert "Never invent or guess URLs." in call_kwargs["system_prompt"]
             assert "Use grammar tools only when the student made a concrete grammar mistake" in (
                 call_kwargs["system_prompt"]
@@ -319,7 +320,7 @@ async def test_run_with_history(teacher_agent, mock_user):
     assert len(messages) == 4
     assert "[CURRENT_DATETIME]" in messages[0].content
     assert messages[1].content == "Old user msg"
-    assert "[NEWS_SOURCES]" in messages[2].content
+    assert "[REFERENCE_SOURCES]" in messages[2].content
     assert "Old bot msg" in messages[2].content
     assert messages[3].content == "Current msg"
 
@@ -756,7 +757,7 @@ def test_format_sources():
 
     formatted = TeacherAgent._format_sources(sources)
     assert formatted.count("\n") >= 1
-    assert "[NEWS_SOURCES]" in formatted
+    assert "[REFERENCE_SOURCES]" in formatted
     assert "example.com" in formatted
     assert "Title 1" in formatted
     assert "Title 20" in formatted


### PR DESCRIPTION
## Summary
- let the Teacher reuse exact grammar reference URLs from earlier assistant messages in the same chat
- keep grammar URL validation strict by accepting only same-turn search results or prior assistant grammar references
- rename the injected source block from NEWS_SOURCES to REFERENCE_SOURCES and cover the new behavior with tests

## Testing
- make backend-test
- uv run pytest tests/agents/test_teacher.py tests/agents/test_manager.py -v

## Review
- Independent gpt-5.5 review approved with no findings