### PR TITLE
feat: tighten personal info summary generation

### DIFF
--- a/src/runestone/agents/specialists/memory_maintainer/personal_info.py
+++ b/src/runestone/agents/specialists/memory_maintainer/personal_info.py
@@ -21,6 +21,8 @@ from runestone.core.exceptions import MemoryItemNotFoundError, PermissionDeniedE
 
 logger = logging.getLogger(__name__)
 
+PERSONAL_INFO_SUMMARY_MAX_CHARS = 690
+
 PERSONAL_INFO_BUCKET_TOPICS_PROMPT = """
 You are Bjorn, an internal learner-memory maintenance specialist.
 You do not interact with the student.
@@ -110,7 +112,7 @@ Rules:
 Return valid JSON matching the provided schema.
 """
 
-PERSONAL_INFO_SUMMARY_PROMPT = """
+PERSONAL_INFO_SUMMARY_PROMPT = f"""
 You are Bjorn, an internal learner-memory maintenance specialist.
 You do not interact with the student.
 
@@ -121,10 +123,18 @@ Rules:
 - The supplied list already represents the final active fact set for this run, even if some
   rows still carry a pre-apply workflow status such as `correction`.
 - Write a compact third-person summary for internal teacher use across future chats.
+- Keep only durable context that is broadly useful across future teacher turns.
 - Keep it factual and stable. Do not include speculation.
 - Exclude transient expired daily-state details such as "today", "tomorrow", or expired
   date-specific work/rest status by comparing facts against the provided current datetime.
 - Mention the student's current goals, preferences, or background only when present in the source facts.
+- Prefer major stable teaching context such as proficiency, long-term goals, language preference,
+  enduring study preferences, and durable background.
+- Omit low-value or overly narrow details that are not generally useful in future chats, such as
+  one-off assignment constraints, temporary formatting requirements, narrow exercise tactics, or
+  flavor facts that do not materially change how the teacher should teach.
+- Do not try to include every fact when a shorter summary is clearer.
+- The final summary must be at most {PERSONAL_INFO_SUMMARY_MAX_CHARS} characters.
 - Omit raw ids, keys, and status labels.
 - If the active facts are empty, return an empty summary.
 
@@ -202,6 +212,7 @@ class PersonalInfoMemoryMaintainer(BaseSpecialist):
     """Background specialist that reconciles raw personal-info facts."""
 
     MODEL_TIMEOUT_SECONDS = 30.0
+    SUMMARY_MAX_CHARS = PERSONAL_INFO_SUMMARY_MAX_CHARS
 
     def __init__(self, settings: Settings):
         super().__init__(name="memory_maintainer")
@@ -450,7 +461,7 @@ class PersonalInfoMemoryMaintainer(BaseSpecialist):
                     artifacts["summary"] = "summary_failed"
                     artifacts["step_errors"].append("summary_failed")
                     return self._error_result("Failed to synthesize personal_info summary", artifacts)
-                summary_text = summary_plan.summary.strip() or None
+                summary_text = self._normalize_summary_text(summary_plan.summary)
             artifacts["summary_preview"] = summary_text
 
             if dry_run:
@@ -921,6 +932,32 @@ class PersonalInfoMemoryMaintainer(BaseSpecialist):
             status=AgentPersonalInfoStatus.ACTIVE.value,
             status_changed_at=self._current_datetime(),
         )
+
+    @classmethod
+    def _normalize_summary_text(cls, summary: str | None) -> str | None:
+        """Normalize and cap the persisted teacher-memory summary deterministically."""
+        if not isinstance(summary, str):
+            return None
+
+        normalized = " ".join(summary.split()).strip()
+        if not normalized:
+            return None
+        if len(normalized) <= cls.SUMMARY_MAX_CHARS:
+            return normalized
+
+        trimmed = normalized[: cls.SUMMARY_MAX_CHARS].rstrip()
+        sentence_end = max(trimmed.rfind("."), trimmed.rfind("!"), trimmed.rfind("?"))
+        if sentence_end >= cls.SUMMARY_MAX_CHARS // 2:
+            trimmed = trimmed[: sentence_end + 1].rstrip()
+        else:
+            trimmed = trimmed[: cls.SUMMARY_MAX_CHARS - 3].rstrip() + "..."
+
+        logger.warning(
+            "[agents:memorymaintainer] Truncated personal_info summary from %s to %s chars",
+            len(normalized),
+            len(trimmed),
+        )
+        return trimmed or None
 
     @staticmethod
     def _serialize_datetime(value: Any) -> str | None:

--- a/src/runestone/agents/specialists/memory_maintainer/personal_info.py
+++ b/src/runestone/agents/specialists/memory_maintainer/personal_info.py
@@ -213,6 +213,7 @@ class PersonalInfoMemoryMaintainer(BaseSpecialist):
 
     MODEL_TIMEOUT_SECONDS = 30.0
     SUMMARY_MAX_CHARS = PERSONAL_INFO_SUMMARY_MAX_CHARS
+    SUMMARY_SENTENCE_BOUNDARY_MIN_RATIO = 0.8
 
     def __init__(self, settings: Settings):
         super().__init__(name="memory_maintainer")
