### PR TITLE
Improve teacher fallback reliability and source handling

### DIFF
--- a/docs/todo/yki-b1-swedish-grammar-roadmap.md
+++ b/docs/todo/yki-b1-swedish-grammar-roadmap.md
@@ -10,7 +10,7 @@ This document captures the Swedish grammar topics needed to transition from the 
 - [ ] **Concessive (Although/Despite):**
   - [ ] `fastän` (although)
   - [ ] `trots att` / `trots det` (even though / despite that)
-  - [ ] `själv om` (even if)
+  - [ ] `även om` (even if)
 - [ ] **Conditional (If/Unless):**
   - [ ] `ifall` (in case / if)
   - [ ] `såvida... inte` / `om inte` (unless)
@@ -54,7 +54,7 @@ This document captures the Swedish grammar topics needed to transition from the 
   - [ ] `hoppas` (to hope)
   - [ ] `trivas` (to feel at home / enjoy oneself)
   - [ ] `minnas` (to remember)
-  - [ ] `skyndas` (to hurry)
+  - [ ] `skämmas` (to be ashamed)
   - [ ] `lyckas` (to succeed)
 
 ### 6) Phrasal Verbs (Partikelverb)

--- a/docs/todo/yki-b1-swedish-grammar-roadmap.md
+++ b/docs/todo/yki-b1-swedish-grammar-roadmap.md
@@ -1,0 +1,84 @@
+# YKI B1 Swedish Grammar Roadmap
+
+## Context
+
+This document captures the Swedish grammar topics needed to transition from the current A1/A2 cheatsheets to the B1 level required to pass the YKI test (keskitaso / intermediate levels 3 & 4).
+
+## Action Items / Grammar Topics
+
+### 1) Advanced Clause Linkage & Conjunctions (Sambandsord)
+- [ ] **Concessive (Although/Despite):**
+  - [ ] `fastän` (although)
+  - [ ] `trots att` / `trots det` (even though / despite that)
+  - [ ] `själv om` (even if)
+- [ ] **Conditional (If/Unless):**
+  - [ ] `ifall` (in case / if)
+  - [ ] `såvida... inte` / `om inte` (unless)
+- [ ] **Causal & Explanatory:**
+  - [ ] `då` (since/as - more formal than `eftersom`)
+  - [ ] `därför att` (because)
+  - [ ] `på grund av` [+ noun] (due to)
+- [ ] **Consecutive & Result:**
+  - [ ] `vilket gör att` (which means that / leading to)
+  - [ ] `därför` / `följaktligen` (therefore / consequently)
+- [ ] **Correlative Conjunctions:**
+  - [ ] `både... och...` (both... and...)
+  - [ ] `antingen... eller...` (either... or...)
+  - [ ] `varken... eller...` (neither... nor...)
+  - [ ] `dels... dels...` (partly... partly...)
+  - [ ] `ju... desto...` (the [more]... the [more]...)
+    - *Example:* *Ju mer du tränar på talet, desto lättare blir det på YKI.*
+
+### 2) Sentence Word Order & The BIFF Rule
+- [ ] **BIFF Rule:** **B**isats **I**nte **F**öre **F**inita verbet.
+  - *Main clause:* Jag dricker **inte** kaffe.
+  - *Subordinate clause:* Han vet att jag **inte** dricker kaffe.
+- [ ] **Inversion (V2 Rule) in Complex Sentences:**
+  - *Example:* *På måndagar studerar jag svenska.* (Pushing subject to 3rd position when starting with adverbial).
+- [ ] **Indirect Speech (Indirekt tal):** Adjusting tenses and word order in reported speech.
+  - *Example:* *Han frågade vem jag var.* (no inversion in indirect questions).
+
+### 3) The Passive Voice (Passiv)
+- [ ] **S-passive (s-passiv):** Added to verb stem for general rules/processes (*skrivs*, *byggdes*).
+  - *Example:* *Skatten höjs av regeringen.*
+- [ ] **Bli-passive (bli-passiv):** *bli* + perfect participle for specific completed actions (*blev vald*).
+  - *Example:* *Han blev överraskad av nyheten.*
+
+### 4) Participles (Particip)
+- [ ] **Perfect Participle (Perfekt particip):** Verb-derived adjectives agreeing in gender/number (*en stängd dörr*, *ett skrivet brev*, *målade väggar*).
+- [ ] **Present Participle (Presens particip):** Ends in `-ande`/`-ende` (*en leende lärare*, *en spännande film*).
+
+### 5) Deponens Verbs (Deponensverb)
+- [ ] Learn verbs ending in `-s` with active meanings:
+  - [ ] `andas` (to breathe)
+  - [ ] `hoppas` (to hope)
+  - [ ] `trivas` (to feel at home / enjoy oneself)
+  - [ ] `minnas` (to remember)
+  - [ ] `skyndas` (to hurry)
+  - [ ] `lyckas` (to succeed)
+
+### 6) Phrasal Verbs (Partikelverb)
+- [ ] Learn common phrasal verbs and their stressed particles:
+  - [ ] `tänka på` / `tänka efter` / `tänka ut`
+  - [ ] `hålla med` / `hålla på med`
+  - [ ] `lägga av`
+  - [ ] `stänga av`
+  - [ ] `hälsa på` (visit vs. greet)
+
+### 7) Noun and Pronoun Nuances
+- [ ] **Determiners Requiring Indefinite Nouns:**
+  - [ ] `samma` (*samma bil*)
+  - [ ] `nästa` (*nästa vecka*)
+  - [ ] `denna / detta / dessa` (*denna bok*)
+- [ ] **No Double Definiteness after Genitives/Possessives:**
+  - [ ] *min bil* (not *min bilen*)
+  - [ ] *Saras hus* (not *Saras huset*)
+- [ ] **Advanced Relative Pronouns:**
+  - [ ] `vars` (whose)
+  - [ ] `vilket` (which - referring to whole clause)
+
+## Validation / Practice Tasks
+
+- [ ] Read news on [8 Sidor](https://8sidor.se/) daily and highlight B1 structures.
+- [ ] Write 3 timed short essays (e.g. formal complaint, opinion piece) using at least 4 B1 conjunctions in each.
+- [ ] Record a 2-minute speech on a current topic, focusing on correct phrasal verb stress.

--- a/src/runestone/agents/manager.py
+++ b/src/runestone/agents/manager.py
@@ -986,7 +986,12 @@ class AgentsManager:
             artifacts = result.get("artifacts")
             if not isinstance(artifacts, dict):
                 continue
+
+            # Extract from "sources" list first, fallback to "results" list if sources is missing or empty
             artifact_sources = artifacts.get("sources")
+            if not isinstance(artifact_sources, list) or not artifact_sources:
+                artifact_sources = artifacts.get("results")
+
             if not isinstance(artifact_sources, list):
                 continue
             for source in artifact_sources:

--- a/src/runestone/agents/specialists/teacher.py
+++ b/src/runestone/agents/specialists/teacher.py
@@ -72,7 +72,7 @@ def _teacher_timing_fields(args, kwargs, _result, _error) -> dict[str, int | str
 class TeacherAgent:
     """LLM-based teacher agent responsible for final response generation."""
 
-    MAX_HISTORY_MESSAGES = 20
+    MAX_HISTORY_MESSAGES = 10
     RECURSION_LIMIT = RECURSION_LIMIT_TEACHER
     RECENT_SIDE_EFFECTS_MAX_ITEMS = 5
     RECENT_SIDE_EFFECTS_MAX_CHARS = 2000
@@ -486,9 +486,13 @@ already names a clear topic.
                     grammar_service=self.grammar_service,
                 ),
             )
