### PR TITLE
[codex] Add teacher mother tongue trim regression test

### DIFF
--- a/tests/agents/test_teacher.py
+++ b/tests/agents/test_teacher.py
@@ -456,15 +456,19 @@ async def test_run_trims_mother_tongue_before_prompt_injection(teacher_agent, mo
 
     await teacher_agent.generate_response(message="msg", history=[], user=mock_user)
 
+    teacher_agent.agent.ainvoke.assert_called_once()
     invoke_args = teacher_agent.agent.ainvoke.call_args[0][0]
     messages = invoke_args["messages"]
-    assert any(
-        isinstance(m, SystemMessage)
-        and "[IMPORTANT] STUDENT'S MOTHER TONGUE: Spanish" in m.content
-        and "  Spanish  " not in m.content
-        and "Use Spanish as the default language for all student-facing interaction." in m.content
-        for m in messages
+    system_messages = [message for message in messages if isinstance(message, SystemMessage)]
+    mother_tongue_msg = next(
+        (message for message in system_messages if "[IMPORTANT] STUDENT'S MOTHER TONGUE:" in message.content),
+        None,
     )
+
+    assert mother_tongue_msg is not None, "Mother tongue system message was not injected"
+    assert "[IMPORTANT] STUDENT'S MOTHER TONGUE: Spanish" in mother_tongue_msg.content
+    assert "  Spanish  " not in mother_tongue_msg.content
+    assert "Use Spanish as the default language for all student-facing interaction." in mother_tongue_msg.content
 
 
 @pytest.mark.anyio

--- a/tests/agents/test_teacher.py
+++ b/tests/agents/test_teacher.py
@@ -448,6 +448,26 @@ async def test_run_ignores_whitespace_only_mother_tongue(teacher_agent, mock_use
 
 
 @pytest.mark.anyio
+async def test_run_trims_mother_tongue_before_prompt_injection(teacher_agent, mock_user):
+    """Non-empty mother tongue values should be stripped before prompt injection."""
+    mock_user.mother_tongue = "  Spanish  "
+
+    teacher_agent.agent.ainvoke.return_value = {"messages": [AIMessage(content="Response")]}
+
+    await teacher_agent.generate_response(message="msg", history=[], user=mock_user)
+
+    invoke_args = teacher_agent.agent.ainvoke.call_args[0][0]
+    messages = invoke_args["messages"]
+    assert any(
+        isinstance(m, SystemMessage)
+        and "[IMPORTANT] STUDENT'S MOTHER TONGUE: Spanish" in m.content
+        and "  Spanish  " not in m.content
+        and "Use Spanish as the default language for all student-facing interaction." in m.content
+        for m in messages
+    )
+
+
+@pytest.mark.anyio
 async def test_run_with_active_learning_focus_memory(teacher_agent, mock_user):
     teacher_agent.agent.ainvoke.return_value = {"messages": [AIMessage(content="Response")]}
 


### PR DESCRIPTION
## What changed
Added a focused regression test for the teacher prompt path that trims a non-empty `mother_tongue` value before injecting it into the system prompt.

## Why
A recent fix introduced `.strip()` handling for `user.mother_tongue`. The existing tests covered plain values and whitespace-only values, but not the trimmed non-empty branch.

## Impact
This keeps the coverage narrowly aligned to the recent teacher prompt change and protects against prompts accidentally preserving surrounding whitespace.

## Validation
- `uv run pytest tests/agents/test_teacher.py -v`
- `make check-readiness` *(fails on unrelated pre-existing Black drift in other files)*