### PR TITLE
[codex] Fix frontend container healthcheck

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -34,9 +34,6 @@ LABEL version="1.0.0"
 LABEL description="Runestone Swedish textbook analysis service - Frontend"
 LABEL org.opencontainers.image.source="https://github.com/your-org/runestone"
 
-# Install runtime tools used by container health checks.
-RUN apk add --no-cache curl
-
 # Copy built assets from builder stage
 COPY --from=builder /app/dist /usr/share/nginx/html
 

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -34,6 +34,9 @@ LABEL version="1.0.0"
 LABEL description="Runestone Swedish textbook analysis service - Frontend"
 LABEL org.opencontainers.image.source="https://github.com/your-org/runestone"
 
+# Install runtime tools used by container health checks.
+RUN apk add --no-cache curl
+
 # Copy built assets from builder stage
 COPY --from=builder /app/dist /usr/share/nginx/html
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -156,7 +156,7 @@ services:
           cpus: '0.1'
           memory: 64M
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3010"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3010"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary
- switch the frontend container healthcheck to BusyBox `wget --spider`
- remove the added `curl` installation from the frontend runtime image
- keep the frontend image lean while preserving the compose healthcheck

## Root cause
The recent compose change added a frontend healthcheck, but the original implementation depended on a tool that was not guaranteed by the runtime image. The safer fix here is to use the `wget` utility already present in `nginx:alpine` instead of adding `curl` just for the healthcheck.

## Validation
- `git commit` pre-commit hooks passed for both PR commits
- verified in a local `nginx:alpine` container that `/usr/bin/wget` exists and supports `--spider`
- full `docker compose` validation in this worktree remains blocked because `.env` is absent
- earlier targeted pytest attempts using `UV_CACHE_DIR=.uv-cache uv run --extra dev python -m pytest ...` were blocked by repeated `uv` dependency download timeouts while fetching large wheels
