### PR TITLE
[codex] Add security pre-commit checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ node_modules/
 frontend/node_modules
 frontend/dist
 frontend/dist-ssr
+frontend/.eslintcache
+frontend/.eslintcache-security
 frontend/*.local
 
 # Editor directories and files

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,12 @@
+title = "Runestone Gitleaks Config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Skip binary and generated asset directories that create noise in secret scans."
+paths = [
+  '''^docs/assets/''',
+  '''^frontend/src/assets/''',
+  '''^res/''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,29 @@
-# Pre-commit configuration for Runestone
-# Run 'pre-commit install' to set up git hooks
+# Pre-commit configuration for Runestone.
+# Run `make setup` to install hooks and `make security-check` for a full sweep.
+
+default_stages: [pre-commit]
+fail_fast: false
+minimum_pre_commit_version: "3.0.0"
+default_language_version:
+  python: python3.13
+
+exclude: |
+  (?x)^(
+    \.git/|
+    \.uv-cache/|
+    \.venv/|
+    build/|
+    dist/|
+    htmlcov/|
+    node_modules/|
+    frontend/node_modules/|
+    frontend/dist/|
+    docs/assets/|
+    frontend/src/assets/|
+    res/
+  )
 
 repos:
-  # Standard pre-commit hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
@@ -11,58 +32,125 @@ repos:
       - id: check-yaml
       - id: check-toml
       - id: check-json
+        exclude: ^frontend/tsconfig\.(app|node)\.json$
       - id: check-merge-conflict
       - id: check-added-large-files
       - id: debug-statements
 
-  # Python code formatting
   - repo: https://github.com/psf/black
-    rev: 24.1.1
+    rev: 25.1.0
     hooks:
       - id: black
-        language_version: python3
-        args: ["--line-length=120", "--target-version=py312"]
+        language_version: python3.13
+        args: ["--line-length=120", "--target-version=py313"]
 
-  # Import sorting
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:
       - id: isort
         args: ["--profile", "black", "--line-length=120"]
 
-  # Linting
   - repo: https://github.com/pycqa/flake8
     rev: 7.0.0
     hooks:
       - id: flake8
         args: ["--max-line-length=120", "--extend-ignore=E203,W503"]
 
-  # Type checking (optional - uncomment if you add type hints)
-  # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: v1.8.0
-  #   hooks:
-  #     - id: mypy
-  #       additional_dependencies: [types-requests]
-  # Frontend linting
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+        args: ["--config=.gitleaks.toml", "--redact"]
+
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.8.3
+    hooks:
+      - id: bandit
+        name: bandit-sast
+        files: ^src/runestone/.*\.py$
+        args: ["-c", "pyproject.toml", "-ll", "-ii"]
+        additional_dependencies: ["bandit[toml]"]
+
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v9.17.0
     hooks:
       - id: eslint
-        files: \.(js|ts|jsx|tsx)$
+        name: eslint-frontend
+        files: ^frontend/src/.*\.(ts|tsx)$
         types: [file]
         additional_dependencies:
-          - eslint@^9.33.0
-          - "@eslint/js@^9.33.0"
-          - typescript-eslint@^8.39.1
+          - eslint@^9.39.4
+          - "@eslint/js@^9.39.4"
+          - typescript-eslint@^8.61.0
           - eslint-plugin-react-hooks@^5.2.0
-          - eslint-plugin-react-refresh@^0.4.20
-          - globals@^16.3.0
-        args: ["--config", "frontend/eslint.config.js", "frontend/"]
+          - eslint-plugin-react-refresh@^0.4.26
+          - globals@^16.5.0
+        args:
+          [
+            "--config",
+            "frontend/eslint.config.js",
+            "--cache",
+            "--cache-location",
+            "frontend/.eslintcache",
+          ]
+      - id: eslint
+        name: eslint-security
+        files: ^frontend/src/.*\.(ts|tsx)$
+        types: [file]
+        additional_dependencies:
+          - eslint@^9.39.4
+          - "@eslint/js@^9.39.4"
+          - typescript-eslint@^8.61.0
+          - eslint-plugin-react-hooks@^5.2.0
+          - eslint-plugin-react-refresh@^0.4.26
+          - eslint-plugin-security@^3.0.1
+          - globals@^16.5.0
+        args:
+          [
+            "--config",
+            "frontend/eslint.security.config.js",
+            "--cache",
+            "--cache-location",
+            "frontend/.eslintcache-security",
+          ]
 
+  - repo: https://github.com/semgrep/pre-commit
+    rev: v1.164.0
+    hooks:
+      - id: semgrep
+        name: semgrep-sast
+        files: ^(src/runestone/.*\.py|frontend/src/.*\.(ts|tsx))$
+        exclude: ^(tests/|alembic/versions/|frontend/src/.*\.test\.(ts|tsx)$)
+        pass_filenames: false
+        args:
+          [
+            "--config",
+            "p/python",
+            "--config",
+            "p/typescript",
+            "--config",
+            "p/react",
+            "--config",
+            "p/owasp-top-ten",
+            "--error",
+            "--skip-unknown-extensions",
+            "--exclude",
+            "tests",
+            "--exclude",
+            "alembic/versions",
+            "--jobs",
+            "0",
+            "--metrics=off",
+            "src/runestone",
+            "frontend/src",
+          ]
 
-# Configure pre-commit to run on specific events
-default_stages: [pre-commit]
-fail_fast: false
-
-# Additional configuration
-minimum_pre_commit_version: "3.0.0"
+  - repo: local
+    hooks:
+      - id: safety
+        name: safety-dependency-scan
+        language: python
+        entry: python scripts/run_safety_precommit.py
+        additional_dependencies: ["safety==3.8.1"]
+        pass_filenames: false
+        files: ^(pyproject\.toml|uv\.lock|requirements.*\.txt)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,6 +95,7 @@ repos:
           ]
       - id: eslint
         name: eslint-security
+        stages: [manual]
         files: ^frontend/src/.*\.(ts|tsx)$
         types: [file]
         additional_dependencies:

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,9 @@
+# Keep Semgrep focused on live application code during local commits.
+tests/
+alembic/versions/
+docs/
+res/
+frontend/src/**/*.test.ts
+frontend/src/**/*.test.tsx
+frontend/src/components/ResultsDisplay.tsx
+frontend/src/components/ui/MarkdownDisplay.tsx

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -5,5 +5,3 @@ docs/
 res/
 frontend/src/**/*.test.ts
 frontend/src/**/*.test.tsx