-        except GraphRecursionError:
+        except Exception as exc:
+            if not isinstance(exc, GraphRecursionError) and not self._is_deadline_exceeded_error(exc):
+                raise
+            fallback_reason = "recursion limit" if isinstance(exc, GraphRecursionError) else "deadline exceeded error"
             logger.warning(
-                "[agents:teacher] Primary run hit recursion limit; retrying once without tools for user_id=%s",
+                "[agents:teacher] Primary run hit %s; retrying once without tools for user_id=%s",
+                fallback_reason,
                 user.id,
             )
             result = await self._ainvoke_without_tools(messages=messages, user=user)
@@ -561,6 +565,22 @@ already names a clear topic.
                         return True
                 continue
             if isinstance(content, str) and "tool call limit reached" in content.lower():
+                return True
+        return False
+
+    @staticmethod
+    def _is_deadline_exceeded_error(error: Exception) -> bool:
+        text = str(error).lower()
+        if "deadline_exceeded" in text or "deadline exceeded" in text or "deadline expired" in text:
+            return True
+        status = getattr(error, "status", None)
+        if isinstance(status, str):
+            normalized_status = status.lower()
+            if (
+                "deadline_exceeded" in normalized_status
+                or "deadline exceeded" in normalized_status
+                or "deadline expired" in normalized_status
+            ):
                 return True
         return False
 

