### PR TITLE
Tighten news retrieval limits and timeouts

### DIFF
--- a/src/runestone/agents/specialists/news_agent.py
+++ b/src/runestone/agents/specialists/news_agent.py
@@ -35,7 +35,7 @@ bounded context for the teacher.
 - Use `search_news_with_dates` first when you do act.
 - Use `read_url` only for selected article URLs when snippets are too thin to help the teacher.
 - Never use `read_url` as a general web crawler.
-- Keep retrieval bounded: max 5 search results and max 2 `read_url` calls.
+- Keep retrieval bounded: max 5 search results and max 3 `read_url` calls.
 
 ## Act when
 - The student clearly names a topic or domain for news.
@@ -57,7 +57,7 @@ bounded context for the teacher.
   and generate a non-empty Swedish query (for example: "senaste nyheterna i Sverige").
 - If coordinator already routed this turn to NewsAgent for news retrieval, do not downgrade to
   `no_action` unless the request is clearly unrelated to real-time information.
-- Keep retrieval bounded: max 5 search results and max 2 `read_url` calls.
+- Keep retrieval bounded: max 5 search results and max 3 `read_url` calls.
 
 ## Output Contract
 Return valid JSON with this exact shape and no extra text:

--- a/src/runestone/agents/tools/news.py
+++ b/src/runestone/agents/tools/news.py
@@ -45,9 +45,9 @@ class NewsResultsOutput(BaseModel):
     results: list[NewsResult]
 
 
-MAX_NEWS_TO_FETCH = 10
-DDGS_TIMEOUT = 20
-DDGS_MAX_RETRIES = 2
+MAX_NEWS_TO_FETCH = 5
+DDGS_TIMEOUT = 8
+DDGS_MAX_RETRIES = 1
 DDGS_RETRY_DELAYS = (0.3, 0.6)
 
 

--- a/src/runestone/agents/tools/read_url.py
+++ b/src/runestone/agents/tools/read_url.py
@@ -136,7 +136,7 @@ async def _fetch_url_bytes(url: str) -> tuple[bytes, str, str, bool] | tuple[Non
         "User-Agent": "runestone-teacher-agent/1.0 (+https://example.invalid)",
         "Accept": "text/html,text/plain,application/xhtml+xml,text/markdown;q=0.9,*/*;q=0.1",
     }
-    timeout = httpx.Timeout(connect=5.0, read=10.0, write=10.0, pool=5.0)
+    timeout = httpx.Timeout(connect=3.0, read=6.0, write=6.0, pool=5.0)
 
     current_url = url
     truncated = False

--- a/tests/agents/specialists/test_news_agent.py
+++ b/tests/agents/specialists/test_news_agent.py
@@ -42,7 +42,7 @@ def test_news_agent_prompt_is_conservative():
     assert "## Act when" in NEWS_AGENT_SYSTEM_PROMPT
     assert "## Return `no_action` when" in NEWS_AGENT_SYSTEM_PROMPT
     assert "Use `read_url` only for selected article URLs" in NEWS_AGENT_SYSTEM_PROMPT
-    assert "max 5 search results and max 2 `read_url` calls" in NEWS_AGENT_SYSTEM_PROMPT
+    assert "max 5 search results and max 3 `read_url` calls" in NEWS_AGENT_SYSTEM_PROMPT
     assert "nyheter om Sverige" in NEWS_AGENT_SYSTEM_PROMPT
     assert "senaste nyheterna i Sverige" in NEWS_AGENT_SYSTEM_PROMPT
     assert "do not downgrade to" in NEWS_AGENT_SYSTEM_PROMPT

--- a/tests/agents/test_tools.py
+++ b/tests/agents/test_tools.py
@@ -106,7 +106,7 @@ async def test_search_news_with_dates_no_results_after_filter(monkeypatch):
 async def test_search_news_with_dates_clamps_k(monkeypatch):
     class FakeDDGSClampsK(FakeDDGS):
         def news(self, query, max_results, timelimit, region):
-            assert max_results == 10
+            assert max_results == 5
             return []
 
     monkeypatch.setattr(agent_news, "DDGS", FakeDDGSClampsK)


### PR DESCRIPTION
## Summary
- reduce news search tool retries and timeout budget while capping fetches at 5 results
- lower read_url fetch timeouts and update the news specialist prompt to allow up to 3 read_url calls
- update news-agent tests to match the bounded retrieval behavior

## Validation
- make check-readiness
- uv run pytest tests/agents/test_tools.py tests/agents/specialists/test_news_agent.py -v
- independent GPT-5.5 review pass completed during preparation