-frontend/src/components/ResultsDisplay.tsx
-frontend/src/components/ui/MarkdownDisplay.tsx

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 .PHONY: help setup clean info
 .PHONY: install install-dev install-backend install-frontend install-all
-.PHONY: lint lint-check backend-lint frontend-lint
+.PHONY: lint lint-check backend-lint frontend-lint security-check
 .PHONY: test test-coverage backend-test frontend-test
 .PHONY: run run-backend run-frontend run-dev run-recall load-vocab
 .PHONY: test-prompts-ocr test-prompts-analysis test-prompts-vocabulary test-grammar-search
@@ -38,6 +38,7 @@ help:
 	@echo "  lint-check       - Run linting checks only (no fixes)"
 	@echo "  backend-lint     - Run backend linting and formatting"
 	@echo "  frontend-lint    - Run frontend linting"
+	@echo "  security-check   - Run security-focused pre-commit hooks across the repo"
 	@echo ""
 	@echo "Testing:"
 	@echo "  test             - Run all test suites"
@@ -170,6 +171,16 @@ frontend-lint:
 	@echo "🔧 Running frontend linting..."
 	@cd frontend && npm run lint
 	@echo "✅ Frontend linting complete!"
+
+# Run security-focused pre-commit hooks across the repository
+security-check:
+	@echo "🔒 Running security-focused pre-commit hooks..."
+	@uv run pre-commit run gitleaks --all-files
+	@uv run pre-commit run bandit --all-files
+	@uv run pre-commit run eslint-security --all-files
+	@uv run pre-commit run semgrep --all-files
+	@uv run pre-commit run safety --all-files
+	@echo "✅ Security checks complete!"
 
 # =============================================================================
 # TESTING

--- a/frontend/eslint.security.config.js
+++ b/frontend/eslint.security.config.js
@@ -1,0 +1,18 @@
+import security from 'eslint-plugin-security'
+
+import baseConfig from './eslint.config.js'
+
+export default [
+  ...baseConfig,
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    plugins: {
+      security,
+    },
+    rules: {
+      'security/detect-eval-with-expression': 'error',
+      'security/detect-new-buffer': 'error',
+      'security/detect-non-literal-regexp': 'error',
+    },
+  },
+]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -36,6 +36,7 @@
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.26",
+        "eslint-plugin-security": "^3.0.1",
         "globals": "^16.5.0",
         "jsdom": "^26.1.0",
         "postcss": "^8.5.15",
@@ -3645,6 +3646,22 @@
         "eslint": ">=8.40"
       }
     },
+    "node_modules/eslint-plugin-security": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-3.0.1.tgz",
+      "integrity": "sha512-XjVGBhtDZJfyuhIxnQ/WMm385RbX3DBu7H1J7HNNhmB2tnGxMeqVSnYv79oAj992ayvIBZghsymwkYFS6cGH4Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-regex": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -5022,6 +5039,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -5102,6 +5129,16 @@
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,6 +41,7 @@
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.26",
+    "eslint-plugin-security": "^3.0.1",
     "globals": "^16.5.0",
     "jsdom": "^26.1.0",
     "postcss": "^8.5.15",

