### PR TITLE
Refresh memory panel after new chat reset

### DIFF
--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -56,6 +56,7 @@ const ChatView: React.FC = () => {
     messages,
     isLoading,
     isSyncingHistory,
+    memoryRefreshToken,
     historySyncNotice,
     isBackendAvailable,
     error,
@@ -625,6 +626,7 @@ const ChatView: React.FC = () => {
       <AgentMemoryModal
         open={isMemoryModalOpen}
         onClose={() => setIsMemoryModalOpen(false)}
+        refreshToken={memoryRefreshToken}
       />
     </Box>
   );

--- a/frontend/src/components/chat/AgentMemoryModal.test.tsx
+++ b/frontend/src/components/chat/AgentMemoryModal.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
 import AgentMemoryModal from './AgentMemoryModal';
 import * as useMemoryItemsModule from '../../hooks/useMemoryItems';
 
@@ -40,8 +40,13 @@ const setMatchMedia = (matches: boolean) => {
 describe('AgentMemoryModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers();
     setMatchMedia(false);
     (useMemoryItemsModule.default as Mock).mockReturnValue(mockUseMemoryItems);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('renders correctly when open', () => {
@@ -57,6 +62,34 @@ describe('AgentMemoryModal', () => {
   it('fetches items on mount when open', () => {
     render(<AgentMemoryModal open={true} onClose={() => {}} />);
     expect(mockUseMemoryItems.fetchItems).toHaveBeenCalledWith('personal_info', undefined, true, 'updated_at', 'desc');
+  });
+
+  it('re-fetches memory for a short window after a new chat refresh token changes', async () => {
+    const { rerender } = render(
+      <AgentMemoryModal open={true} onClose={() => {}} refreshToken={0} />
+    );
+
+    mockUseMemoryItems.fetchItems.mockClear();
+
+    rerender(<AgentMemoryModal open={true} onClose={() => {}} refreshToken={1} />);
+
+    expect(screen.getByText('Teacher memory is refreshing after the new chat reset.')).toBeInTheDocument();
+    expect(mockUseMemoryItems.fetchItems).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+    expect(mockUseMemoryItems.fetchItems).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+    expect(mockUseMemoryItems.fetchItems).toHaveBeenCalledTimes(3);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(8000);
+    });
+    expect(mockUseMemoryItems.fetchItems).toHaveBeenCalledTimes(4);
   });
 
   it('changes category when tab is clicked', () => {
@@ -392,5 +425,46 @@ describe('AgentMemoryModal', () => {
     });
 
     expect(mockUseMemoryItems.deleteItem).toHaveBeenCalledWith(1);
+  });
+
+  it('refreshes the list when delete fails because the item went stale', async () => {
+    const mockDeleteItem = vi.fn().mockRejectedValueOnce(new Error('Memory item with id 1 not found'));
+    const mockItems = [
+      {
+        id: 1,
+        key: 'verb-tense',
+        content: 'Struggles with verb tense',
+        category: 'area_to_improve',
+        status: 'struggling',
+        priority: 2,
+        updated_at: new Date().toISOString(),
+      },
+    ];
+    (useMemoryItemsModule.default as Mock).mockReturnValue({
+      ...mockUseMemoryItems,
+      items: mockItems,
+      deleteItem: mockDeleteItem,
+    });
+
+    render(<AgentMemoryModal open={true} onClose={() => {}} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Delete item'));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Confirm delete'));
+    });
+
+    expect(mockUseMemoryItems.fetchItems).toHaveBeenLastCalledWith(
+      'personal_info',
+      undefined,
+      true,
+      'updated_at',
+      'desc'
+    );
+    expect(
+      screen.getByText('That memory item changed during background cleanup. Refreshed the list.')
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/chat/AgentMemoryModal.test.tsx
+++ b/frontend/src/components/chat/AgentMemoryModal.test.tsx
@@ -92,6 +92,46 @@ describe('AgentMemoryModal', () => {
     expect(mockUseMemoryItems.fetchItems).toHaveBeenCalledTimes(4);
   });
 
+  it('does not cancel the refresh loop when tab is switched during the refresh window', async () => {
+    const { rerender } = render(
+      <AgentMemoryModal open={true} onClose={() => {}} refreshToken={0} />
+    );
+
+    mockUseMemoryItems.fetchItems.mockClear();
+
+    rerender(<AgentMemoryModal open={true} onClose={() => {}} refreshToken={1} />);
+
+    expect(screen.getByText('Teacher memory is refreshing after the new chat reset.')).toBeInTheDocument();
+    expect(mockUseMemoryItems.fetchItems).toHaveBeenCalledTimes(1);
+
+    // Switch tab/category to 'Areas to Improve'
+    const areasTab = screen.getByText('Areas to Improve');
+    fireEvent.click(areasTab);
+
+    // The fetchItems call from switching tab immediately is expected
+    // Let's clear mock calls to isolate the timer callbacks
+    mockUseMemoryItems.fetchItems.mockClear();
+
+    // Now advance timers to check if the loop is still running
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+    // It should call fetchItems again as part of the refresh loop
+    expect(mockUseMemoryItems.fetchItems).toHaveBeenCalled();
+    expect(screen.getByText('Teacher memory is refreshing after the new chat reset.')).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+    expect(mockUseMemoryItems.fetchItems).toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(8000);
+    });
+    // After the last attempt, the sync notice should disappear
+    expect(screen.queryByText('Teacher memory is refreshing after the new chat reset.')).not.toBeInTheDocument();
+  });
+
   it('changes category when tab is clicked', () => {
     render(<AgentMemoryModal open={true} onClose={() => {}} />);
 

--- a/frontend/src/components/chat/AgentMemoryModal.tsx
+++ b/frontend/src/components/chat/AgentMemoryModal.tsx
@@ -45,6 +45,7 @@ import useMemoryItems, {
 interface AgentMemoryModalProps {
   open: boolean;
   onClose: () => void;
+  refreshToken?: number;
 }
 
 const CATEGORIES: { id: MemoryCategory; label: string }[] = [
@@ -167,6 +168,7 @@ const textFieldStyles = {
 const AgentMemoryModal: React.FC<AgentMemoryModalProps> = ({
   open,
   onClose,
+  refreshToken = 0,
 }) => {
   const dialogPaperRef = useRef<HTMLDivElement | null>(null);
   const [isCompactLayout, setIsCompactLayout] = useState(false);
@@ -192,6 +194,7 @@ const AgentMemoryModal: React.FC<AgentMemoryModalProps> = ({
   const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
   const [confirmClear, setConfirmClear] = useState(false);
   const [editingPriorityId, setEditingPriorityId] = useState<number | null>(null);
+  const [syncNotice, setSyncNotice] = useState<string | null>(null);
   const [formData, setFormData] = useState<MemoryItemCreate>({
     category: "personal_info",
     key: "",
@@ -201,6 +204,8 @@ const AgentMemoryModal: React.FC<AgentMemoryModalProps> = ({
   });
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const refreshTimerRef = useRef<number | null>(null);
+  const lastHandledRefreshTokenRef = useRef<number>(refreshToken);
   const displayedCountLabel = `${items.length} item${items.length === 1 ? "" : "s"}`;
   const sortSummaryLabel =
     sortBy === "priority"
@@ -236,17 +241,67 @@ const AgentMemoryModal: React.FC<AgentMemoryModalProps> = ({
     }
   };
 
+  const refreshActiveItems = useCallback(async () => {
+    await fetchItems(
+      activeTab,
+      statusFilter === "all" ? undefined : statusFilter,
+      true,
+      sortBy,
+      sortDirection,
+    );
+  }, [activeTab, fetchItems, sortBy, sortDirection, statusFilter]);
+
   useEffect(() => {
     if (open) {
-      fetchItems(
-        activeTab,
-        statusFilter === "all" ? undefined : statusFilter,
-        true,
-        sortBy,
-        sortDirection,
-      );
+      void refreshActiveItems();
     }
-  }, [open, activeTab, statusFilter, sortBy, sortDirection, fetchItems]);
+  }, [open, activeTab, statusFilter, sortBy, sortDirection, refreshActiveItems]);
+
+  useEffect(() => {
+    if (!open || lastHandledRefreshTokenRef.current === refreshToken) {
+      return;
+    }
+
+    lastHandledRefreshTokenRef.current = refreshToken;
+    setSyncNotice("Teacher memory is refreshing after the new chat reset.");
+
+    if (refreshTimerRef.current !== null) {
+      window.clearTimeout(refreshTimerRef.current);
+      refreshTimerRef.current = null;
+    }
+
+    let cancelled = false;
+    const refreshDelaysMs = [0, 1500, 4000, 8000];
+
+    const runRefresh = async (attemptIndex: number) => {
+      if (cancelled) {
+        return;
+      }
+
+      await refreshActiveItems();
+
+      if (attemptIndex >= refreshDelaysMs.length - 1) {
+        if (!cancelled) {
+          setSyncNotice(null);
+        }
+        return;
+      }
+
+      refreshTimerRef.current = window.setTimeout(() => {
+        void runRefresh(attemptIndex + 1);
+      }, refreshDelaysMs[attemptIndex + 1]);
+    };
+
+    void runRefresh(0);
+
+    return () => {
+      cancelled = true;
+      if (refreshTimerRef.current !== null) {
+        window.clearTimeout(refreshTimerRef.current);
+        refreshTimerRef.current = null;
+      }
+    };
+  }, [open, refreshActiveItems, refreshToken]);
 
   useEffect(() => {
     if (!open) {
@@ -254,6 +309,11 @@ const AgentMemoryModal: React.FC<AgentMemoryModalProps> = ({
       setConfirmClear(false);
       setEditingPriorityId(null);
       setIsFiltersOpen(false);
+      setSyncNotice(null);
+      if (refreshTimerRef.current !== null) {
+        window.clearTimeout(refreshTimerRef.current);
+        refreshTimerRef.current = null;
+      }
     }
   }, [open]);
 
@@ -340,6 +400,7 @@ const AgentMemoryModal: React.FC<AgentMemoryModalProps> = ({
   const handleSaveItem = async () => {
     try {
       await createItem(formData);
+      setSyncNotice(null);
       setIsFormOpen(false);
     } catch (err) {
       console.error("Failed to save memory item", err);
@@ -357,7 +418,14 @@ const AgentMemoryModal: React.FC<AgentMemoryModalProps> = ({
   const handlePriorityChange = async (id: number, value: string) => {
     const priority = value === "" ? null : Number(value);
     setEditingPriorityId(null);
-    await updatePriority(id, priority);
+    try {
+      await updatePriority(id, priority);
+      setSyncNotice(null);
+    } catch (err) {
+      console.error("Failed to update memory priority", err);
+      setSyncNotice("That memory item changed during background cleanup. Refreshed the list.");
+      await refreshActiveItems();
+    }
   };
 
   const renderStatusMenuItems = (category: MemoryCategory) =>
@@ -793,6 +861,19 @@ const AgentMemoryModal: React.FC<AgentMemoryModalProps> = ({
               </Box>
             )}
 
+            {syncNotice && (
+              <Box
+                sx={{
+                  p: 2,
+                  bgcolor: "rgba(56, 224, 123, 0.08)",
+                  border: "1px solid rgba(56, 224, 123, 0.18)",
+                  borderRadius: 1,
+                }}
+              >
+                <Typography sx={{ color: "#d1fae5" }}>{syncNotice}</Typography>
+              </Box>
+            )}
+
             {items.length === 0 && !loading && (
               <Box sx={{ py: 8, textAlign: "center", color: "#6b7280" }}>
                 <Typography variant="body1">
@@ -1008,8 +1089,18 @@ const AgentMemoryModal: React.FC<AgentMemoryModalProps> = ({
                             <IconButton
                               size="small"
                               onClick={async () => {
-                                await deleteItem(item.id);
-                                setConfirmDeleteId(null);
+                                try {
+                                  await deleteItem(item.id);
+                                  setSyncNotice(null);
+                                  setConfirmDeleteId(null);
+                                } catch (err) {
+                                  console.error("Failed to delete memory item", err);
+                                  setConfirmDeleteId(null);
+                                  setSyncNotice(
+                                    "That memory item changed during background cleanup. Refreshed the list.",
+                                  );
+                                  await refreshActiveItems();
+                                }
                               }}
                               aria-label="Confirm delete"
                               sx={{ color: "#ef4444" }}

--- a/frontend/src/components/chat/AgentMemoryModal.tsx
+++ b/frontend/src/components/chat/AgentMemoryModal.tsx
@@ -251,6 +251,11 @@ const AgentMemoryModal: React.FC<AgentMemoryModalProps> = ({
     );
   }, [activeTab, fetchItems, sortBy, sortDirection, statusFilter]);
 
+  const refreshActiveItemsRef = useRef(refreshActiveItems);
+  useEffect(() => {
+    refreshActiveItemsRef.current = refreshActiveItems;
+  }, [refreshActiveItems]);
+
   useEffect(() => {
     if (open) {
       void refreshActiveItems();
@@ -278,7 +283,7 @@ const AgentMemoryModal: React.FC<AgentMemoryModalProps> = ({
         return;
       }
 
-      await refreshActiveItems();
+      await refreshActiveItemsRef.current();
 
       if (attemptIndex >= refreshDelaysMs.length - 1) {
         if (!cancelled) {
@@ -301,7 +306,7 @@ const AgentMemoryModal: React.FC<AgentMemoryModalProps> = ({
         refreshTimerRef.current = null;
       }
     };
-  }, [open, refreshActiveItems, refreshToken]);
+  }, [open, refreshToken]);
 
   useEffect(() => {
     if (!open) {

--- a/frontend/src/hooks/useChat.test.ts
+++ b/frontend/src/hooks/useChat.test.ts
@@ -416,6 +416,48 @@ describe('useChat', () => {
     });
   });
 
+  it('increments memory refresh token after starting a new chat', async () => {
+    mockFetch.mockImplementation((url, options) => {
+      if (options?.method === 'GET' || !options?.method) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve(
+              buildHistoryPayload([{ id: 1, role: 'assistant', content: 'Hej' }], 'chat-1', 1)
+            ),
+        });
+      }
+
+      if (options?.method === 'DELETE') {
+        return Promise.resolve({
+          ok: true,
+          status: 204,
+          json: () => Promise.resolve({}),
+        });
+      }
+
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ message: 'Response' }),
+      });
+    });
+
+    const { result } = renderHook(() => useChat());
+
+    await waitFor(() => {
+      expect(result.current.messages).toHaveLength(1);
+    });
+
+    expect(result.current.memoryRefreshToken).toBe(0);
+
+    await act(async () => {
+      await result.current.startNewChat();
+    });
+
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.memoryRefreshToken).toBe(1);
+  });
+
   it('should show initial history error when first history fetch fails', async () => {
     mockFetch.mockImplementation((url, options) => {
       if (options?.method === 'GET' || !options?.method) {

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -47,6 +47,7 @@ interface UseChatReturn {
   isLoading: boolean;
   isFetchingHistory: boolean;
   isSyncingHistory: boolean;
+  memoryRefreshToken: number;
   historySyncNotice: string | null;
   isBackendAvailable: boolean;
   error: string | null;
@@ -95,6 +96,7 @@ export const useChat = (): UseChatReturn => {
   const [isLoading, setIsLoading] = useState(false);
   const [isFetchingHistory, setIsFetchingHistory] = useState(false);
   const [isSyncingHistory, setIsSyncingHistory] = useState(false);
+  const [memoryRefreshToken, setMemoryRefreshToken] = useState(0);
   const [historySyncNotice, setHistorySyncNotice] = useState<string | null>(null);
   const [isBackendAvailable, setIsBackendAvailable] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -430,6 +432,7 @@ export const useChat = (): UseChatReturn => {
       setHistorySyncNotice(null);
       currentChatIdRef.current = null;
       lastMessageIdRef.current = 0;
+      setMemoryRefreshToken((previous) => previous + 1);
       resetPollingInterval();
       broadcastChange();
     } catch (err) {
@@ -455,6 +458,7 @@ export const useChat = (): UseChatReturn => {
     isLoading,
     isFetchingHistory,
     isSyncingHistory,
+    memoryRefreshToken,
     historySyncNotice,
     isBackendAvailable,
     error,


### PR DESCRIPTION
## Summary
- refresh the memory modal after a new chat reset so background maintenance can settle
- recover gracefully when a memory item disappears during background cleanup
- add hook and modal tests for the new refresh behavior

## Testing
- make frontend-lint
- make frontend-test
- cd frontend && npm run build