### PR TITLE
[codex] Add FileUpload keyboard coverage

### DIFF
--- a/frontend/src/components/FileUpload.test.tsx
+++ b/frontend/src/components/FileUpload.test.tsx
@@ -180,10 +180,10 @@ describe('FileUpload', () => {
       />
     );
 
-    const zoomTrigger = screen.getByAltText('Preview').parentElement;
+    const zoomTrigger = screen.getByTestId('compact-preview-trigger');
     expect(zoomTrigger).toHaveAttribute('role', 'button');
 
-    fireEvent.keyDown(zoomTrigger!, { key: ' ' });
+    fireEvent.keyDown(zoomTrigger, { key: ' ' });
 
     expect(screen.getByAltText('Enlarged Preview')).toBeInTheDocument();
   });
@@ -197,7 +197,7 @@ describe('FileUpload', () => {
       />
     );
 
-    const uploadPlaceholder = screen.getByText('No file selected').closest('div')?.previousElementSibling;
+    const uploadPlaceholder = screen.getByTestId('compact-preview-trigger');
     expect(uploadPlaceholder).not.toHaveAttribute('role');
     expect(uploadPlaceholder).toHaveAttribute('tabindex', '-1');
   });

--- a/frontend/src/components/FileUpload.test.tsx
+++ b/frontend/src/components/FileUpload.test.tsx
@@ -169,6 +169,39 @@ describe('FileUpload', () => {
     expect(screen.getByAltText('Enlarged Preview')).toBeInTheDocument();
   });
 
+  it('opens compact preview zoom with the spacebar', () => {
+    const file = new File(['test'], 'test.jpg', { type: 'image/jpeg' });
+    render(
+      <FileUpload
+        onFileSelect={mockOnFileSelect}
+        isProcessing={false}
+        compact
+        selectedFileOverride={file}
+      />
+    );
+
+    const zoomTrigger = screen.getByAltText('Preview').parentElement;
+    expect(zoomTrigger).toHaveAttribute('role', 'button');
+
+    fireEvent.keyDown(zoomTrigger!, { key: ' ' });
+
+    expect(screen.getByAltText('Enlarged Preview')).toBeInTheDocument();
+  });
+
+  it('does not expose compact preview keyboard affordances without a file', () => {
+    render(
+      <FileUpload
+        onFileSelect={mockOnFileSelect}
+        isProcessing={false}
+        compact
+      />
+    );
+
+    const uploadPlaceholder = screen.getByText('No file selected').closest('div')?.previousElementSibling;
+    expect(uploadPlaceholder).not.toHaveAttribute('role');
+    expect(uploadPlaceholder).toHaveAttribute('tabindex', '-1');
+  });
+
   it('cleans up object URL on unmount', async () => {
     const revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
 

--- a/frontend/src/components/FileUpload.tsx
+++ b/frontend/src/components/FileUpload.tsx
@@ -152,6 +152,7 @@ const FileUpload: React.FC<FileUploadProps> = ({
             }}
           >
             <Box
+              data-testid="compact-preview-trigger"
               onClick={previewUrl ? () => setIsZoomed(true) : undefined}
               onKeyDown={
                 previewUrl


### PR DESCRIPTION
## What changed
- add a compact-mode test that opens the preview zoom with the spacebar
- add a guard test that keeps the compact preview non-focusable when no file is present

## Why
The recent keyboard-accessibility change in `FileUpload` added a new `Enter`/`Space` branch for opening the compact preview. The `Enter` path was covered, but the `Space` path and the no-preview guard state were not.

## Impact
This keeps the new keyboard behavior from regressing and documents the intended accessibility contract for the compact preview trigger.

## Validation
- `cd frontend && npm run test:run -- src/components/FileUpload.test.tsx`
- `make frontend-test`
- `make check-readiness` *(fails on existing unrelated import-order issue in `src/runestone/services/vocabulary_service.py`)*
