### PR TITLE
Ban problematic OpenRouter upstream providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ GEMINI_API_KEY=your_gemini_api_key_here
 
 # OpenRouter Configuration
 OPENROUTER_API_KEY=your_openrouter_api_key_here
+# Comma-separated provider slugs to avoid via OpenRouter routing, e.g. "bad-provider".
+OPENROUTER_DISALLOWED_PROVIDERS=
 OCR_LLM_PROVIDER=openrouter
 OCR_LLM_MODEL_NAME=amazon/nova-lite-v1
 

--- a/.env.test
+++ b/.env.test
@@ -10,6 +10,7 @@ OPENAI_API_KEY=test_openai_api_key_for_testing_only
 
 # OpenRouter Configuration (TEST KEYS - NOT REAL)
 OPENROUTER_API_KEY=test_openrouter_api_key_for_testing_only
+OPENROUTER_DISALLOWED_PROVIDERS=
 OCR_LLM_PROVIDER=openrouter
 OCR_LLM_MODEL_NAME=amazon/nova-lite-v1
 

--- a/src/runestone/agents/llm.py
+++ b/src/runestone/agents/llm.py
@@ -40,8 +40,15 @@ def build_chat_model(
         raise ValueError(f"API key for {agent_settings.provider} is not configured")
 
     extra_kwargs = {}
-    if agent_settings.provider == "openrouter" and agent_settings.reasoning_level != ReasoningLevel.NONE:
-        extra_kwargs["extra_body"] = {"reasoning": {"effort": agent_settings.reasoning_level.value}}
+    if agent_settings.provider == "openrouter":
+        extra_body: dict[str, object] = {}
+        if agent_settings.reasoning_level != ReasoningLevel.NONE:
+            extra_body["reasoning"] = {"effort": agent_settings.reasoning_level.value}
+        disallowed_providers = settings.resolve_openrouter_disallowed_providers()
+        if disallowed_providers:
+            extra_body["provider"] = {"ignore": disallowed_providers}
+        if extra_body:
+            extra_kwargs["extra_body"] = extra_body
 
     logger.debug(
         "[agents:llm] Building chat model: agent=%s, provider=%s, model=%s, temp=%.2f, reasoning=%s",

--- a/src/runestone/config.py
+++ b/src/runestone/config.py
@@ -209,7 +209,11 @@ class Settings(BaseSettings):
         """Return normalized OpenRouter providers to avoid routing through."""
         if not self.openrouter_disallowed_providers:
             return []
-        return [provider.strip() for provider in self.openrouter_disallowed_providers.split(",") if provider.strip()]
+        return list(
+            dict.fromkeys(
+                provider.strip() for provider in self.openrouter_disallowed_providers.split(",") if provider.strip()
+            )
+        )
 
     def get_agent_llm_settings(
         self,

--- a/src/runestone/config.py
+++ b/src/runestone/config.py
@@ -51,6 +51,7 @@ class Settings(BaseSettings):
 
     # OpenRouter Configuration
     openrouter_api_key: Optional[str] = None
+    openrouter_disallowed_providers: Optional[str] = None
     ocr_llm_provider: Optional[str] = None
     ocr_llm_model_name: Optional[str] = None
 
@@ -203,6 +204,12 @@ class Settings(BaseSettings):
         if self.ocr_llm_model_name:
             return self.ocr_llm_model_name
         return self.resolve_service_llm_model(provider=self.resolve_ocr_llm_provider())
+
+    def resolve_openrouter_disallowed_providers(self) -> list[str]:
+        """Return normalized OpenRouter providers to avoid routing through."""
+        if not self.openrouter_disallowed_providers:
+            return []
+        return [provider.strip() for provider in self.openrouter_disallowed_providers.split(",") if provider.strip()]
 
     def get_agent_llm_settings(
         self,

--- a/src/runestone/core/service_llm.py
+++ b/src/runestone/core/service_llm.py
@@ -56,6 +56,10 @@ def build_service_llm_model(
         api_key = settings.openrouter_api_key
         if not api_key:
             raise APIKeyError("OpenRouter API key is required. Set OPENROUTER_API_KEY environment variable.")
+        extra_body: dict[str, object] | None = None
+        disallowed_providers = settings.resolve_openrouter_disallowed_providers()
+        if disallowed_providers:
+            extra_body = {"provider": {"ignore": disallowed_providers}}
         return ChatOpenAI(
             model=effective_model_name,
             api_key=SecretStr(api_key),
@@ -66,6 +70,7 @@ def build_service_llm_model(
                 "X-Title": "Runestone",
             },
             timeout=SERVICE_LLM_TIMEOUT_SECONDS,
+            extra_body=extra_body,
         )
 
     if effective_provider == "gemini":

--- a/tests/agents/test_llm.py
+++ b/tests/agents/test_llm.py
@@ -23,6 +23,7 @@ def mock_settings():
     settings.openrouter_api_key = "test-openrouter-key"
     settings.openai_api_key = "test-openai-key"
     settings.gemini_api_key = "test-gemini-key"
+    settings.resolve_openrouter_disallowed_providers.return_value = []
     settings.get_agent_llm_settings.return_value = AgentLLMSettings(
         provider="openrouter",
         model="test-chat-model",
@@ -140,6 +141,17 @@ def test_build_chat_model_adds_openrouter_reasoning_when_configured(mock_setting
 
         call_kwargs = mock_chat_openai.call_args[1]
         assert call_kwargs["extra_body"] == {"reasoning": {"effort": "minimal"}}
+
+
+def test_build_chat_model_adds_openrouter_ignored_providers(mock_settings):
+    """OpenRouter requests should include provider ignore list when configured."""
+    mock_settings.resolve_openrouter_disallowed_providers.return_value = ["bad-provider"]
+
+    with patch("runestone.agents.llm.ChatOpenAI") as mock_chat_openai:
+        build_chat_model(mock_settings, "teacher")
+
+        call_kwargs = mock_chat_openai.call_args[1]
+        assert call_kwargs["extra_body"] == {"provider": {"ignore": ["bad-provider"]}}
 
 
 def test_build_chat_model_does_not_send_reasoning_when_disabled(mock_settings):

--- a/tests/core/test_factory.py
+++ b/tests/core/test_factory.py
@@ -30,6 +30,7 @@ class TestServiceLLMBuilder:
         mock_settings.llm_model_name = "gpt-4o-mini"
         mock_settings.resolve_service_llm_provider.return_value = "openai"
         mock_settings.resolve_service_llm_model.return_value = "gpt-4o-mini"
+        mock_settings.resolve_openrouter_disallowed_providers.return_value = []
         mock_settings.openai_api_key = "test-openai-key"
 
         build_service_llm_model(mock_settings)
@@ -50,6 +51,7 @@ class TestServiceLLMBuilder:
         mock_settings.llm_model_name = None
         mock_settings.resolve_service_llm_provider.return_value = "openai"
         mock_settings.resolve_service_llm_model.return_value = DEFAULT_SERVICE_LLM_MODEL
+        mock_settings.resolve_openrouter_disallowed_providers.return_value = []
         mock_settings.openai_api_key = "test-openai-key"
 
         build_service_llm_model(mock_settings)
@@ -65,6 +67,7 @@ class TestServiceLLMBuilder:
         mock_settings.llm_model_name = "anthropic/claude-3.5-sonnet"
         mock_settings.resolve_service_llm_provider.return_value = "openrouter"
         mock_settings.resolve_service_llm_model.return_value = "anthropic/claude-3.5-sonnet"
+        mock_settings.resolve_openrouter_disallowed_providers.return_value = []
         mock_settings.openrouter_api_key = "test-openrouter-key"
 
         build_service_llm_model(mock_settings)
@@ -76,7 +79,24 @@ class TestServiceLLMBuilder:
         assert call_kwargs["default_headers"]["HTTP-Referer"] == "https://runestone.app"
         assert call_kwargs["default_headers"]["X-Title"] == "Runestone"
         assert call_kwargs["timeout"] == SERVICE_LLM_TIMEOUT_SECONDS
+        assert call_kwargs["extra_body"] is None
         assert "max_retries" not in call_kwargs
+
+    @patch("runestone.core.service_llm.ChatOpenAI")
+    def test_build_service_llm_model_openrouter_adds_provider_blacklist(self, mock_chat_openai):
+        """OpenRouter builder should pass ignored providers when configured."""
+        mock_settings = Mock(spec=Settings)
+        mock_settings.llm_provider = "openrouter"
+        mock_settings.llm_model_name = "anthropic/claude-3.5-sonnet"
+        mock_settings.resolve_service_llm_provider.return_value = "openrouter"
+        mock_settings.resolve_service_llm_model.return_value = "anthropic/claude-3.5-sonnet"
+        mock_settings.resolve_openrouter_disallowed_providers.return_value = ["bad-provider"]
+        mock_settings.openrouter_api_key = "test-openrouter-key"
+
+        build_service_llm_model(mock_settings)
+
+        call_kwargs = mock_chat_openai.call_args[1]
+        assert call_kwargs["extra_body"] == {"provider": {"ignore": ["bad-provider"]}}
 
     @patch("runestone.core.service_llm.ChatOpenAI")
     def test_build_service_llm_model_respects_overrides(self, mock_chat_openai):
@@ -86,6 +106,7 @@ class TestServiceLLMBuilder:
         mock_settings.llm_model_name = "gpt-4o-mini"
         mock_settings.resolve_service_llm_provider.return_value = "openai"
         mock_settings.resolve_service_llm_model.return_value = "gpt-4o-mini"
+        mock_settings.resolve_openrouter_disallowed_providers.return_value = []
         mock_settings.openai_api_key = "unused-openai-key"
         mock_settings.openrouter_api_key = "test-openrouter-key"
 
@@ -111,6 +132,7 @@ class TestServiceLLMBuilder:
         mock_settings.llm_model_name = "gemini-2.5-flash"
         mock_settings.resolve_service_llm_provider.return_value = "gemini"
         mock_settings.resolve_service_llm_model.return_value = "gemini-2.5-flash"
+        mock_settings.resolve_openrouter_disallowed_providers.return_value = []
         mock_settings.gemini_api_key = "test-gemini-key"
 
         build_service_llm_model(mock_settings)
@@ -129,6 +151,7 @@ class TestServiceLLMBuilder:
         mock_settings.llm_model_name = None
         mock_settings.resolve_service_llm_provider.return_value = "gemini"
         mock_settings.resolve_service_llm_model.return_value = DEFAULT_GEMINI_SERVICE_LLM_MODEL
+        mock_settings.resolve_openrouter_disallowed_providers.return_value = []
         mock_settings.gemini_api_key = "test-gemini-key"
 
         build_service_llm_model(mock_settings)
@@ -143,6 +166,7 @@ class TestServiceLLMBuilder:
         mock_settings.llm_model_name = "gpt-4o-mini"
         mock_settings.resolve_service_llm_provider.return_value = "openai"
         mock_settings.resolve_service_llm_model.return_value = "gpt-4o-mini"
+        mock_settings.resolve_openrouter_disallowed_providers.return_value = []
         mock_settings.openai_api_key = ""
 
         with pytest.raises(APIKeyError, match="OpenAI API key is required"):
@@ -155,6 +179,7 @@ class TestServiceLLMBuilder:
         mock_settings.llm_model_name = "anthropic/claude-3.5-sonnet"
         mock_settings.resolve_service_llm_provider.return_value = "openrouter"
         mock_settings.resolve_service_llm_model.return_value = "anthropic/claude-3.5-sonnet"
+        mock_settings.resolve_openrouter_disallowed_providers.return_value = []
         mock_settings.openrouter_api_key = ""
 
         with pytest.raises(APIKeyError, match="OpenRouter API key is required"):
@@ -167,6 +192,7 @@ class TestServiceLLMBuilder:
         mock_settings.llm_model_name = "gemini-2.5-flash"
         mock_settings.resolve_service_llm_provider.return_value = "gemini"
         mock_settings.resolve_service_llm_model.return_value = "gemini-2.5-flash"
+        mock_settings.resolve_openrouter_disallowed_providers.return_value = []
         mock_settings.gemini_api_key = ""
 
         with pytest.raises(APIKeyError, match="Gemini API key is required"):
@@ -179,6 +205,7 @@ class TestServiceLLMBuilder:
         mock_settings.llm_model_name = "test-model"
         mock_settings.resolve_service_llm_provider.return_value = "unsupported"
         mock_settings.resolve_service_llm_model.return_value = "test-model"
+        mock_settings.resolve_openrouter_disallowed_providers.return_value = []
 
         with pytest.raises(ValueError, match="Unsupported LLM provider: unsupported"):
             build_service_llm_model(mock_settings)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -236,6 +236,29 @@ class TestSettings:
         assert test_settings.resolve_ocr_llm_provider() == "openrouter"
         assert test_settings.resolve_ocr_llm_model() == "anthropic/claude-3.5-sonnet"
 
+    def test_openrouter_disallowed_providers_resolver_parses_csv(self):
+        """OpenRouter ignore list resolver should normalize comma-separated provider slugs."""
+        test_settings = Settings.model_construct(
+            llm_provider="openai",
+            llm_model_name="gpt-5-mini",
+            openai_api_key="test-key",
+            gemini_api_key="test-gemini-key",
+            openrouter_api_key="test-openrouter-key",
+            openrouter_disallowed_providers=" bad-provider,another-provider , , ",
+            ocr_llm_provider=None,
+            ocr_llm_model_name=None,
+            allowed_origins="http://localhost:3000",
+            database_url="sqlite:///./test.db",
+            telegram_bot_token="test-token",
+            frontend_url="http://localhost:5173",
+            jwt_secret_key="secret",
+            teacher_provider="openrouter",
+            teacher_model="teacher-model",
+            coordinator_model="coordinator-model",
+        )
+
+        assert test_settings.resolve_openrouter_disallowed_providers() == ["bad-provider", "another-provider"]
+
     def test_gemini_service_provider_can_keep_ocr_on_openrouter(self):
         """Gemini service flows should coexist with an explicit OpenRouter OCR override."""
         test_settings = Settings.model_construct(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -244,7 +244,7 @@ class TestSettings:
             openai_api_key="test-key",
             gemini_api_key="test-gemini-key",
             openrouter_api_key="test-openrouter-key",
-            openrouter_disallowed_providers=" bad-provider,another-provider , , ",
+            openrouter_disallowed_providers=" bad-provider,another-provider,bad-provider , , ",
             ocr_llm_provider=None,
             ocr_llm_model_name=None,
             allowed_origins="http://localhost:3000",


### PR DESCRIPTION
## Summary
- add OPENROUTER_DISALLOWED_PROVIDERS setting to configure a provider blacklist
- include OpenRouter provider ignore routing in both agent and service LLM builders
- add tests for config parsing and OpenRouter payload wiring
- document the new env var in .env.example and .env.test

## Validation
- make backend-test (918 passed)
- uv run --extra dev pytest tests/agents/test_llm.py tests/core/test_factory.py tests/test_config.py -q (41 passed)

## Context
This addresses the OpenRouter provider glitch noted in Dart task: https://app.dartai.com/t/4ZP47a8Gkry6-bug-provider-glitch-on-openrou