### PR TITLE
Improve memory maintenance sync flow

### DIFF
--- a/docs/memory-maintainer.md
+++ b/docs/memory-maintainer.md
@@ -34,6 +34,24 @@ process-local and is acceptable for the current single-process deployment.
 If the backend later runs multiple worker processes or instances, this guard
 should move to a shared store or durable job system.
 
+## Checking Maintenance Status and Frontend Sync
+
+To prevent the frontend from displaying outdated or incomplete memory items while the background task is running, the backend exposes the task status, and the frontend polls for completion.
+
+### Status Endpoint
+
+- **Route**: `GET /api/memory/maintenance-status`
+- **Controller**: `get_memory_maintenance_status()` in [memory_endpoints.py](file:///Users/40min/www/runestone/src/runestone/api/memory_endpoints.py).
+- **Logic**: Inspects the `AgentsManager` in-memory `_memory_maintenance_registry` to see if a background task for `user.id` is currently active (registered and not `done()`). Returns `{"running": true}` or `{"running": false}`.
+
+### Frontend Polling Flow
+
+When the user initiates a new chat reset:
+1. The frontend hook increments `memoryRefreshToken` and the `AgentMemoryModal` sets a sync notice: `"Teacher memory is refreshing after the new chat reset."`
+2. It waits **5 seconds** (since the backend maintenance task does not finish immediately) before making the first `GET /api/memory/maintenance-status` check.
+3. It polls the status endpoint every **5 seconds**.
+4. When `running` becomes `false` (or the safety timeout of **240 seconds** is reached), it refreshes the active memory items list one final time to fetch the reconciled database records, and hides the sync notice.
+
 ## Scope
 
 The background reset entrypoint now runs two separate maintenance domains:

--- a/frontend/src/components/chat/AgentMemoryModal.test.tsx
+++ b/frontend/src/components/chat/AgentMemoryModal.test.tsx
@@ -19,6 +19,7 @@ const mockUseMemoryItems = {
   updatePriority: mockUpdatePriority,
   deleteItem: vi.fn().mockResolvedValue(undefined),
   clearCategory: vi.fn().mockResolvedValue(undefined),
+  checkMaintenanceStatus: vi.fn().mockResolvedValue(false),
 };
 
 const setMatchMedia = (matches: boolean) => {
@@ -42,6 +43,8 @@ describe('AgentMemoryModal', () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     setMatchMedia(false);
+    mockUseMemoryItems.checkMaintenanceStatus.mockReset();
+    mockUseMemoryItems.checkMaintenanceStatus.mockResolvedValue(false);
     (useMemoryItemsModule.default as Mock).mockReturnValue(mockUseMemoryItems);
   });
 
@@ -64,72 +67,253 @@ describe('AgentMemoryModal', () => {
     expect(mockUseMemoryItems.fetchItems).toHaveBeenCalledWith('personal_info', undefined, true, 'updated_at', 'desc');
   });
 
-  it('re-fetches memory for a short window after a new chat refresh token changes', async () => {
+  it('re-fetches memory when maintenance completes after a new chat reset', async () => {
+    // Start with maintenance running
+    mockUseMemoryItems.checkMaintenanceStatus.mockResolvedValue(true);
+
     const { rerender } = render(
       <AgentMemoryModal open={true} onClose={() => {}} refreshToken={0} />
     );
 
     mockUseMemoryItems.fetchItems.mockClear();
+    mockUseMemoryItems.checkMaintenanceStatus.mockClear();
 
     rerender(<AgentMemoryModal open={true} onClose={() => {}} refreshToken={1} />);
 
+    // Sync notice should be displayed immediately
     expect(screen.getByText('Teacher memory is refreshing after the new chat reset.')).toBeInTheDocument();
+    // No status check or items fetch should happen synchronously
+    expect(mockUseMemoryItems.checkMaintenanceStatus).not.toHaveBeenCalled();
+    expect(mockUseMemoryItems.fetchItems).not.toHaveBeenCalled();
+
+    // Advance by 5s to trigger the first status check
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    // It should check status, see it is still running, and keep notice without fetching items
+    expect(mockUseMemoryItems.checkMaintenanceStatus).toHaveBeenCalledTimes(1);
+    expect(mockUseMemoryItems.fetchItems).not.toHaveBeenCalled();
+    expect(screen.getByText('Teacher memory is refreshing after the new chat reset.')).toBeInTheDocument();
+
+    // Now pretend maintenance completes
+    mockUseMemoryItems.checkMaintenanceStatus.mockResolvedValue(false);
+
+    // Advance by another 5s
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    // It should check status, see it has finished, fetch the items one last time, and clear the notice
+    expect(mockUseMemoryItems.checkMaintenanceStatus).toHaveBeenCalledTimes(2);
     expect(mockUseMemoryItems.fetchItems).toHaveBeenCalledTimes(1);
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(1500);
-    });
-    expect(mockUseMemoryItems.fetchItems).toHaveBeenCalledTimes(2);
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(4000);
-    });
-    expect(mockUseMemoryItems.fetchItems).toHaveBeenCalledTimes(3);
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(8000);
-    });
-    expect(mockUseMemoryItems.fetchItems).toHaveBeenCalledTimes(4);
+    expect(screen.queryByText('Teacher memory is refreshing after the new chat reset.')).not.toBeInTheDocument();
   });
 