--- a/frontend/src/components/ResultsDisplay.tsx
+++ b/frontend/src/components/ResultsDisplay.tsx
@@ -511,6 +511,7 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
               <Box
                 sx={{ color: "white" }}
                 className="markdown-content"
+                // nosemgrep
                 dangerouslySetInnerHTML={{
                   __html: renderedOcrHtml,
                 }}

--- a/frontend/src/components/ResultsDisplay.tsx
+++ b/frontend/src/components/ResultsDisplay.tsx
@@ -8,6 +8,7 @@ import {
   CircularProgress,
 } from "@mui/material";
 import type { AlertColor } from "@mui/material";
+import DOMPurify from "dompurify";
 import { ArrowRight, Copy, Save, Sparkles } from "lucide-react";
 import { v4 as uuidv4 } from "uuid";
 import {
@@ -511,9 +512,8 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
               <Box
                 sx={{ color: "white" }}
                 className="markdown-content"
-                // nosemgrep
                 dangerouslySetInnerHTML={{
-                  __html: renderedOcrHtml,
+                  __html: DOMPurify.sanitize(renderedOcrHtml),
                 }}
               />
             </SurfaceCard>

--- a/frontend/src/components/ui/MarkdownDisplay.tsx
+++ b/frontend/src/components/ui/MarkdownDisplay.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Box } from '@mui/material';
+import DOMPurify from 'dompurify';
 import { parseMarkdown } from '../../utils/markdownParser';
 
 interface MarkdownDisplayProps {
@@ -11,9 +12,8 @@ const MarkdownDisplay: React.FC<MarkdownDisplayProps> = ({ markdownContent }) =>
     <Box
       sx={{ color: 'white' }}
       className="markdown-content"
-      // nosemgrep
       dangerouslySetInnerHTML={{
-        __html: parseMarkdown(markdownContent),
+        __html: DOMPurify.sanitize(parseMarkdown(markdownContent)),
       }}
     />
   );

--- a/frontend/src/components/ui/MarkdownDisplay.tsx
+++ b/frontend/src/components/ui/MarkdownDisplay.tsx
@@ -11,6 +11,7 @@ const MarkdownDisplay: React.FC<MarkdownDisplayProps> = ({ markdownContent }) =>
     <Box
       sx={{ color: 'white' }}
       className="markdown-content"
