### PR TITLE
fix(nginx): use dynamic DNS resolution for backend upstream

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -20,10 +20,10 @@ server {
     location / {
         try_files $uri $uri/ /index.html;
     }
-
     # API proxy to backend
     location /api/ {
-        proxy_pass http://backend:8010;
+        set $backend_upstream backend;
+        proxy_pass http://$backend_upstream:8010;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";


### PR DESCRIPTION
Resolves the 502 Bad Gateway issue caused by Nginx caching stale backend container IPs after restarts/redeployments. By defining the upstream hostname as a variable, Nginx will query the Docker resolver dynamically instead of caching it once at startup.