-  it('does not cancel the refresh loop when tab is switched during the refresh window', async () => {
+  it('stops polling and clears notice after safety timeout if maintenance hangs', async () => {
+    // Keep maintenance running indefinitely
+    mockUseMemoryItems.checkMaintenanceStatus.mockResolvedValue(true);
+
     const { rerender } = render(
       <AgentMemoryModal open={true} onClose={() => {}} refreshToken={0} />
     );
 
     mockUseMemoryItems.fetchItems.mockClear();
+    mockUseMemoryItems.checkMaintenanceStatus.mockClear();
 
     rerender(<AgentMemoryModal open={true} onClose={() => {}} refreshToken={1} />);
 
     expect(screen.getByText('Teacher memory is refreshing after the new chat reset.')).toBeInTheDocument();
+
+    // Advance timers by 240 seconds (which is the MAX_DURATION_MS)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(240000);
+    });
+
+    // The safety timeout should trigger. It fetches items once and clears the notice.
+    expect(mockUseMemoryItems.checkMaintenanceStatus.mock.calls.length).toBeLessThanOrEqual(48);
     expect(mockUseMemoryItems.fetchItems).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Teacher memory is refreshing after the new chat reset.')).not.toBeInTheDocument();
+  });
+
+  it('keeps polling when a maintenance status check fails', async () => {
+    mockUseMemoryItems.checkMaintenanceStatus
+      .mockRejectedValueOnce(new Error('temporary status failure'))
+      .mockResolvedValueOnce(false);
+
+    const { rerender } = render(
+      <AgentMemoryModal open={true} onClose={() => {}} refreshToken={0} />
+    );
+
+    mockUseMemoryItems.fetchItems.mockClear();
+    mockUseMemoryItems.checkMaintenanceStatus.mockClear();
+
+    rerender(<AgentMemoryModal open={true} onClose={() => {}} refreshToken={1} />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    expect(mockUseMemoryItems.checkMaintenanceStatus).toHaveBeenCalledTimes(1);
+    expect(mockUseMemoryItems.fetchItems).not.toHaveBeenCalled();
+    expect(screen.getByText('Teacher memory is refreshing after the new chat reset.')).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(9000);
+    });
+
+    expect(mockUseMemoryItems.checkMaintenanceStatus).toHaveBeenCalledTimes(2);
+    expect(mockUseMemoryItems.fetchItems).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Teacher memory is refreshing after the new chat reset.')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the safety timeout when a maintenance status check never resolves', async () => {
+    mockUseMemoryItems.checkMaintenanceStatus.mockImplementation(
+      () => new Promise<boolean>(() => {})
+    );
+
+    const { rerender } = render(
+      <AgentMemoryModal open={true} onClose={() => {}} refreshToken={0} />
+    );
+
+    mockUseMemoryItems.fetchItems.mockClear();
+    mockUseMemoryItems.checkMaintenanceStatus.mockClear();
+
+    rerender(<AgentMemoryModal open={true} onClose={() => {}} refreshToken={1} />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(244000);
+    });
+
+    expect(mockUseMemoryItems.checkMaintenanceStatus.mock.calls.length).toBeGreaterThan(1);
+    expect(mockUseMemoryItems.checkMaintenanceStatus.mock.calls.length).toBeLessThan(30);
+    expect(mockUseMemoryItems.fetchItems).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Teacher memory is refreshing after the new chat reset.')).not.toBeInTheDocument();
+  });
+
+  it('does not cancel the status checks when tab is switched during the refresh window', async () => {
+    mockUseMemoryItems.checkMaintenanceStatus.mockResolvedValue(true);
+
+    const { rerender } = render(
+      <AgentMemoryModal open={true} onClose={() => {}} refreshToken={0} />
+    );
+
+    mockUseMemoryItems.fetchItems.mockClear();
+    mockUseMemoryItems.checkMaintenanceStatus.mockClear();
+
+    rerender(<AgentMemoryModal open={true} onClose={() => {}} refreshToken={1} />);
+
+    expect(screen.getByText('Teacher memory is refreshing after the new chat reset.')).toBeInTheDocument();
 
     // Switch tab/category to 'Areas to Improve'
     const areasTab = screen.getByText('Areas to Improve');
-    fireEvent.click(areasTab);
+    await act(async () => {
+      fireEvent.click(areasTab);
+    });
 
-    // The fetchItems call from switching tab immediately is expected
-    // Let's clear mock calls to isolate the timer callbacks
+    // Switch tab should trigger fetchItems for the new category immediately
+    expect(mockUseMemoryItems.fetchItems).toHaveBeenCalled();
     mockUseMemoryItems.fetchItems.mockClear();
 
-    // Now advance timers to check if the loop is still running
+    // Now advance timers to check if the status check loop is still running
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(1500);
+      await vi.advanceTimersByTimeAsync(5000);
     });