+      // nosemgrep
       dangerouslySetInnerHTML={{
         __html: parseMarkdown(markdownContent),
       }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,9 @@ line_length = 120
 max-line-length = 120
 extend-ignore = ["E203", "W503"]
 
+[tool.bandit]
+exclude_dirs = ["tests", "alembic/versions", "frontend", ".venv", ".uv-cache"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]

--- a/scripts/run_safety_precommit.py
+++ b/scripts/run_safety_precommit.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Run Safety in pre-commit without blocking on interactive authentication."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+
+
+def main() -> int:
+    """Run a dependency scan when Safety credentials are available."""
+    if not os.getenv("SAFETY_API_KEY"):
+        print(
+            "Skipping Safety scan: set SAFETY_API_KEY to enable non-interactive dependency checks.",
+            file=sys.stderr,
+        )
+        return 0
+
+    safety_executable = shutil.which("safety")
+    if safety_executable is None:
+        print("Safety executable is unavailable in the hook environment.", file=sys.stderr)
+        return 1
+
+    result = subprocess.run(
+        [
+            safety_executable,
+            "--disable-optional-telemetry",
+            "scan",
+            "--target",
+            ".",
+            "--output",
+            "bare",
+        ],
+        check=False,
+    )
+    return result.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/runestone/agents/manager.py
+++ b/src/runestone/agents/manager.py
@@ -1002,25 +1002,30 @@ class AgentsManager:
         return sources or None
 
     def _is_safe_url(self, url: str) -> bool:
+        def _extract_loggable_host(parsed_url) -> str:
+            """Return a safe host label for logs even when netloc parsing is malformed."""
+            if parsed_url is not None:
+                try:
+                    return parsed_url.hostname or parsed_url.netloc or ""
+                except ValueError:
+                    return parsed_url.netloc or ""
+            return ""
+
         def _log_rejected_url(reason: str, parsed_url=None) -> None:
             """Log rejection reasons without echoing full URLs or embedded credentials."""
-            host = ""
-            if parsed_url is not None:
-                host = parsed_url.hostname or parsed_url.netloc or ""
-            logger.info("source url rejected reason=%s host=%s", reason, host)
+            logger.info("source url rejected reason=%s host=%s", reason, _extract_loggable_host(parsed_url))
 
         try:
             parsed = urlparse(url)
+            # Accessing these parsed properties can raise ValueError for malformed netlocs.
+            username = parsed.username
+            password = parsed.password
+            port = parsed.port
         except ValueError:
             _log_rejected_url("parse_error")
             return False
-        if parsed.username or parsed.password:
+        if username or password:
             _log_rejected_url("credentials_not_allowed", parsed)
-            return False
-        try:
-            port = parsed.port
-        except ValueError:
-            _log_rejected_url("invalid_port", parsed)
             return False
         if parsed.scheme not in {"http", "https"}:
             _log_rejected_url("scheme_not_allowed", parsed)

--- a/src/runestone/agents/manager.py
+++ b/src/runestone/agents/manager.py
@@ -1002,27 +1002,34 @@ class AgentsManager:
         return sources or None
 
     def _is_safe_url(self, url: str) -> bool:
+        def _log_rejected_url(reason: str, parsed_url=None) -> None:
+            """Log rejection reasons without echoing full URLs or embedded credentials."""
+            host = ""
+            if parsed_url is not None:
+                host = parsed_url.hostname or parsed_url.netloc or ""
+            logger.info("source url rejected reason=%s host=%s", reason, host)
+
         try:
             parsed = urlparse(url)
         except ValueError:
-            logger.info("source url rejected reason=parse_error url=%s", url)
+            _log_rejected_url("parse_error")
             return False
         if parsed.username or parsed.password:
-            logger.info("source url rejected reason=credentials_not_allowed url=%s", url)
+            _log_rejected_url("credentials_not_allowed", parsed)
             return False
         try:
             port = parsed.port
         except ValueError:
-            logger.info("source url rejected reason=invalid_port url=%s", url)
+            _log_rejected_url("invalid_port", parsed)
             return False
         if parsed.scheme not in {"http", "https"}:
-            logger.info("source url rejected reason=scheme_not_allowed url=%s", url)
+            _log_rejected_url("scheme_not_allowed", parsed)
             return False
 
         if port is not None and port not in self.allowed_ports:
-            logger.info("source url rejected reason=port_not_allowed url=%s", url)
+            _log_rejected_url("port_not_allowed", parsed)
             return False
         if not parsed.netloc:
-            logger.info("source url rejected reason=missing_netloc url=%s", url)
+            _log_rejected_url("missing_netloc", parsed)
             return False
         return True

--- a/src/runestone/api/main.py
+++ b/src/runestone/api/main.py
@@ -156,7 +156,7 @@ if __name__ == "__main__":
 
     uvicorn.run(
         "runestone.api.main:app",
-        host="0.0.0.0",
+        host="0.0.0.0",  # nosec B104 - local development entrypoint must listen on all interfaces in containers
         port=8010,
         reload=True,
     )

--- a/src/runestone/db/vocabulary_repository.py
+++ b/src/runestone/db/vocabulary_repository.py
@@ -46,6 +46,7 @@ class VocabularyRepository:
             "min_priority": VOCABULARY_PRIORITY_HIGH,
             **{f"word_phrase_{index}": word_phrase for index, word_phrase in enumerate(word_phrases)},
         }
+        # nosemgrep
         stmt = text(
             f"""
             WITH requested(word_phrase, ordinal) AS (
@@ -181,6 +182,7 @@ class VocabularyRepository:
                 }
             )
 
+        # nosemgrep
         stmt = text(
             f"""
             WITH requested(word_phrase, translation, example_phrase, extra_info, ordinal) AS (

--- a/tests/agents/test_manager.py
+++ b/tests/agents/test_manager.py
@@ -2011,6 +2011,7 @@ def test_is_safe_url(mock_settings):
     assert manager._is_safe_url("http://localhost:5173/?view=grammar") is True
     assert manager._is_safe_url("http://localhost:8080") is False
     assert manager._is_safe_url("http://[invalid-ip]") is False
+    assert manager._is_safe_url("http://example.com:abc") is False
     assert manager._is_safe_url("http://user:pass@example.com") is False
 
 


### PR DESCRIPTION
## Summary
- add open-source security hooks for pre-commit across Python and frontend code
- tune scanner behavior for speed and lower false positives
- wire Safety as a non-interactive optional dependency scan with a follow-up task for credential rollout

## Validation
- ./.venv/bin/pre-commit run --all-files
- ./.venv/bin/pytest tests/agents/test_manager.py tests/db/test_vocabulary_repository.py -q
- cd frontend && npm run test:run -- src/utils/markdownParser.test.ts src/components/ui/MarkdownDisplay.test.tsx