### PR TITLE
Fix broken security-check ESLint invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ security-check:
 	@echo "🔒 Running security-focused pre-commit hooks..."
 	@uv run pre-commit run gitleaks --all-files
 	@uv run pre-commit run bandit --all-files
-	@uv run pre-commit run eslint-security --all-files
+	@uv run pre-commit run eslint --hook-stage manual --all-files
 	@uv run pre-commit run semgrep --all-files
 	@uv run pre-commit run safety --all-files
 	@echo "✅ Security checks complete!"


### PR DESCRIPTION
## Summary
- fix the Makefile security-check target to invoke the manual-stage ESLint hook by id
- keep the change minimal and limited to the broken pre-commit command

## Evidence
- commit bc69084 added make security-check and a manual pre-commit hook named eslint-security
- .pre-commit-config.yaml defines that hook with id 'eslint' and stages: [manual], so 'pre-commit run eslint-security --all-files' cannot select it
- local commit-time pre-commit validation passed on this change

## Validation
- git commit pre-commit suite on the staged Makefile change