@@ -947,7 +948,7 @@ class PersonalInfoMemoryMaintainer(BaseSpecialist):
 
         trimmed = normalized[: cls.SUMMARY_MAX_CHARS].rstrip()
         sentence_end = max(trimmed.rfind("."), trimmed.rfind("!"), trimmed.rfind("?"))
-        if sentence_end >= cls.SUMMARY_MAX_CHARS // 2:
+        if sentence_end >= int(cls.SUMMARY_MAX_CHARS * cls.SUMMARY_SENTENCE_BOUNDARY_MIN_RATIO):
             trimmed = trimmed[: sentence_end + 1].rstrip()
         else:
             trimmed = trimmed[: cls.SUMMARY_MAX_CHARS - 3].rstrip() + "..."

--- a/tests/agents/specialists/test_memory_maintainer_personal_info.py
+++ b/tests/agents/specialists/test_memory_maintainer_personal_info.py
@@ -9,6 +9,8 @@ from runestone.agents.specialists.memory_maintainer.personal_info import (
     PERSONAL_INFO_BAKE_GROUP_PROMPT,
     PERSONAL_INFO_BUCKET_TOPICS_PROMPT,
     PERSONAL_INFO_REVIEW_BUCKET_PROMPT,
+    PERSONAL_INFO_SUMMARY_MAX_CHARS,
+    PERSONAL_INFO_SUMMARY_PROMPT,
     BakeGroupPlan,
     BucketReviewGroup,
     BucketReviewPlan,
@@ -185,6 +187,27 @@ async def test_personal_info_maintainer_injects_current_datetime_into_bucket_rev
     assert '"current_datetime": "2026-06-14T10:30:00+00:00"' in bake_messages[1].content
     assert "Current datetime: 2026-06-14T10:30:00+00:00" in summary_messages[0].content
     assert '"current_datetime": "2026-06-14T10:30:00+00:00"' in summary_messages[1].content
+
+
+def test_personal_info_summary_normalization_caps_long_output_deterministically():
+    long_sentence = "A" * (PERSONAL_INFO_SUMMARY_MAX_CHARS + 25)
+
+    normalized = PersonalInfoMemoryMaintainer._normalize_summary_text(f"  {long_sentence}\n\n")
+
+    assert normalized is not None
+    assert len(normalized) == PERSONAL_INFO_SUMMARY_MAX_CHARS
+    assert normalized.endswith("...")
+
+
+def test_personal_info_summary_normalization_prefers_sentence_boundary_when_available():
+    sentence = "Andrei is a B1 Swedish learner who prefers independent practice. "
+    summary = sentence * 20
+
+    normalized = PersonalInfoMemoryMaintainer._normalize_summary_text(summary)
+
+    assert normalized is not None
+    assert len(normalized) <= PERSONAL_INFO_SUMMARY_MAX_CHARS
+    assert normalized.endswith(".")
 
 
 @pytest.mark.anyio
@@ -432,3 +455,5 @@ def test_personal_info_prompts_require_bucket_review_and_baking_contract():
     assert "group the provided `personal_info` rows into candidate topic buckets" in PERSONAL_INFO_BUCKET_TOPICS_PROMPT
     assert "reason chronologically" in PERSONAL_INFO_REVIEW_BUCKET_PROMPT
     assert "produce one final active fact or no surviving fact" in PERSONAL_INFO_BAKE_GROUP_PROMPT
+    assert f"at most {PERSONAL_INFO_SUMMARY_MAX_CHARS} characters" in PERSONAL_INFO_SUMMARY_PROMPT
+    assert "Omit low-value or overly narrow details" in PERSONAL_INFO_SUMMARY_PROMPT

--- a/tests/agents/specialists/test_memory_maintainer_personal_info.py
+++ b/tests/agents/specialists/test_memory_maintainer_personal_info.py
@@ -210,6 +210,17 @@ def test_personal_info_summary_normalization_prefers_sentence_boundary_when_avai
     assert normalized.endswith(".")
 
 
+def test_personal_info_summary_normalization_skips_early_sentence_boundary():
+    early_sentence = "A" * int(PERSONAL_INFO_SUMMARY_MAX_CHARS * 0.7) + ". "
+    trailing_text = "B" * PERSONAL_INFO_SUMMARY_MAX_CHARS
+
+    normalized = PersonalInfoMemoryMaintainer._normalize_summary_text(early_sentence + trailing_text)
+
+    assert normalized is not None
+    assert len(normalized) == PERSONAL_INFO_SUMMARY_MAX_CHARS
+    assert normalized.endswith("...")
+
+
 @pytest.mark.anyio
 async def test_personal_info_maintainer_deletes_consumed_outdated_group_in_dry_run(mock_settings, mock_user):
     items = [


### PR DESCRIPTION
## Summary
- tighten the personal-info maintainer summary prompt to keep only durable, broadly useful teacher context
- add a hard 690-character summary cap with deterministic normalization after generation
- cover the prompt contract and truncation behavior with focused maintainer tests

## Validation
- uv run pytest tests/agents/specialists/test_memory_maintainer_personal_info.py -v
- make check-readiness