-    // It should call fetchItems again as part of the refresh loop
-    expect(mockUseMemoryItems.fetchItems).toHaveBeenCalled();
+    expect(mockUseMemoryItems.checkMaintenanceStatus).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Teacher memory is refreshing after the new chat reset.')).toBeInTheDocument();
+
+    // Resolve maintenance
+    mockUseMemoryItems.checkMaintenanceStatus.mockResolvedValue(false);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    // The notice should disappear, and fetchItems should be called one final time
+    expect(screen.queryByText('Teacher memory is refreshing after the new chat reset.')).not.toBeInTheDocument();
+    expect(mockUseMemoryItems.fetchItems).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let an older refresh cycle clear the notice for a newer reset', async () => {
+    let resolvePendingRefresh: (() => void) | null = null;
+    mockUseMemoryItems.checkMaintenanceStatus.mockResolvedValue(false);
+
+    const { rerender } = render(
+      <AgentMemoryModal open={true} onClose={() => {}} refreshToken={0} />
+    );
+
+    mockUseMemoryItems.fetchItems.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvePendingRefresh = resolve;
+        })
+    );
+    mockUseMemoryItems.fetchItems.mockClear();
+    mockUseMemoryItems.checkMaintenanceStatus.mockClear();
+
+    rerender(<AgentMemoryModal open={true} onClose={() => {}} refreshToken={1} />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    expect(mockUseMemoryItems.checkMaintenanceStatus).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Teacher memory is refreshing after the new chat reset.')).toBeInTheDocument();
+
+    mockUseMemoryItems.checkMaintenanceStatus.mockResolvedValue(true);
+    rerender(<AgentMemoryModal open={true} onClose={() => {}} refreshToken={2} />);
+
+    await act(async () => {
+      resolvePendingRefresh?.();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Teacher memory is refreshing after the new chat reset.')).toBeInTheDocument();
+  });
+
+  it('resumes maintenance polling after closing and reopening the modal', async () => {
+    mockUseMemoryItems.checkMaintenanceStatus.mockResolvedValue(true);
+
+    const { rerender } = render(
+      <AgentMemoryModal open={true} onClose={() => {}} refreshToken={0} />
+    );
+
+    mockUseMemoryItems.fetchItems.mockClear();
+    mockUseMemoryItems.checkMaintenanceStatus.mockClear();
+
+    rerender(<AgentMemoryModal open={true} onClose={() => {}} refreshToken={1} />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    expect(mockUseMemoryItems.checkMaintenanceStatus).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Teacher memory is refreshing after the new chat reset.')).toBeInTheDocument();
+
+    rerender(<AgentMemoryModal open={false} onClose={() => {}} refreshToken={1} />);
+    expect(screen.queryByText('Teacher memory is refreshing after the new chat reset.')).not.toBeInTheDocument();
+
+    mockUseMemoryItems.checkMaintenanceStatus.mockResolvedValue(false);
+    rerender(<AgentMemoryModal open={true} onClose={() => {}} refreshToken={1} />);
+
     expect(screen.getByText('Teacher memory is refreshing after the new chat reset.')).toBeInTheDocument();
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(4000);
+      await vi.advanceTimersByTimeAsync(5000);
+      await Promise.resolve();
     });
-    expect(mockUseMemoryItems.fetchItems).toHaveBeenCalled();
-
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(8000);
+      await Promise.resolve();
     });
