### PR TITLE
Fix backup retention cutoff

### DIFF
--- a/scripts/postgres-backup.sh
+++ b/scripts/postgres-backup.sh
@@ -17,6 +17,15 @@ log() {
   printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
 }
 
+validate_retention_days() {
+  case "${BACKUP_RETENTION_DAYS}" in
+    ''|0|*[!0-9]*|0[0-9]*)
+      log "POSTGRES_BACKUP_RETENTION_DAYS must be a positive integer without leading zeros"
+      exit 1
+      ;;
+  esac
+}
+
 wait_for_postgres() {
   until pg_isready -h "${PGHOST}" -p "${PGPORT}" -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" >/dev/null 2>&1; do
     log "waiting for postgres at ${PGHOST}:${PGPORT}/${POSTGRES_DB}"
@@ -58,6 +67,7 @@ prune_backups() {
 }
 
 mkdir -p "${BACKUP_DIR}"
+validate_retention_days
 wait_for_postgres
 
 while true; do

--- a/scripts/postgres-backup.sh
+++ b/scripts/postgres-backup.sh
@@ -49,7 +49,12 @@ run_backup() {
 
 prune_backups() {
   log "pruning backups older than ${BACKUP_RETENTION_DAYS} days from ${BACKUP_DIR}"
-  find "${BACKUP_DIR}" -maxdepth 1 -type f -name "${POSTGRES_DB}-*.dump" -mtime "+${BACKUP_RETENTION_DAYS}" -exec rm -f {} \;
+  # `find -mtime` rounds file ages down to whole 24-hour buckets, so `+6` is the closest match for a 7-day cutoff.
+  retention_buckets=$((BACKUP_RETENTION_DAYS - 1))
+  if [ "${retention_buckets}" -lt 0 ]; then
+    retention_buckets=0
+  fi
+  find "${BACKUP_DIR}" -maxdepth 1 -type f -name "${POSTGRES_DB}-*.dump" -mtime "+${retention_buckets}" -exec rm -f {} \;
 }
 
 mkdir -p "${BACKUP_DIR}"

--- a/tests/test_postgres_backup.py
+++ b/tests/test_postgres_backup.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def test_backup_script_prunes_dumps_older_than_retention_window(tmp_path: Path) -> None:
+    """Backups older than the configured retention window should be removed on the next cycle."""
+    backup_dir = tmp_path / "backups"
+    backup_dir.mkdir()
+    old_dump = backup_dir / "runestone-old.dump"
+    old_dump.write_text("stale backup")
+    stale_time = datetime.now(UTC) - timedelta(days=7, minutes=1)
+    os.utime(old_dump, (stale_time.timestamp(), stale_time.timestamp()))
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_executable(
+        fake_bin / "pg_isready",
+        "#!/bin/sh\nexit 0\n",
+    )
+    _write_executable(
+        fake_bin / "pg_dump",
+        """#!/bin/sh
+file=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --file=*)
+      file="${1#--file=}"
+      shift
+      continue
+      ;;
+    --file)
+    file="$2"
+    shift 2
+    continue
+      ;;
+  esac
+  shift
+done
+touch "$file"
+exit 0
+""",
+    )
+    _write_executable(
+        fake_bin / "sleep",
+        "#!/bin/sh\nexit 1\n",
+    )
+
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "postgres-backup.sh"
+    env = os.environ | {
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "POSTGRES_BACKUP_DIR": str(backup_dir),
+        "POSTGRES_BACKUP_INTERVAL_SECONDS": "60",
+        "POSTGRES_BACKUP_RETENTION_DAYS": "7",
+        "POSTGRES_USER": "postgres",
+        "POSTGRES_PASSWORD": "secret",
+        "POSTGRES_DB": "runestone",
+    }
+
+    result = subprocess.run(
+        ["/bin/sh", str(script_path)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert not old_dump.exists()
+    assert any(path.name.startswith("runestone-") and path.suffix == ".dump" for path in backup_dir.iterdir())

--- a/tests/test_postgres_backup.py
+++ b/tests/test_postgres_backup.py
@@ -12,15 +12,7 @@ def _write_executable(path: Path, content: str) -> None:
     path.chmod(path.stat().st_mode | stat.S_IXUSR)
 
 
-def test_backup_script_prunes_dumps_older_than_retention_window(tmp_path: Path) -> None:
-    """Backups older than the configured retention window should be removed on the next cycle."""
-    backup_dir = tmp_path / "backups"
-    backup_dir.mkdir()
-    old_dump = backup_dir / "runestone-old.dump"
-    old_dump.write_text("stale backup")
-    stale_time = datetime.now(UTC) - timedelta(days=7, minutes=1)
-    os.utime(old_dump, (stale_time.timestamp(), stale_time.timestamp()))
-
+def _build_script_env(tmp_path: Path, backup_dir: Path, retention_days: str = "7") -> dict[str, str]:
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     _write_executable(
@@ -55,16 +47,28 @@ exit 0
         "#!/bin/sh\nexit 1\n",
     )
 
-    script_path = Path(__file__).resolve().parents[1] / "scripts" / "postgres-backup.sh"
-    env = os.environ | {
+    return os.environ | {
         "PATH": f"{fake_bin}:{os.environ['PATH']}",
         "POSTGRES_BACKUP_DIR": str(backup_dir),
         "POSTGRES_BACKUP_INTERVAL_SECONDS": "60",
-        "POSTGRES_BACKUP_RETENTION_DAYS": "7",
+        "POSTGRES_BACKUP_RETENTION_DAYS": retention_days,
         "POSTGRES_USER": "postgres",
         "POSTGRES_PASSWORD": "secret",
         "POSTGRES_DB": "runestone",
     }
+
+
+def test_backup_script_prunes_dumps_older_than_retention_window(tmp_path: Path) -> None:
+    """Backups older than the configured retention window should be removed on the next cycle."""
+    backup_dir = tmp_path / "backups"
+    backup_dir.mkdir()
+    old_dump = backup_dir / "runestone-old.dump"
+    old_dump.write_text("stale backup")
+    stale_time = datetime.now(UTC) - timedelta(days=7, minutes=1)
+    os.utime(old_dump, (stale_time.timestamp(), stale_time.timestamp()))
+
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "postgres-backup.sh"
+    env = _build_script_env(tmp_path, backup_dir)
 
     result = subprocess.run(
         ["/bin/sh", str(script_path)],
@@ -77,3 +81,22 @@ exit 0
     assert result.returncode == 1
     assert not old_dump.exists()
     assert any(path.name.startswith("runestone-") and path.suffix == ".dump" for path in backup_dir.iterdir())
+
+
+def test_backup_script_rejects_invalid_retention_days(tmp_path: Path) -> None:
+    """Invalid retention settings should fail fast before the backup loop starts."""
+    backup_dir = tmp_path / "backups"
+    backup_dir.mkdir()
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "postgres-backup.sh"
+    env = _build_script_env(tmp_path, backup_dir, retention_days="07")
+
+    result = subprocess.run(
+        ["/bin/sh", str(script_path)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "POSTGRES_BACKUP_RETENTION_DAYS must be a positive integer without leading zeros" in result.stdout


### PR DESCRIPTION
## Summary

- fix the Postgres backup retention cutoff so a 7-day policy prunes dumps older than 7 days instead of nearly 8
- add a regression test that executes the backup shell script with stubbed postgres commands

## Root cause

The backup sidecar used `find -mtime +${POSTGRES_BACKUP_RETENTION_DAYS}`, but `find -mtime` rounds file ages down to whole 24-hour buckets. With a 7-day retention setting, that kept dumps until they were almost 8 days old.

## Validation

- `UV_CACHE_DIR=.uv-cache uv run --extra dev python -m pytest tests/test_postgres_backup.py -v`
