### PR TITLE
fix: include uv lockfile in docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -48,5 +48,4 @@ test_*
 # Development files
 .pre-commit-config.yaml
 Makefile
-uv.lock
 .python-version

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -18,12 +18,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Copy dependency metadata into the build context so remote builders do not
+# depend on BuildKit bind mounts resolving repository files.
+COPY pyproject.toml uv.lock ./
+
 # Install locked dependencies using uv.
 # torch is pinned to the PyTorch CPU index in pyproject.toml, while the
 # remaining packages resolve from the lockfile's default PyPI sources.
 RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=uv.lock,target=uv.lock \
-    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --frozen --no-dev --no-editable --no-install-project
 
 # Production stage

--- a/Dockerfile.recall
+++ b/Dockerfile.recall
@@ -18,12 +18,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Copy dependency metadata into the build context so remote builders do not
+# depend on BuildKit bind mounts resolving repository files.
+COPY pyproject.toml uv.lock ./
+
 # Install locked dependencies using uv.
 # torch is pinned to the PyTorch CPU index in pyproject.toml, while the
 # remaining packages resolve from the lockfile's default PyPI sources.
 RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=uv.lock,target=uv.lock \
-    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --frozen --no-dev --no-editable --no-install-project
 
 # Production stage


### PR DESCRIPTION
## Summary
- copy `pyproject.toml` and `uv.lock` into the backend and recall builder stages before `uv sync`
- stop excluding `uv.lock` from the Docker build context in `.dockerignore`
- keep the existing BuildKit cache mount while removing the fragile bind mounts that failed in Coolify

## Why
The last Coolify Runestone deployment failed on 2026-06-15 during `docker compose build` because BuildKit could not resolve `/uv.lock` for the `RUN --mount=type=bind,source=uv.lock,target=uv.lock` step in the Python Dockerfiles.

## Validation
- extracted the failed Coolify deployment record and confirmed the exact error was `"/uv.lock": not found`
- `docker build` now reaches the new `COPY pyproject.toml uv.lock ./` step instead of failing on a missing lockfile
- full local BuildKit validation is blocked in this environment because the local Docker installation is missing the `buildx` component required for BuildKit-enabled `docker build`
