### PR TITLE
Pin runestone user/group UID/GID to 10001 in Dockerfiles

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -57,8 +57,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user and state directory
-RUN groupadd -r runestone \
-    && useradd -r -g runestone -d /home/runestone -m runestone \
+RUN groupadd -g 10001 runestone \
+    && useradd -u 10001 -g runestone -d /home/runestone -m runestone \
     && mkdir -p /app/state/hf-cache \
     && chown -R runestone:runestone /app /home/runestone
 

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -57,8 +57,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user and state directory
-RUN groupadd -g 10001 runestone \
-    && useradd -u 10001 -g runestone -d /home/runestone -m runestone \
+ARG USER_UID=10001
+ARG USER_GID=10001
+RUN groupadd -g ${USER_GID} runestone \
+    && useradd -u ${USER_UID} -g runestone -d /home/runestone -m -s /usr/sbin/nologin runestone \
     && mkdir -p /app/state/hf-cache \
     && chown -R runestone:runestone /app /home/runestone
 

--- a/Dockerfile.recall
+++ b/Dockerfile.recall
@@ -52,8 +52,10 @@ ENV PYTHONUNBUFFERED=1 \
 WORKDIR /app
 
 # Create non-root user and state directory
-RUN groupadd -g 10001 runestone \
-    && useradd -u 10001 -g runestone -d /home/runestone -m runestone \
+ARG USER_UID=10001
+ARG USER_GID=10001
+RUN groupadd -g ${USER_GID} runestone \
+    && useradd -u ${USER_UID} -g runestone -d /home/runestone -m -s /usr/sbin/nologin runestone \
     && mkdir -p /app/state/hf-cache \
     && chown -R runestone:runestone /app /home/runestone
 

--- a/Dockerfile.recall
+++ b/Dockerfile.recall
@@ -52,8 +52,8 @@ ENV PYTHONUNBUFFERED=1 \
 WORKDIR /app
 
 # Create non-root user and state directory
-RUN groupadd -r runestone \
-    && useradd -r -g runestone -d /home/runestone -m runestone \
+RUN groupadd -g 10001 runestone \
+    && useradd -u 10001 -g runestone -d /home/runestone -m runestone \
     && mkdir -p /app/state/hf-cache \
     && chown -R runestone:runestone /app /home/runestone
 

--- a/README.md
+++ b/README.md
@@ -405,6 +405,19 @@ The Docker setup automatically handles SQLite database permissions to prevent "a
 
 This clean solution eliminates the need for complex user ID mapping while maintaining security and portability.
 
+### Coolify Volume Permissions
+
+When deploying the application in Coolify, the backend and recall services run as non-root user `runestone` with UID/GID `10001:10001` (to prevent conflicts with host system users like `ollama` or `systemd-journal`).
+
+Since the `state` directory is bind-mounted on the host under `/data/coolify/applications/<uuid>/state`, the container might experience permission denied errors (e.g., when accessing `hf-cache` or `state.json`) unless the host directory ownership matches.
+
+To resolve this, run the following command on the host machine:
+
+```bash
+sudo chown -R 10001:10001 /data/coolify/applications/<uuid>/state
+```
+Replace `<uuid>` with your Coolify application's UUID.
+
 ### Running Tests
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -405,18 +405,20 @@ The Docker setup automatically handles SQLite database permissions to prevent "a
 
 This clean solution eliminates the need for complex user ID mapping while maintaining security and portability.
 
-### Coolify Volume Permissions
+### Docker Volume Permissions
 
-When deploying the application in Coolify, the backend and recall services run as non-root user `runestone` with UID/GID `10001:10001` (to prevent conflicts with host system users like `ollama` or `systemd-journal`).
+When deploying the application inside Docker containers (using `docker compose` or orchestrators like Coolify), the backend and recall services run as a non-root user `runestone` with UID/GID `10001:10001`. This ensures security and avoids namespace conflicts with standard system accounts on the host.
 
-Since the `state` directory is bind-mounted on the host under `/data/coolify/applications/<uuid>/state`, the container might experience permission denied errors (e.g., when accessing `hf-cache` or `state.json`) unless the host directory ownership matches.
+If you bind-mount a host directory to `/app/state` (for example, the default `./state` directory in raw Docker Compose, or `/data/coolify/applications/<uuid>/state` under Coolify), the container processes may encounter "Permission Denied" errors when trying to write to files (like `state.json`) or create directories (like `hf-cache`).
 
-To resolve this, run the following command on the host machine:
+To resolve this, ensure the host directory is owned by the container's UID/GID. You can update the ownership of your state directory on the host by running:
 
 ```bash
-sudo chown -R 10001:10001 /data/coolify/applications/<uuid>/state
+sudo chown -R 10001:10001 /path/to/host/state
 ```
-Replace `<uuid>` with your Coolify application's UUID.
+
+* **For raw Docker Compose:** `/path/to/host/state` is typically the `./state` directory in your local project directory.
+* **For Coolify:** `/path/to/host/state` is typically `/data/coolify/applications/<uuid>/state` on the host server.
 
 ### Running Tests
 


### PR DESCRIPTION
This pull request hardcodes the UID and GID to 10001 inside the Dockerfiles (backend and recall worker) to prevent numeric UID/GID collision on the host system (where the dynamically allocated UID/GID 999 clashed with ollama/systemd-journal).