### PR TITLE
[codex] Update AGENTS.md for security-check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Keep package `__init__.py` files empty unless there is an explicit, reviewed rea
 Prefer the Makefile targets over spelling out raw tool commands; the Makefile also keeps the `uv` cache inside the repo for reproducible local and CI runs.
 
 - Use `make check-readiness` before commit-sized changes. It runs lint checks, backend and frontend tests, then a frontend build dry-run.
-- Use scoped checks while iterating: `make backend-lint`, `make frontend-lint`, `make backend-test`, `make frontend-test`, `make lint-check`, `make test`, `make test-coverage`, or targeted `uv run pytest tests/path -v` for backend tests.
+- Use scoped checks while iterating: `make backend-lint`, `make frontend-lint`, `make security-check`, `make backend-test`, `make frontend-test`, `make lint-check`, `make test`, `make test-coverage`, or targeted `uv run pytest tests/path -v` for backend tests.
 - For broader validation sweeps, prefer the composed Make workflows: `make dev-test`, `make dev-full`, `make ci-lint`, and `make ci-test`.
 - Use `make install` for production-only dependencies, `make install-dev` for the full Python development set, and `make install-all` when bootstrapping a fresh worktree. Use `make install-backend` and `make install-frontend` for partial dependency refreshes. Run `make setup` to install pre-commit hooks (which also runs `install-dev` under the hood).
 - Start services with `make run-backend` (applies Alembic migrations, serves FastAPI on port 8010), `make run-frontend` (Vite on port 5173), or `make run-dev` for both.


### PR DESCRIPTION
## Summary
- add the documented `make security-check` workflow to Runestone agent guidance
- keep the AGENTS.md change limited to the repo-backed Makefile addition

## Validation
- reviewed `Makefile` and recent repo history to confirm `security-check` was added after the last AGENTS.md update
- no code tests run; docs-only change