### PR TITLE
[codex] Add timeout wiring tests for news tools

### DIFF
--- a/tests/agents/test_read_url_tool.py
+++ b/tests/agents/test_read_url_tool.py
@@ -61,3 +61,62 @@ async def test_read_url_logs_when_output_is_truncated(monkeypatch, caplog):
     assert "read_url output truncated" in caplog.text
     assert "[Truncated output.]" in result
     assert "Note: Content was truncated due to size limits." in result
+
+
+@pytest.mark.anyio
+async def test_fetch_url_bytes_uses_tightened_http_timeouts(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def _allow_url(_url: str) -> tuple[bool, str]:
+        return True, ""
+
+    class FakeResponse:
+        status_code = 200
+        headers = {"content-type": "text/plain"}
+        url = "https://example.com"
+
+        async def aiter_bytes(self):
+            yield b"hello"
+
+    class FakeStreamContext:
+        async def __aenter__(self):
+            return FakeResponse()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            captured["timeout"] = kwargs["timeout"]
+            captured["follow_redirects"] = kwargs["follow_redirects"]
+            captured["headers"] = kwargs["headers"]
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def stream(self, method: str, url: str):
+            captured["method"] = method
+            captured["url"] = url
+            return FakeStreamContext()
+
+    monkeypatch.setattr(tools, "_validate_fetch_url", _allow_url)
+    monkeypatch.setattr(tools.httpx, "AsyncClient", FakeAsyncClient)
+
+    content, final_url, content_type, truncated = await tools._fetch_url_bytes("https://example.com")
+
+    timeout = captured["timeout"]
+    assert content == b"hello"
+    assert final_url == "https://example.com"
+    assert content_type == "text/plain"
+    assert truncated is False
+    assert captured["follow_redirects"] is False
+    assert captured["method"] == "GET"
+    assert captured["url"] == "https://example.com"
+    assert captured["headers"]["User-Agent"] == "runestone-teacher-agent/1.0 (+https://example.invalid)"
+    assert timeout.connect == 3.0
+    assert timeout.read == 6.0
+    assert timeout.write == 6.0
+    assert timeout.pool == 5.0

--- a/tests/agents/test_tools.py
+++ b/tests/agents/test_tools.py
@@ -138,3 +138,23 @@ async def test_search_news_with_dates_rate_limited(monkeypatch):
 
     assert output["error_type"] == "rate_limited"
     assert call_count["count"] == agent_news.DDGS_MAX_RETRIES + 1
+
+
+@pytest.mark.anyio
+async def test_search_news_with_dates_uses_tightened_ddgs_timeout(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class FakeDDGSTimeout(FakeDDGS):
+        def __init__(self, *args, **kwargs):
+            captured["timeout"] = kwargs.get("timeout")
+
+        def news(self, query, max_results, timelimit, region):
+            return []
+
+    monkeypatch.setattr(agent_news, "DDGS", FakeDDGSTimeout)
+
+    output = await agent_news.search_news_with_dates.ainvoke({"query": "ekonomi"})
+
+    assert output["tool"] == "search_news_with_dates"
+    assert output["results"] == []
+    assert captured["timeout"] == agent_news.DDGS_TIMEOUT

--- a/tests/agents/test_tools.py
+++ b/tests/agents/test_tools.py
@@ -148,9 +148,6 @@ async def test_search_news_with_dates_uses_tightened_ddgs_timeout(monkeypatch):
         def __init__(self, *args, **kwargs):
             captured["timeout"] = kwargs.get("timeout")
 
-        def news(self, query, max_results, timelimit, region):
-            return []
-
     monkeypatch.setattr(agent_news, "DDGS", FakeDDGSTimeout)
 
     output = await agent_news.search_news_with_dates.ainvoke({"query": "ekonomi"})


### PR DESCRIPTION
## Summary
- add coverage for the tightened DDGS timeout used by `search_news_with_dates`
- add coverage for the tightened `httpx` timeout used by `read_url` fetches

## Why
The recent news retrieval limit and timeout changes updated runtime wiring but did not directly assert the new timeout values. These tests lock those paths down without changing production code.

## Validation
- `uv run pytest tests/agents/test_tools.py tests/agents/test_read_url_tool.py -v`
- `uv run black --check tests/agents/test_tools.py tests/agents/test_read_url_tool.py`
- `uv run isort --check-only tests/agents/test_tools.py tests/agents/test_read_url_tool.py`
- `uv run flake8 --max-line-length=120 --extend-ignore=E203,W503 tests/agents/test_tools.py tests/agents/test_read_url_tool.py`