-    // After the last attempt, the sync notice should disappear
-    expect(screen.queryByText('Teacher memory is refreshing after the new chat reset.')).not.toBeInTheDocument();
+
+    expect(mockUseMemoryItems.checkMaintenanceStatus).toHaveBeenCalledTimes(2);
+    expect(mockUseMemoryItems.fetchItems).toHaveBeenCalledTimes(2);
+
+    rerender(<AgentMemoryModal open={true} onClose={() => {}} refreshToken={1} />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    expect(mockUseMemoryItems.checkMaintenanceStatus).toHaveBeenCalledTimes(2);
   });
 
   it('changes category when tab is clicked', () => {

--- a/frontend/src/components/chat/AgentMemoryModal.tsx
+++ b/frontend/src/components/chat/AgentMemoryModal.tsx
@@ -186,6 +186,7 @@ const AgentMemoryModal: React.FC<AgentMemoryModalProps> = ({
     updatePriority,
     deleteItem,
     clearCategory,
+    checkMaintenanceStatus,
   } = useMemoryItems();
 
   const [isFormOpen, setIsFormOpen] = useState(false);
@@ -205,6 +206,7 @@ const AgentMemoryModal: React.FC<AgentMemoryModalProps> = ({
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const refreshTimerRef = useRef<number | null>(null);
+  const maintenancePollCycleRef = useRef(0);
   const lastHandledRefreshTokenRef = useRef<number>(refreshToken);
   const displayedCountLabel = `${items.length} item${items.length === 1 ? "" : "s"}`;
   const sortSummaryLabel =
@@ -267,7 +269,6 @@ const AgentMemoryModal: React.FC<AgentMemoryModalProps> = ({
       return;
     }
 
-    lastHandledRefreshTokenRef.current = refreshToken;
     setSyncNotice("Teacher memory is refreshing after the new chat reset.");
 
     if (refreshTimerRef.current !== null) {
@@ -276,28 +277,89 @@ const AgentMemoryModal: React.FC<AgentMemoryModalProps> = ({
     }
 
     let cancelled = false;
-    const refreshDelaysMs = [0, 1500, 4000, 8000];
+    const cycleId = maintenancePollCycleRef.current + 1;
+    maintenancePollCycleRef.current = cycleId;
+    const POLL_INTERVAL_MS = 5000;
+    const STATUS_REQUEST_TIMEOUT_MS = 4000;
+    const MAX_DURATION_MS = 240000; // 240 seconds backend timeout
+    const startTime = Date.now();
+    const isCurrentCycle = () => !cancelled && maintenancePollCycleRef.current === cycleId;
+    const markRefreshHandled = () => {
+      lastHandledRefreshTokenRef.current = refreshToken;
+    };
 
-    const runRefresh = async (attemptIndex: number) => {
-      if (cancelled) {
+    const getMaintenanceStatusWithTimeout = async (): Promise<boolean | null> => {
+      return Promise.race<boolean | null>([
+        Promise.resolve(checkMaintenanceStatus()).catch(() => null),
+        new Promise<null>((resolve) => {
+          window.setTimeout(() => resolve(null), STATUS_REQUEST_TIMEOUT_MS);
+        }),
+      ]);
+    };
+
+    const checkStatusAndSchedule = async () => {
+      if (!isCurrentCycle()) {
         return;
       }
 
-      await refreshActiveItemsRef.current();
+      const isRunning = await getMaintenanceStatusWithTimeout();
+      if (!isCurrentCycle()) {
+        return;
+      }
 
-      if (attemptIndex >= refreshDelaysMs.length - 1) {
-        if (!cancelled) {
+      if (!isRunning) {
+        if (isRunning === null) {
+          const elapsedAfterError = Date.now() - startTime;
+          if (elapsedAfterError >= MAX_DURATION_MS) {
+            if (isCurrentCycle()) {
+              await refreshActiveItemsRef.current();
+            }
+            if (isCurrentCycle()) {
+              markRefreshHandled();
+              setSyncNotice(null);
+            }
+            return;
+          }
+
+          refreshTimerRef.current = window.setTimeout(() => {
+            void checkStatusAndSchedule();
+          }, POLL_INTERVAL_MS);
+          return;
+        }
+
+        if (isCurrentCycle()) {
+          await refreshActiveItemsRef.current();
+        }
+        if (isCurrentCycle()) {
+          markRefreshHandled();
           setSyncNotice(null);
         }
         return;
       }
 
+      const elapsed = Date.now() - startTime;
+      if (elapsed >= MAX_DURATION_MS) {
+        if (isCurrentCycle()) {
+          // Safety timeout reached: fetch items one last time and hide notice
+          await refreshActiveItemsRef.current();
+        }
+        if (isCurrentCycle()) {
+          markRefreshHandled();
+          setSyncNotice(null);
+        }
+        return;
+      }
+
+      // Schedule next check
       refreshTimerRef.current = window.setTimeout(() => {
-        void runRefresh(attemptIndex + 1);
-      }, refreshDelaysMs[attemptIndex + 1]);
+        void checkStatusAndSchedule();
+      }, POLL_INTERVAL_MS);
     };
 
-    void runRefresh(0);
+    // Wait 5 seconds before checking status for the first time
+    refreshTimerRef.current = window.setTimeout(() => {
+      void checkStatusAndSchedule();
+    }, POLL_INTERVAL_MS);
 
     return () => {
       cancelled = true;
@@ -306,7 +368,7 @@ const AgentMemoryModal: React.FC<AgentMemoryModalProps> = ({
         refreshTimerRef.current = null;
       }
     };
-  }, [open, refreshToken]);
+  }, [open, refreshToken, checkMaintenanceStatus]);
 
   useEffect(() => {
     if (!open) {

--- a/frontend/src/components/chat/AgentMemoryModal.tsx
+++ b/frontend/src/components/chat/AgentMemoryModal.tsx
@@ -289,12 +289,20 @@ const AgentMemoryModal: React.FC<AgentMemoryModalProps> = ({
     };
 
     const getMaintenanceStatusWithTimeout = async (): Promise<boolean | null> => {
-      return Promise.race<boolean | null>([
-        Promise.resolve(checkMaintenanceStatus()).catch(() => null),
-        new Promise<null>((resolve) => {
-          window.setTimeout(() => resolve(null), STATUS_REQUEST_TIMEOUT_MS);
-        }),
-      ]);
+      let timeoutId: number | undefined;
+      const timeoutPromise = new Promise<null>((resolve) => {
+        timeoutId = window.setTimeout(() => resolve(null), STATUS_REQUEST_TIMEOUT_MS);
+      });
+      try {
+        return await Promise.race<boolean | null>([
+          Promise.resolve(checkMaintenanceStatus()).catch(() => null),
+          timeoutPromise,
+        ]);
+      } finally {
+        if (timeoutId !== undefined) {
+          window.clearTimeout(timeoutId);
+        }
+      }
     };
 
     const checkStatusAndSchedule = async () => {

--- a/frontend/src/hooks/useMemoryItems.ts
+++ b/frontend/src/hooks/useMemoryItems.ts
@@ -44,6 +44,7 @@ interface UseMemoryItemsReturn {
   updatePriority: (id: number, priority: number | null) => Promise<MemoryItem>;
   deleteItem: (id: number) => Promise<void>;
   clearCategory: (category: MemoryCategory) => Promise<void>;
+  checkMaintenanceStatus: () => Promise<boolean | null>;
 }
 
 const useMemoryItems = (): UseMemoryItemsReturn => {
@@ -171,6 +172,16 @@ const useMemoryItems = (): UseMemoryItemsReturn => {
     [apiDelete]
   );
 
+  const checkMaintenanceStatus = useCallback(async (): Promise<boolean | null> => {
+    try {
+      const data = await get<{ running: boolean }>("/api/memory/maintenance-status");
+      return data.running;
+    } catch (err) {
+      console.error("Failed to check memory maintenance status", err);
+      return null;
+    }
+  }, [get]);
+
   return {
     items,
     loading,
@@ -182,6 +193,7 @@ const useMemoryItems = (): UseMemoryItemsReturn => {
     updatePriority,
     deleteItem,
     clearCategory,
+    checkMaintenanceStatus,
   };
 };
 

--- a/src/runestone/agents/manager.py
+++ b/src/runestone/agents/manager.py
@@ -569,6 +569,11 @@ class AgentsManager:
         """Run the memory maintainer directly for chat-reset startup hygiene."""
         return await self.memory_maintainer.run_for_user(user)
 
+    def is_memory_maintenance_running(self, user_id: int) -> bool:
+        """Check if a memory maintenance task is currently active for the user."""
+        task = self._memory_maintenance_registry.tasks.get(str(user_id))
+        return task is not None and not task.done()
+
     async def start_background_post_turn(
         self,
         message: str,

--- a/src/runestone/api/main.py
+++ b/src/runestone/api/main.py
@@ -57,7 +57,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     app.state.grammar_service = GrammarService(settings.cheatsheets_dir)
     app.state.grammar_index = GrammarIndex(settings.cheatsheets_dir, settings.frontend_url)
     app.state.recall_state_manager = StateManager(settings.state_file_path)
-    app.state.agent_service = AgentsManager(
+    app.state.agents_manager = AgentsManager(
         settings,
         grammar_index=app.state.grammar_index,
         grammar_service=app.state.grammar_service,

--- a/src/runestone/api/memory_endpoints.py
+++ b/src/runestone/api/memory_endpoints.py
@@ -8,6 +8,7 @@ from typing import Annotated, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
+from runestone.agents.manager import AgentsManager
 from runestone.api.memory_item_schemas import (
     MemoryCategory,
     MemoryItemCreate,
@@ -21,7 +22,7 @@ from runestone.auth.dependencies import get_current_user
 from runestone.core.exceptions import PermissionDeniedError, UserNotFoundError
 from runestone.core.logging_config import get_logger
 from runestone.db.models import User
-from runestone.dependencies import get_memory_item_service
+from runestone.dependencies import get_agents_manager, get_memory_item_service
 from runestone.services.memory_item_service import MemoryItemService
 
 router = APIRouter()
@@ -224,3 +225,25 @@ async def clear_memory_category(
     except Exception as e:
         logger.error(f"Failed to clear category {category} for user {current_user.id}: {e}")
         raise HTTPException(status_code=500, detail="Failed to clear category")
+
+
+@router.get(
+    "/memory/maintenance-status",
+    responses={
+        200: {"description": "Memory maintenance status retrieved successfully"},
+        401: {"description": "Not authenticated"},
+    },
+)
+async def get_memory_maintenance_status(
+    current_user: Annotated[User, Depends(get_current_user)],
+    agents_manager: Annotated[AgentsManager, Depends(get_agents_manager)],
+) -> dict:
+    """
+    Check if memory maintenance is currently running for the current user.
+    """
+    try:
+        running = agents_manager.is_memory_maintenance_running(current_user.id)
+        return {"running": running}
+    except Exception as e:
+        logger.error(f"Failed to check memory maintenance status for user {current_user.id}: {e}")
+        raise HTTPException(status_code=500, detail="Failed to check memory maintenance status")

--- a/src/runestone/api/memory_endpoints.py
+++ b/src/runestone/api/memory_endpoints.py
@@ -18,6 +18,7 @@ from runestone.api.memory_item_schemas import (
     MemorySortBy,
     SortDirection,
 )
+from runestone.api.schemas import MemoryMaintenanceStatusResponse
 from runestone.auth.dependencies import get_current_user
 from runestone.core.exceptions import PermissionDeniedError, UserNotFoundError
 from runestone.core.logging_config import get_logger
@@ -229,6 +230,7 @@ async def clear_memory_category(
 
 @router.get(
     "/memory/maintenance-status",
+    response_model=MemoryMaintenanceStatusResponse,
     responses={
         200: {"description": "Memory maintenance status retrieved successfully"},
         401: {"description": "Not authenticated"},
@@ -237,13 +239,13 @@ async def clear_memory_category(
 async def get_memory_maintenance_status(
     current_user: Annotated[User, Depends(get_current_user)],
     agents_manager: Annotated[AgentsManager, Depends(get_agents_manager)],
-) -> dict:
+) -> MemoryMaintenanceStatusResponse:
     """
     Check if memory maintenance is currently running for the current user.
     """
     try:
         running = agents_manager.is_memory_maintenance_running(current_user.id)
-        return {"running": running}
+        return MemoryMaintenanceStatusResponse(running=running)
     except Exception as e:
         logger.error(f"Failed to check memory maintenance status for user {current_user.id}: {e}")
         raise HTTPException(status_code=500, detail="Failed to check memory maintenance status")

--- a/src/runestone/api/schemas.py
+++ b/src/runestone/api/schemas.py
@@ -42,6 +42,7 @@ __all__ = [
     "VocabularyStatsResponse",
     "UserProfileResponse",
     "UserProfileUpdate",
+    "MemoryMaintenanceStatusResponse",
 ]
 
 
@@ -220,3 +221,9 @@ class UserProfileUpdate(BaseModel):
 class LoginRequest(BaseModel):
     email: str
     password: str
+
+
+class MemoryMaintenanceStatusResponse(BaseModel):
+    """Schema for memory maintenance status response."""
+
+    running: bool

--- a/src/runestone/dependencies.py
+++ b/src/runestone/dependencies.py
@@ -273,17 +273,17 @@ def get_grammar_service(request: Request) -> GrammarService:
     return request.app.state.grammar_service
 
 
-def get_agent_service(request: Request) -> AgentsManager:
+def get_agents_manager(request: Request) -> AgentsManager:
     """
-    Dependency injection for agent service.
+    Dependency injection for the shared agents manager.
 
     Args:
         request: FastAPI request object
 
     Returns:
-        AgentsManager: Cached service instance for chat agent operations
+        AgentsManager: Cached orchestration manager for chat agent operations
     """
-    return request.app.state.agent_service
+    return request.app.state.agents_manager
 
 
 def get_tts_service(request: Request) -> TTSService:
@@ -317,7 +317,7 @@ def get_chat_service(
     repo: Annotated[ChatRepository, Depends(get_chat_repository)],
     side_effect_service: Annotated[AgentSideEffectService, Depends(get_agent_side_effect_service)],
     user_service: Annotated[UserService, Depends(get_user_service)],
-    agent_service: Annotated[AgentsManager, Depends(get_agent_service)],
+    agents_manager: Annotated[AgentsManager, Depends(get_agents_manager)],
     processor: Annotated[RunestoneProcessor, Depends(get_runestone_processor)],
     vocabulary_service: Annotated[VocabularyService, Depends(get_vocabulary_service)],
     tts_service: Annotated[TTSService, Depends(get_tts_service)],
@@ -330,7 +330,7 @@ def get_chat_service(
         settings: Application settings from dependency injection
         repo: ChatRepository from dependency injection
         user_service: UserService from dependency injection
-        agent_service: AgentsManager from dependency injection
+        agents_manager: AgentsManager from dependency injection
         processor: RunestoneProcessor from dependency injection
         vocabulary_service: VocabularyService from dependency injection
         tts_service: TTSService from dependency injection
@@ -343,7 +343,7 @@ def get_chat_service(
         repo,
         side_effect_service,
         user_service,
-        agent_service,
+        agents_manager,
         processor,
         vocabulary_service,
         tts_service,

--- a/src/runestone/services/chat_service.py
+++ b/src/runestone/services/chat_service.py
@@ -48,7 +48,7 @@ class ChatService:
         repository: ChatRepository,
         side_effect_service: AgentSideEffectService,
         user_service: UserService,
-        agent_service: AgentsManager,
+        agents_manager: AgentsManager,
         processor: RunestoneProcessor,
         vocabulary_service: VocabularyService,
         tts_service: TTSService,
@@ -65,7 +65,7 @@ class ChatService:
         self.repository = repository
         self.side_effect_service = side_effect_service
         self.user_service = user_service
-        self.agent_service = agent_service
+        self.agents_manager = agents_manager
         self.processor = processor
         self.vocabulary_service = vocabulary_service
         self.tts_service = tts_service
@@ -126,7 +126,7 @@ class ChatService:
             raise ValueError(f"User {user_id} not found")
 
         # 5. Generate response using agents
-        assistant_text, sources, teacher_emotion = await self.agent_service.process_turn(
+        assistant_text, sources, teacher_emotion = await self.agents_manager.process_turn(
             message=message_text,
             chat_id=chat_id,
             history=history[:-1],
@@ -211,7 +211,7 @@ Instructions:
 2. Then provide phrase-by-phrase translation in format: "Swedish phrase (translation). Next phrase (translation)."
 3. Use {mother_tongue} for all translations."""
 
-        assistant_text, _sources, teacher_emotion = await self.agent_service.process_turn(
+        assistant_text, _sources, teacher_emotion = await self.agents_manager.process_turn(
             message=translation_prompt,
             chat_id=chat_id,
             history=history,
@@ -252,7 +252,7 @@ Instructions:
             return chat_id
 
         try:
-            await self.agent_service.start_background_memory_maintenance(user)
+            await self.agents_manager.start_background_memory_maintenance(user)
         except Exception:
             logger.error(
                 "[chat:service] Failed to schedule background memory maintenance for user %s",

--- a/tests/agents/test_manager.py
+++ b/tests/agents/test_manager.py
@@ -210,12 +210,16 @@ async def test_start_background_memory_maintenance_runs_specialist_and_clears_re
         )
     )
 
+    assert manager.is_memory_maintenance_running(mock_user.id) is False
+
     scheduled = await manager.start_background_memory_maintenance(mock_user)
 
     assert scheduled is True
+    assert manager.is_memory_maintenance_running(mock_user.id) is True
     task = manager._memory_maintenance_registry.tasks[str(mock_user.id)]
     await task
     manager.memory_maintainer.run_for_user.assert_awaited_once_with(mock_user)
+    assert manager.is_memory_maintenance_running(mock_user.id) is False
     assert str(mock_user.id) not in manager._memory_maintenance_registry.tasks
 
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -151,9 +151,9 @@ def client_with_overrides(mock_llm_model, db_with_test_user):
         overrides[get_runestone_processor] = lambda: processor_instance
 
         if agent_service:
-            agent_service_instance = agent_service
+            agents_manager_instance = agent_service
         else:
-            agent_service_instance = Mock()
+            agents_manager_instance = Mock()
 
         # Always mock TTSService
         from runestone.dependencies import get_tts_service, get_voice_service
@@ -165,12 +165,12 @@ def client_with_overrides(mock_llm_model, db_with_test_user):
 
         # Always provide AgentsManager via dependency + app.state so callers that
         # access request.app.state.* directly don't explode.
-        from runestone.dependencies import get_agent_service
+        from runestone.dependencies import get_agents_manager
 
-        overrides[get_agent_service] = lambda: agent_service_instance
+        overrides[get_agents_manager] = lambda: agents_manager_instance
 
         # Also inject into app.state to avoid attribute errors
-        app.state.agent_service = agent_service_instance
+        app.state.agents_manager = agents_manager_instance
         app.state.tts_service = tts_service_instance
         app.state.voice_service = voice_service_instance
 
@@ -202,7 +202,7 @@ def client_with_overrides(mock_llm_model, db_with_test_user):
                 "processor": processor,
                 "llm_model": llm_model or mock_llm_model,
                 "current_user": current_user or test_user,
-                "agent_service": agent_service_instance,
+                "agents_manager": agents_manager_instance,
                 "tts_service": tts_service_instance,
                 "voice_service": voice_service_instance,
             }

--- a/tests/api/test_memory_endpoints.py
+++ b/tests/api/test_memory_endpoints.py
@@ -29,3 +29,25 @@ async def test_list_memory_items_supports_legacy_status_query_param(client):
 
     assert response.status_code == 200
     assert [item["key"] for item in response.json()] == ["goal"]
+
+
+async def test_get_memory_maintenance_status_running(client):
+    # Mock the behavior of is_memory_maintenance_running
+    client.app.state.agents_manager.is_memory_maintenance_running.return_value = True
+
+    response = await client.get("/api/memory/maintenance-status")
+
+    assert response.status_code == 200
+    assert response.json() == {"running": True}
+    client.app.state.agents_manager.is_memory_maintenance_running.assert_called_once_with(client.user.id)
+
+
+async def test_get_memory_maintenance_status_not_running(client):
+    # Mock the behavior of is_memory_maintenance_running
+    client.app.state.agents_manager.is_memory_maintenance_running.return_value = False
+
+    response = await client.get("/api/memory/maintenance-status")
+
+    assert response.status_code == 200
+    assert response.json() == {"running": False}
+    client.app.state.agents_manager.is_memory_maintenance_running.assert_called_once_with(client.user.id)

--- a/tests/services/test_chat_service.py
+++ b/tests/services/test_chat_service.py
@@ -267,7 +267,7 @@ async def test_clear_history_schedules_background_maintenance(chat_service, db_w
     chat_service.user_service.get_user_by_id = AsyncMock(return_value=user)
     await chat_service.clear_history(user.id)
     chat_service.user_service.rotate_current_chat_id.assert_awaited_once_with(user.id)
-    chat_service.agent_service.start_background_memory_maintenance.assert_awaited_once_with(user)
+    chat_service.agents_manager.start_background_memory_maintenance.assert_awaited_once_with(user)
 
 
 @pytest.mark.anyio
@@ -277,7 +277,7 @@ async def test_start_new_chat_skips_maintenance_when_user_missing(chat_service):
 
     await chat_service.start_new_chat(user_id=123)
 
-    chat_service.agent_service.start_background_memory_maintenance.assert_not_called()
+    chat_service.agents_manager.start_background_memory_maintenance.assert_not_called()
 
 
 @pytest.mark.anyio
@@ -286,7 +286,7 @@ async def test_start_new_chat_logs_and_keeps_success_when_scheduling_fails(chat_
     next_chat_id = str(uuid4())
     chat_service.user_service.rotate_current_chat_id = AsyncMock(return_value=next_chat_id)
     chat_service.user_service.get_user_by_id = AsyncMock(return_value=user)
-    chat_service.agent_service.start_background_memory_maintenance = AsyncMock(side_effect=RuntimeError("boom"))
+    chat_service.agents_manager.start_background_memory_maintenance = AsyncMock(side_effect=RuntimeError("boom"))
 
     with caplog.at_level("ERROR"):
         returned_chat_id = await chat_service.start_new_chat(user.id)


### PR DESCRIPTION
## Summary
- add a memory maintenance status endpoint and frontend polling flow that waits for background cleanup to finish
- harden the modal sync loop for request failures, hanging checks, overlapping resets, and close/reopen cycles
- rename the shared AgentsManager app-state and dependency surface from agent_service to agents_manager where this work touches it

## Testing
- make check-readiness
- make frontend-test
- uv run pytest tests/api/test_memory_endpoints.py tests/agents/test_manager.py tests/services/test_chat_service.py -v