--- a/src/runestone/agents/specialists/teacher.py
+++ b/src/runestone/agents/specialists/teacher.py
@@ -570,8 +570,15 @@ already names a clear topic.
 
     @staticmethod
     def _is_deadline_exceeded_error(error: Exception) -> bool:
+        if isinstance(error, TimeoutError) or "timeout" in type(error).__name__.lower():
+            return True
         text = str(error).lower()
-        if "deadline_exceeded" in text or "deadline exceeded" in text or "deadline expired" in text:
+        if (
+            "deadline_exceeded" in text
+            or "deadline exceeded" in text
+            or "deadline expired" in text
+            or "timeout" in text
+        ):
             return True
         status = getattr(error, "status", None)
         if isinstance(status, str):
@@ -580,6 +587,7 @@ already names a clear topic.
                 "deadline_exceeded" in normalized_status
                 or "deadline exceeded" in normalized_status
                 or "deadline expired" in normalized_status
+                or "timeout" in normalized_status
             ):
                 return True
         return False

--- a/tests/agents/test_manager.py
+++ b/tests/agents/test_manager.py
@@ -629,6 +629,51 @@ async def test_generate_teacher_response_combines_news_sources_from_pre_results(
 
 
 @pytest.mark.anyio
+async def test_generate_teacher_response_fallback_to_news_agent_results_if_sources_missing(mock_settings, mock_user):
+    manager = _make_manager(mock_settings)
+    manager.teacher = AsyncMock()
+    manager.teacher.generate_response.return_value = TeacherGenerationResult(
+        message="Svar med källor",
+        final_messages=[],
+    )
+
+    response, sources, _teacher_emotion, _vocabulary_candidates = await manager.generate_teacher_response(
+        message="Nyheter",
+        history=[],
+        user=mock_user,
+        pre_results=[
+            {
+                "name": "news_agent",
+                "result": {
+                    "status": "action_taken",
+                    "artifacts": {
+                        "topic": "ekonomi",
+                        "query": "svenska ekonominyheter",
+                        "timelimit": "w",
+                        "results": [
+                            {
+                                "title": "Nyhet från resultat",
+                                "url": "https://example.com/article-from-results",
+                                "date": "2026-02-05",
+                                "snippet": "summary",
+                                "article_text": "",
+                            }
+                        ],
+                    },
+                },
+            }
+        ],
+        starter_memory="",
+        recent_side_effects=[],
+    )
+
+    assert response == "Svar med källor"
+    assert sources == [
+        {"title": "Nyhet från resultat", "url": "https://example.com/article-from-results", "date": "2026-02-05"}
+    ]
+
+
+@pytest.mark.anyio
 async def test_generate_teacher_response_deduplicates_sources_across_pre_results_and_teacher(mock_settings, mock_user):
     manager = _make_manager(mock_settings)
     manager.teacher = AsyncMock()

--- a/tests/agents/test_teacher.py
+++ b/tests/agents/test_teacher.py
@@ -751,6 +751,19 @@ async def test_generate_response_retries_after_deadline_exceeded_error_with_spac
     fallback_agent.ainvoke.assert_called_once()
 
 
+@pytest.mark.anyio
+async def test_generate_response_retries_after_timeout_error(teacher_agent, mock_user):
+    teacher_agent.agent.ainvoke.side_effect = TimeoutError()
+    fallback_agent = AsyncMock()
+    fallback_agent.ainvoke.return_value = {"messages": [AIMessage(content="Fallback after timeout error.")]}
+    teacher_agent._get_tool_limit_fallback_agent = MagicMock(return_value=fallback_agent)
+
+    generated = await teacher_agent.generate_response(message="Need help", history=[], user=mock_user)
+
+    assert generated.message == "Fallback after timeout error."
+    fallback_agent.ainvoke.assert_called_once()
+
+
 def test_openai_provider_configuration(mock_settings):
     """Test that OpenAI provider is configured correctly."""
     mock_settings.teacher_provider = "openai"

--- a/tests/agents/test_teacher.py
+++ b/tests/agents/test_teacher.py
@@ -722,6 +722,35 @@ async def test_generate_response_retries_after_graph_recursion_error(teacher_age
     fallback_agent.ainvoke.assert_called_once()
 
 
+@pytest.mark.anyio
+async def test_generate_response_retries_after_deadline_exceeded_error(teacher_agent, mock_user):
+    teacher_agent.agent.ainvoke.side_effect = RuntimeError(
+        "504 DEADLINE_EXCEEDED. "
+        "{'error': {'code': 504, 'message': 'Deadline expired before operation could complete.'}}"
+    )
+    fallback_agent = AsyncMock()
+    fallback_agent.ainvoke.return_value = {"messages": [AIMessage(content="Svar utan verktyg efter timeout.")]}
+    teacher_agent._get_tool_limit_fallback_agent = MagicMock(return_value=fallback_agent)
+
+    generated = await teacher_agent.generate_response(message="Explain this quickly", history=[], user=mock_user)
+
+    assert generated.message == "Svar utan verktyg efter timeout."
+    fallback_agent.ainvoke.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_generate_response_retries_after_deadline_exceeded_error_with_space_wording(teacher_agent, mock_user):
+    teacher_agent.agent.ainvoke.side_effect = RuntimeError("504 Deadline Exceeded")
+    fallback_agent = AsyncMock()
+    fallback_agent.ainvoke.return_value = {"messages": [AIMessage(content="Fallback after Deadline Exceeded wording.")]}
+    teacher_agent._get_tool_limit_fallback_agent = MagicMock(return_value=fallback_agent)
+
+    generated = await teacher_agent.generate_response(message="Need help", history=[], user=mock_user)
+
+    assert generated.message == "Fallback after Deadline Exceeded wording."
+    fallback_agent.ainvoke.assert_called_once()
+
+
 def test_openai_provider_configuration(mock_settings):
     """Test that OpenAI provider is configured correctly."""
     mock_settings.teacher_provider = "openai"


### PR DESCRIPTION
## Summary
- retry Teacher once without tools when primary run fails with recursion-limit or deadline-exceeded errors
- broaden deadline detection to include both DEADLINE_EXCEEDED and Deadline Exceeded wording variants
- add regression tests for no-tools fallback paths and keep related manager/teacher updates on this branch

## Validation
- make backend-test
- uv run pytest tests/agents/test_teacher.py -k 'deadline_exceeded_error or graph_recursion_error or tool_limit_termination' -v

## Notes
- includes prior staged branch work (news/source-related and teacher-history adjustments) as requested