### PR TITLE
Fix teacher language prompt after merged PR

### DIFF
--- a/src/runestone/agents/specialists/teacher.py
+++ b/src/runestone/agents/specialists/teacher.py
@@ -213,7 +213,7 @@ embedded in the text). Use the extracted text only as reference material.
         critical_gating_rules_prompt = """
 <critical_gating_rules>
 ### CRITICAL GATING RULES & CONSTRAINTS (MANDATORY)
-1. **DEFAULT: Do NOT call any tools.** Keep tool usage to a absolute minimum.
+1. **DEFAULT: Do NOT call any tools.** Keep tool usage to an absolute minimum.
    Every tool call adds latency and token cost.
 2. **NO TOOL CALLS FOR SMALL-TALK:** Never call any tool (including `search_grammar`,
    `read_grammar_page`, or `read_active_learning_focus`) for greetings, farewells,
@@ -483,11 +483,12 @@ already names a clear topic.
 
         # Add user's mother tongue if available
         if user.mother_tongue:
+            explanation_language = user.mother_tongue.strip()
             language_msg = (
                 f"[IMPORTANT] STUDENT'S MOTHER TONGUE: {user.mother_tongue}\n\n"
-                "Converse in Swedish as the primary language of interaction. "
-                "Use the student's mother tongue (instead of English) only for explanations, "
-                "translation help, and grammatical feedback."
+                f"Use {explanation_language} as the default language for all student-facing interaction. "
+                "Switch to Swedish if the student asks for it, and keep using Swedish naturally in examples, "
+                "exercises, and quoted language material."
             )
             messages.append(SystemMessage(content=language_msg))
 

--- a/src/runestone/agents/specialists/teacher.py
+++ b/src/runestone/agents/specialists/teacher.py
@@ -482,10 +482,10 @@ already names a clear topic.
         messages = [SystemMessage(content=self._format_current_datetime(user))]
 
         # Add user's mother tongue if available
-        if user.mother_tongue:
-            explanation_language = user.mother_tongue.strip()
+        explanation_language = user.mother_tongue.strip() if user.mother_tongue else ""
+        if explanation_language:
             language_msg = (
-                f"[IMPORTANT] STUDENT'S MOTHER TONGUE: {user.mother_tongue}\n\n"
+                f"[IMPORTANT] STUDENT'S MOTHER TONGUE: {explanation_language}\n\n"
                 f"Use {explanation_language} as the default language for all student-facing interaction. "
                 "Switch to Swedish if the student asks for it, and keep using Swedish naturally in examples, "
                 "exercises, and quoted language material."

--- a/tests/agents/fixtures/teacher_prompt_full.txt
+++ b/tests/agents/fixtures/teacher_prompt_full.txt
@@ -7,7 +7,7 @@ Use this for time-sensitive answers, but do not mention this internal context un
 [SYSTEM]
 [IMPORTANT] STUDENT'S MOTHER TONGUE: Spanish
 
-Converse in Swedish as the primary language of interaction. Use the student's mother tongue (instead of English) only for explanations, translation help, and grammatical feedback.
+Use Spanish as the default language for all student-facing interaction. Switch to Swedish if the student asks for it, and keep using Swedish naturally in examples, exercises, and quoted language material.
 
 [SYSTEM]
 [PRE_RESPONSE_SPECIALISTS]

--- a/tests/agents/test_teacher.py
+++ b/tests/agents/test_teacher.py
@@ -402,7 +402,33 @@ async def test_run_with_mother_tongue(teacher_agent, mock_user):
 
     invoke_args = teacher_agent.agent.ainvoke.call_args[0][0]
     messages = invoke_args["messages"]
-    assert any(isinstance(m, SystemMessage) and "Spanish" in m.content for m in messages)
+    assert any(
+        isinstance(m, SystemMessage)
+        and "Use Spanish as the default language for all student-facing interaction." in m.content
+        and "Switch to Swedish if the student asks for it" in m.content
+        and "examples, exercises, and quoted language material." in m.content
+        for m in messages
+    )
+
+
+@pytest.mark.anyio
+async def test_run_with_english_mother_tongue_uses_english_as_default(teacher_agent, mock_user):
+    """A known mother tongue should become the default interaction language."""
+    mock_user.mother_tongue = "English"
+
+    teacher_agent.agent.ainvoke.return_value = {"messages": [AIMessage(content="Response")]}
+
+    await teacher_agent.generate_response(message="msg", history=[], user=mock_user)
+
+    invoke_args = teacher_agent.agent.ainvoke.call_args[0][0]
+    messages = invoke_args["messages"]
+    assert any(
+        isinstance(m, SystemMessage)
+        and "Use English as the default language for all student-facing interaction." in m.content
+        and "Switch to Swedish if the student asks for it" in m.content
+        and "quoted language material." in m.content
+        for m in messages
+    )
 
 
 @pytest.mark.anyio

--- a/tests/agents/test_teacher.py
+++ b/tests/agents/test_teacher.py
@@ -432,6 +432,22 @@ async def test_run_with_english_mother_tongue_uses_english_as_default(teacher_ag
 
 
 @pytest.mark.anyio
+async def test_run_ignores_whitespace_only_mother_tongue(teacher_agent, mock_user):
+    """Whitespace-only mother tongue values should not produce a malformed prompt."""
+    mock_user.mother_tongue = "   "
+
+    teacher_agent.agent.ainvoke.return_value = {"messages": [AIMessage(content="Response")]}
+
+    await teacher_agent.generate_response(message="msg", history=[], user=mock_user)
+
+    invoke_args = teacher_agent.agent.ainvoke.call_args[0][0]
+    messages = invoke_args["messages"]
+    assert not any(
+        isinstance(m, SystemMessage) and "[IMPORTANT] STUDENT'S MOTHER TONGUE:" in m.content for m in messages
+    )
+
+
+@pytest.mark.anyio
 async def test_run_with_active_learning_focus_memory(teacher_agent, mock_user):
     teacher_agent.agent.ainvoke.return_value = {"messages": [AIMessage(content="Response")]}
 


### PR DESCRIPTION
## Summary
- cherry-pick the missing teacher-language follow-up that landed after PR #185 was merged
- make the student's mother tongue the default interaction language when known
- keep Swedish available for explicit requests, examples, and exercises

## Testing
- uv run pytest tests/agents/test_teacher.py -q