### PR TITLE
Limit Teacher grammar search attempts

### DIFF
--- a/src/runestone/agents/specialists/teacher.py
+++ b/src/runestone/agents/specialists/teacher.py
@@ -141,10 +141,10 @@ Every search adds latency and token cost — skip it unless one of the explicit 
 **How to search:**
 - First check earlier assistant messages in this chat for a clearly relevant grammar reference.
   If one exists, reuse that exact URL instead of searching again.
-- Use `search_grammar` 1–2 times with focused queries.
+- Use `search_grammar` at most once with one focused query.
   It returns a `results` list; each result has `title`, `url`, and `path`.
-  Focus on top results first. If relevance is unclear, call `read_grammar_page(path)` for
-  the top 1–2 results to verify before including a URL.
+- Focus on the top result first. If relevance is unclear, call `read_grammar_page(path)` for
+  the top result to verify before including its URL.
 - If the search returns nothing useful, stop and answer without grammar links.
 
 **grammar_source_urls:**

--- a/src/runestone/agents/specialists/teacher.py
+++ b/src/runestone/agents/specialists/teacher.py
@@ -143,7 +143,7 @@ Every search adds latency and token cost — skip it unless one of the explicit 
   If one exists, reuse that exact URL instead of searching again.
 - Use `search_grammar` at most once with one focused query.
   It returns a `results` list; each result has `title`, `url`, and `path`.
-- Focus on the top result first. If relevance is unclear, call `read_grammar_page(path)` for
+- Focus on the top result. If relevance is unclear, call `read_grammar_page(path)` for
   the top result to verify before including its URL.
 - If the search returns nothing useful, stop and answer without grammar links.
 

--- a/src/runestone/constants.py
+++ b/src/runestone/constants.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 MEMORY_DEFAULT_AREA_TO_IMPROVE_PRIORITY = 9
 MAX_TEACHER_GRAMMAR_SOURCE_LINKS = 2
-MAX_GRAMMAR_SEARCH_CALLS = 2
+MAX_GRAMMAR_SEARCH_CALLS = 1
 MAX_GRAMMAR_READ_CALLS = 10
 
 # Specialist recursion limits to prevent runaway tool loops

--- a/tests/agents/test_teacher.py
+++ b/tests/agents/test_teacher.py
@@ -163,9 +163,9 @@ def test_build_agent(mock_settings, mock_chat_model):
             assert "content, status, or priority change" in call_kwargs["system_prompt"]
             assert "[memory:<category>:<id>]" in call_kwargs["system_prompt"]
             assert "[memory:personal_info:5]" in call_kwargs["system_prompt"]
-            assert "Use `search_grammar` 1" in call_kwargs["system_prompt"]
+            assert "Use `search_grammar` at most once with one focused query." in call_kwargs["system_prompt"]
             assert "each result has `title`, `url`, and `path`" in call_kwargs["system_prompt"]
-            assert "top 1" in call_kwargs["system_prompt"]
+            assert "Focus on the top result first." in call_kwargs["system_prompt"]
             assert "stop and answer without grammar links" in call_kwargs["system_prompt"]
             assert "Never search for:" in call_kwargs["system_prompt"]
             assert "Greetings, farewells, or small-talk" in call_kwargs["system_prompt"]
@@ -661,7 +661,7 @@ async def test_generate_response_passes_recursion_limit(teacher_agent, mock_user
 @pytest.mark.anyio
 async def test_generate_response_retries_after_tool_limit_termination(teacher_agent, mock_user):
     teacher_agent.agent.ainvoke.return_value = {
-        "messages": [AIMessage(content="'search_grammar' tool call limit reached: run limit exceeded (3/2 calls).")]
+        "messages": [AIMessage(content="'search_grammar' tool call limit reached: run limit exceeded (2/1 calls).")]
     }
     fallback_agent = AsyncMock()
     fallback_agent.ainvoke.return_value = {
@@ -691,7 +691,7 @@ async def test_generate_response_retries_after_tool_limit_termination_in_text_bl
                     {"type": "text", "text": "Some preliminary content."},
                     {
                         "type": "text",
-                        "text": "'search_grammar' tool call limit reached: run limit exceeded (3/2 calls).",
+                        "text": "'search_grammar' tool call limit reached: run limit exceeded (2/1 calls).",
                     },
                 ]
             )

--- a/tests/agents/test_teacher.py
+++ b/tests/agents/test_teacher.py
@@ -165,7 +165,7 @@ def test_build_agent(mock_settings, mock_chat_model):
             assert "[memory:personal_info:5]" in call_kwargs["system_prompt"]
             assert "Use `search_grammar` at most once with one focused query." in call_kwargs["system_prompt"]
             assert "each result has `title`, `url`, and `path`" in call_kwargs["system_prompt"]
-            assert "Focus on the top result first." in call_kwargs["system_prompt"]
+            assert "Focus on the top result." in call_kwargs["system_prompt"]
             assert "stop and answer without grammar links" in call_kwargs["system_prompt"]
             assert "Never search for:" in call_kwargs["system_prompt"]
             assert "Greetings, farewells, or small-talk" in call_kwargs["system_prompt"]


### PR DESCRIPTION
## Summary
- limit the Teacher runtime guardrail to a single `search_grammar` call per turn
- simplify the Teacher prompt so it instructs one focused grammar search attempt and then stops
- update Teacher tests for the new prompt wording and tool-limit fallback text

## Testing
- `git commit` pre-commit hooks: passed (`black`, `isort`, `flake8`, and repository checks)
- `make backend-test TEST_ARGS='tests/agents/test_teacher.py -v'` currently fails during test collection because `asyncpg` is missing in the local test environment

## Review
- independent `gpt-5.5` code review: approved with no findings