### PR TITLE
Fix OpenRouter disallowed provider slug normalization

### DIFF
--- a/src/runestone/config.py
+++ b/src/runestone/config.py
@@ -20,16 +20,11 @@ DEFAULT_GEMINI_SERVICE_LLM_MODEL = "gemini-2.5-flash"
 
 def _slugify_openrouter_provider(value: str) -> str:
     """Normalize provider labels to the slug format OpenRouter routing expects."""
-    segments: list[str] = []
-    for raw_segment in value.strip().split("/"):
-        segment = raw_segment.strip().lower()
-        if not segment:
-            continue
-        segment = re.sub(r"[^a-z0-9]+", "-", segment)
-        segment = segment.strip("-")
-        if segment:
-            segments.append(segment)
-    return "/".join(segments)
+    return "/".join(
+        slug
+        for raw_segment in value.split("/")
+        if (slug := re.sub(r"[^a-z0-9]+", "-", raw_segment.strip().lower()).strip("-"))
+    )
 
 
 class ReasoningLevel(str, Enum):

--- a/src/runestone/config.py
+++ b/src/runestone/config.py
@@ -6,6 +6,7 @@ loaded from environment variables using Pydantic BaseSettings.
 """
 
 import os
+import re
 from enum import Enum
 from typing import Literal, Optional
 
@@ -15,6 +16,20 @@ from pydantic_settings import BaseSettings
 
 DEFAULT_SERVICE_LLM_MODEL = "gpt-5.4-nano"
 DEFAULT_GEMINI_SERVICE_LLM_MODEL = "gemini-2.5-flash"
+
+
+def _slugify_openrouter_provider(value: str) -> str:
+    """Normalize provider labels to the slug format OpenRouter routing expects."""
+    segments: list[str] = []
+    for raw_segment in value.strip().split("/"):
+        segment = raw_segment.strip().lower()
+        if not segment:
+            continue
+        segment = re.sub(r"[^a-z0-9]+", "-", segment)
+        segment = segment.strip("-")
+        if segment:
+            segments.append(segment)
+    return "/".join(segments)
 
 
 class ReasoningLevel(str, Enum):
@@ -206,12 +221,14 @@ class Settings(BaseSettings):
         return self.resolve_service_llm_model(provider=self.resolve_ocr_llm_provider())
 
     def resolve_openrouter_disallowed_providers(self) -> list[str]:
-        """Return normalized OpenRouter providers to avoid routing through."""
+        """Return OpenRouter provider slugs to avoid routing through."""
         if not self.openrouter_disallowed_providers:
             return []
         return list(
             dict.fromkeys(
-                provider.strip() for provider in self.openrouter_disallowed_providers.split(",") if provider.strip()
+                slug
+                for provider in self.openrouter_disallowed_providers.split(",")
+                if (slug := _slugify_openrouter_provider(provider))
             )
         )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -237,14 +237,14 @@ class TestSettings:
         assert test_settings.resolve_ocr_llm_model() == "anthropic/claude-3.5-sonnet"
 
     def test_openrouter_disallowed_providers_resolver_parses_csv(self):
-        """OpenRouter ignore list resolver should normalize comma-separated provider slugs."""
+        """OpenRouter ignore list resolver should canonicalize display names into slugs."""
         test_settings = Settings.model_construct(
             llm_provider="openai",
             llm_model_name="gpt-5-mini",
             openai_api_key="test-key",
             gemini_api_key="test-gemini-key",
             openrouter_api_key="test-openrouter-key",
-            openrouter_disallowed_providers=" bad-provider,another-provider,bad-provider , , ",
+            openrouter_disallowed_providers=" DeepInfra, google vertex / us-east5,deepinfra , , ",
             ocr_llm_provider=None,
             ocr_llm_model_name=None,
             allowed_origins="http://localhost:3000",
@@ -257,7 +257,7 @@ class TestSettings:
             coordinator_model="coordinator-model",
         )
 
-        assert test_settings.resolve_openrouter_disallowed_providers() == ["bad-provider", "another-provider"]
+        assert test_settings.resolve_openrouter_disallowed_providers() == ["deepinfra", "google-vertex/us-east5"]
 
     def test_gemini_service_provider_can_keep_ocr_on_openrouter(self):
         """Gemini service flows should coexist with an explicit OpenRouter OCR override."""


### PR DESCRIPTION
## Summary
- normalize OPENROUTER_DISALLOWED_PROVIDERS entries into OpenRouter-style slugs before sending provider.ignore
- preserve slash-delimited endpoint suffixes like google-vertex/us-east5
- cover mixed display-name and slug input with a config test

## Testing
- uv run pytest /Users/40min/www/runestone/tests/test_config.py -k openrouter_disallowed_providers -v
- uv run pytest /Users/40min/www/runestone/tests/agents/test_llm.py -k ignored_providers -v
- pre-commit hooks on commit: black, isort, flake8

## Notes
- make lint-check currently fails on an unrelated existing import-order issue in src/runestone/services/vocabulary_service.py, outside this diff.