### PR TITLE
[codex] add vocabulary statistics modal

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "marked": "^18.0.5",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
+        "recharts": "^3.9.1",
         "uuid": "^14.0.1"
       },
       "devDependencies": {
@@ -117,6 +118,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -463,6 +465,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -486,29 +489,9 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -579,6 +562,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -622,6 +606,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1422,6 +1407,7 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.11.tgz",
       "integrity": "sha512-yq8bPc3LxOwKRWpcjRgDkYFmpM6aKlARfESTmOQcvLYFeJwtHte2tw6hJDrb8sk8wcvpDprHEHVaoUU0MslIkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "@mui/core-downloads-tracker": "^7.3.11",
@@ -1622,6 +1608,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1980,6 +1992,18 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.2",
@@ -2373,8 +2397,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2432,6 +2455,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2480,6 +2566,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2490,6 +2577,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2508,6 +2596,12 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/uuid": {
@@ -2561,6 +2655,7 @@
       "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.0",
         "@typescript-eslint/types": "8.61.0",
@@ -2953,6 +3048,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3003,7 +3099,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3154,6 +3249,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3361,6 +3457,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -3397,6 +3614,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-eql": {
@@ -3440,8 +3663,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -3510,6 +3732,16 @@
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
+      "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -3581,6 +3813,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3777,6 +4010,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.2.2",
@@ -4047,6 +4286,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "11.1.11",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.11.tgz",
+      "integrity": "sha512-qzXuyXAkPySAGYkfsAwodDPWT8Zm7/Uo5BNt4BjhMhG5WlWyZZ4wQqnWwdS8kjlQ1Cwu6gjw3A6+0gTQwlyYtw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -4081,6 +4330,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-arrayish": {
@@ -4185,6 +4443,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -4617,7 +4876,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4893,6 +5151,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -4925,7 +5184,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4941,7 +5199,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4954,8 +5211,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -4989,6 +5245,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4998,6 +5255,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5009,7 +5267,32 @@
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
       "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -5037,6 +5320,36 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.9.1.tgz",
+      "integrity": "sha512-WMcwlXcB7l+BbxiEdyClkG+1sxrMHNZpzT577LEvU4+rXPd8oTAy1wXk72hnk2KOOmxuLvw3z5DtXT7HEAydtg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^11.1.8",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.2.0",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -5051,6 +5364,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/regexp-tree": {
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
@@ -5060,6 +5389,12 @@
       "bin": {
         "regexp-tree": "bin/regexp-tree"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -5353,6 +5688,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -5408,6 +5749,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5530,6 +5872,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5603,6 +5946,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/uuid": {
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
@@ -5616,12 +5968,35 @@
         "uuid": "dist-node/bin/uuid"
       }
     },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
     "node_modules/vite": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5738,6 +6113,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "marked": "^18.0.5",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
+    "recharts": "^3.9.1",
     "uuid": "^14.0.1"
   },
   "devDependencies": {

--- a/frontend/src/components/VocabularyStatsModal.test.tsx
+++ b/frontend/src/components/VocabularyStatsModal.test.tsx
@@ -92,6 +92,17 @@ describe("VocabularyStatsModal", () => {
     expect(screen.queryByTestId("pie-chart")).not.toBeInTheDocument();
   });
 
+  it("shows loading spinner before the initial request updates loading state", () => {
+    mockUseDistribution.mockReturnValue({
+      data: null,
+      loading: false,
+      error: null,
+    });
+    renderModal();
+    expect(document.querySelector("[role='progressbar']")).toBeInTheDocument();
+    expect(screen.queryByTestId("pie-chart")).not.toBeInTheDocument();
+  });
+
   it("shows error message on fetch failure", () => {
     mockUseDistribution.mockReturnValue({
       data: null,

--- a/frontend/src/components/VocabularyStatsModal.test.tsx
+++ b/frontend/src/components/VocabularyStatsModal.test.tsx
@@ -1,0 +1,263 @@
+/// <reference types="vitest/globals" />
+/// <reference types="@testing-library/jest-dom" />
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import VocabularyStatsModal from "./VocabularyStatsModal";
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock("../context/AuthContext", () => ({
+  useAuth: () => ({
+    token: null,
+    userData: null,
+    login: vi.fn(),
+    logout: vi.fn(),
+    isAuthenticated: () => false,
+  }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("../utils/api", () => ({
+  useApi: vi.fn(() => ({
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  })),
+}));
+
+// Recharts is SVG-heavy and doesn't render well in jsdom — stub it so tests
+// can focus on accessible text and labels without relying on SVG internals.
+vi.mock("recharts", () => ({
+  PieChart: ({ children }: { children: React.ReactNode }) => <div data-testid="pie-chart">{children}</div>,
+  Pie: ({ data, nameKey, children }: { data: Array<Record<string, unknown>>; nameKey: string; children: React.ReactNode }) => (
+    <ul data-testid="pie-slices">
+      {data.map((entry) => (
+        <li key={String(entry[nameKey])} data-testid="pie-slice">
+          {String(entry[nameKey])}: {String(entry["count"])}
+        </li>
+      ))}
+      {children}
+    </ul>
+  ),
+  Cell: ({ fill }: { fill: string }) => <li data-testid="pie-cell" data-fill={fill} />,
+  Tooltip: () => null,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+import { useVocabularyDistribution } from "../hooks/useVocabulary";
+
+vi.mock("../hooks/useVocabulary", () => ({
+  useVocabularyDistribution: vi.fn(),
+}));
+
+const mockUseDistribution = vi.mocked(useVocabularyDistribution);
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const makePriorityDistribution = (counts: number[] = Array(10).fill(0)) =>
+  counts.map((count, i) => ({
+    priority: i,
+    label: `Priority ${i}`,
+    count,
+  }));
+
+const makeLearnedDistribution = (
+  never = 0,
+  one10 = 0,
+  eleven30 = 0,
+  gt30 = 0
+) => [
+  { label: "Never", count: never },
+  { label: "1\u201310", count: one10 },
+  { label: "11\u201330", count: eleven30 },
+  { label: ">30", count: gt30 },
+];
+
+const renderModal = (open = true) =>
+  render(<VocabularyStatsModal open={open} onClose={vi.fn()} />);
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("VocabularyStatsModal", () => {
+  beforeEach(() => {
+    mockUseDistribution.mockReset();
+  });
+
+  it("shows loading spinner while fetching", () => {
+    mockUseDistribution.mockReturnValue({ data: null, loading: true, error: null });
+    renderModal();
+    // LoadingSpinner renders a CircularProgress; check it's present
+    expect(document.querySelector("[role='progressbar']")).toBeInTheDocument();
+    expect(screen.queryByTestId("pie-chart")).not.toBeInTheDocument();
+  });
+
+  it("shows error message on fetch failure", () => {
+    mockUseDistribution.mockReturnValue({
+      data: null,
+      loading: false,
+      error: "Failed to load vocabulary statistics",
+    });
+    renderModal();
+    expect(
+      screen.getByText(/failed to load vocabulary statistics/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("pie-chart")).not.toBeInTheDocument();
+  });
+
+  it("shows empty-state message when all counts are zero", () => {
+    mockUseDistribution.mockReturnValue({
+      data: {
+        priority_distribution: makePriorityDistribution(),
+        learned_times_distribution: makeLearnedDistribution(),
+      },
+      loading: false,
+      error: null,
+    });
+    renderModal();
+    expect(screen.getByText(/no vocabulary data yet/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("pie-chart")).not.toBeInTheDocument();
+  });
+
+  it("renders charts section when data has positive counts", () => {
+    mockUseDistribution.mockReturnValue({
+      data: {
+        priority_distribution: makePriorityDistribution([5, 0, 0, 0, 0, 0, 0, 0, 0, 2]),
+        learned_times_distribution: makeLearnedDistribution(3, 2, 0, 0),
+      },
+      loading: false,
+      error: null,
+    });
+    renderModal();
+    expect(screen.queryByText(/no vocabulary data yet/i)).not.toBeInTheDocument();
+    // Two pie charts rendered
+    const charts = screen.getAllByTestId("pie-chart");
+    expect(charts.length).toBe(2);
+  });
+
+  it("renders only positive-count slices in the pie", () => {
+    mockUseDistribution.mockReturnValue({
+      data: {
+        priority_distribution: makePriorityDistribution([5, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        learned_times_distribution: makeLearnedDistribution(3, 0, 0, 0),
+      },
+      loading: false,
+      error: null,
+    });
+    renderModal();
+    // Our Pie stub renders only positive-count entries
+    const slices = screen.getAllByTestId("pie-slice");
+    // Priority pie: only count=5 slice; Learned pie: only count=3 slice
+    expect(slices).toHaveLength(2);
+  });
+
+  it("maps highest priority to alert red and lowest priority to green", () => {
+    mockUseDistribution.mockReturnValue({
+      data: {
+        priority_distribution: makePriorityDistribution([1, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
+        learned_times_distribution: makeLearnedDistribution(),
+      },
+      loading: false,
+      error: null,
+    });
+
+    renderModal();
+
+    const cells = screen.getAllByTestId("pie-cell");
+    expect(cells[0]).toHaveAttribute("data-fill", "#991b1b");
+    expect(cells[1]).toHaveAttribute("data-fill", "#4ade80");
+  });
+
+  it("shows all bucket labels in the legend (including zero-count)", () => {
+    mockUseDistribution.mockReturnValue({
+      data: {
+        priority_distribution: makePriorityDistribution([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        learned_times_distribution: makeLearnedDistribution(2, 0, 0, 0),
+      },
+      loading: false,
+      error: null,
+    });
+    renderModal();
+    // All 10 priority labels visible
+    for (let i = 0; i < 10; i++) {
+      expect(screen.getByText(`Priority ${i}`)).toBeInTheDocument();
+    }
+    // All 4 learned-times labels visible
+    expect(screen.getByText("Never")).toBeInTheDocument();
+    expect(screen.getByText("1\u201310")).toBeInTheDocument();
+    expect(screen.getByText("11\u201330")).toBeInTheDocument();
+    expect(screen.getByText(">30")).toBeInTheDocument();
+  });
+
+  it("shows section titles for both charts", () => {
+    mockUseDistribution.mockReturnValue({
+      data: {
+        priority_distribution: makePriorityDistribution([1]),
+        learned_times_distribution: makeLearnedDistribution(1),
+      },
+      loading: false,
+      error: null,
+    });
+    renderModal();
+    expect(screen.getByText("Words by Priority")).toBeInTheDocument();
+    expect(screen.getByText("Words by Times Learned")).toBeInTheDocument();
+  });
+
+  it("shows individual chart empty-state when only one distribution is all zeros", () => {
+    mockUseDistribution.mockReturnValue({
+      data: {
+        priority_distribution: makePriorityDistribution([3]),       // has data
+        learned_times_distribution: makeLearnedDistribution(0, 0, 0, 0), // empty
+      },
+      loading: false,
+      error: null,
+    });
+    renderModal();
+    // Global empty state should NOT show (priority has data)
+    expect(screen.queryByText(/no vocabulary data yet/i)).not.toBeInTheDocument();
+    // Per-chart empty state shown for learned-times
+    expect(screen.getByText("No data yet")).toBeInTheDocument();
+  });
+
+  it("passes open=false to hook when modal is closed", () => {
+    mockUseDistribution.mockReturnValue({ data: null, loading: false, error: null });
+    renderModal(false);
+    expect(mockUseDistribution).toHaveBeenCalledWith(false);
+  });
+
+  it("calls onClose when the close button is clicked", () => {
+    const onClose = vi.fn();
+    mockUseDistribution.mockReturnValue({ data: null, loading: false, error: null });
+    render(<VocabularyStatsModal open onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: "Close vocabulary statistics" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("dialog has accessible title", () => {
+    mockUseDistribution.mockReturnValue({
+      data: {
+        priority_distribution: makePriorityDistribution([1]),
+        learned_times_distribution: makeLearnedDistribution(1),
+      },
+      loading: false,
+      error: null,
+    });
+    renderModal();
+    expect(
+      screen.getByRole("dialog", { name: /vocabulary statistics/i })
+    ).toBeInTheDocument();
+  });
+
+  it("triggers a fresh fetch on each open (hook called with current open value)", async () => {
+    mockUseDistribution.mockReturnValue({ data: null, loading: false, error: null });
+    const { rerender } = render(
+      <VocabularyStatsModal open={false} onClose={vi.fn()} />
+    );
+    expect(mockUseDistribution).toHaveBeenLastCalledWith(false);
+
+    rerender(<VocabularyStatsModal open onClose={vi.fn()} />);
+    await waitFor(() =>
+      expect(mockUseDistribution).toHaveBeenLastCalledWith(true)
+    );
+  });
+});

--- a/frontend/src/components/VocabularyStatsModal.tsx
+++ b/frontend/src/components/VocabularyStatsModal.tsx
@@ -251,6 +251,7 @@ const VocabularyStatsModal: React.FC<VocabularyStatsModalProps> = ({
     data !== null &&
     priorityItems.every((i) => i.count === 0) &&
     learnedItems.every((i) => i.count === 0);
+  const showLoading = loading || (!data && !error);
 
   return (
     <Dialog
@@ -293,11 +294,11 @@ const VocabularyStatsModal: React.FC<VocabularyStatsModalProps> = ({
       </DialogTitle>
 
       <DialogContent>
-        {loading && <LoadingSpinner />}
+        {showLoading && <LoadingSpinner />}
 
-        {!loading && error && <ErrorAlert message={error} />}
+        {!showLoading && error && <ErrorAlert message={error} />}
 
-        {!loading && !error && allEmpty && (
+        {!showLoading && !error && allEmpty && (
           <Box sx={{ textAlign: "center", py: 6 }}>
             <Typography sx={{ color: "rgba(255,255,255,0.5)", mb: 1 }}>
               No vocabulary data yet
@@ -310,7 +311,7 @@ const VocabularyStatsModal: React.FC<VocabularyStatsModalProps> = ({
           </Box>
         )}
 
-        {!loading && !error && !allEmpty && data && (
+        {!showLoading && !error && !allEmpty && data && (
           <Box
             sx={{
               display: "flex",

--- a/frontend/src/components/VocabularyStatsModal.tsx
+++ b/frontend/src/components/VocabularyStatsModal.tsx
@@ -1,0 +1,342 @@
+import React from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  Box,
+  IconButton,
+  Typography,
+} from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from "recharts";
+import { useVocabularyDistribution } from "../hooks/useVocabulary";
+import type {
+  PriorityDistributionItem,
+  LearnedTimesDistributionItem,
+} from "../hooks/useVocabulary";
+import { LoadingSpinner, ErrorAlert } from "./ui";
+
+// ─── Colour palettes ────────────────────────────────────────────────────────
+
+/** 10-step gradient: red alert (highest priority 0) → green (lowest priority 9) */
+const PRIORITY_COLORS = [
+  "#991b1b", // 0 Highest
+  "#dc2626", // 1 Very High
+  "#ef4444", // 2 High
+  "#f97316", // 3 Above Average
+  "#fb923c", // 4 Average
+  "#fbbf24", // 5 Below Average
+  "#fde047", // 6 Low
+  "#bef264", // 7 Very Low
+  "#86efac", // 8 Minimal
+  "#4ade80", // 9 Default
+];
+
+const LEARNED_COLORS = ["#6366f1", "#22d3ee", "#a78bfa", "#34d399"];
+
+// ─── Shared sub-components ──────────────────────────────────────────────────
+
+interface ChartEntry {
+  label: string;
+  count: number;
+}
+
+interface LegendItemProps {
+  color: string;
+  label: string;
+  count: number;
+}
+
+const LegendItem: React.FC<LegendItemProps> = ({ color, label, count }) => (
+  <Box sx={{ display: "flex", alignItems: "center", gap: 1, py: 0.25 }}>
+    <Box
+      sx={{
+        width: 10,
+        height: 10,
+        borderRadius: "50%",
+        backgroundColor: color,
+        flexShrink: 0,
+        opacity: count === 0 ? 0.35 : 1,
+      }}
+    />
+    <Typography
+      sx={{
+        color:
+          count === 0 ? "rgba(255,255,255,0.4)" : "rgba(255,255,255,0.85)",
+        fontSize: "0.75rem",
+        lineHeight: 1.4,
+      }}
+    >
+      {label}
+    </Typography>
+    <Typography
+      sx={{
+        color:
+          count === 0 ? "rgba(255,255,255,0.3)" : "rgba(255,255,255,0.7)",
+        fontSize: "0.75rem",
+        ml: "auto",
+        pl: 1,
+      }}
+    >
+      {count}
+    </Typography>
+  </Box>
+);
+
+interface DonutChartProps {
+  title: string;
+  items: ChartEntry[];
+  colors: string[];
+  ariaLabel: string;
+}
+
+const DonutChart: React.FC<DonutChartProps> = ({
+  title,
+  items,
+  colors,
+  ariaLabel,
+}) => {
+  const total = items.reduce((s, i) => s + i.count, 0);
+  const pieData = items.filter((i) => i.count > 0);
+  const allZero = total === 0;
+
+  return (
+    <Box
+      sx={{
+        flex: 1,
+        minWidth: { xs: "100%", sm: 280 },
+        p: 2,
+        borderRadius: 2,
+        background:
+          "linear-gradient(180deg, rgba(255,255,255,0.06) 0%, rgba(255,255,255,0.02) 100%)",
+        border: "1px solid rgba(255,255,255,0.08)",
+      }}
+    >
+      <Typography
+        sx={{
+          color: "rgba(255,255,255,0.9)",
+          fontWeight: 600,
+          fontSize: "0.875rem",
+          mb: 1.5,
+          textAlign: "center",
+        }}
+      >
+        {title}
+      </Typography>
+
+      {allZero ? (
+        <Box sx={{ textAlign: "center", py: 3 }}>
+          <Typography
+            sx={{ color: "rgba(255,255,255,0.4)", fontSize: "0.8rem" }}
+          >
+            No data yet
+          </Typography>
+        </Box>
+      ) : (
+        <Box sx={{ position: "relative", width: "100%", height: 180 }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <PieChart aria-label={ariaLabel}>
+              <Pie
+                data={pieData}
+                dataKey="count"
+                nameKey="label"
+                cx="50%"
+                cy="50%"
+                innerRadius={52}
+                outerRadius={78}
+                paddingAngle={2}
+                isAnimationActive
+              >
+                {pieData.map((entry) => {
+                  const idx = items.findIndex((i) => i.label === entry.label);
+                  return (
+                    <Cell
+                      key={entry.label}
+                      fill={colors[idx % colors.length]}
+                    />
+                  );
+                })}
+              </Pie>
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: "rgba(17,24,39,0.92)",
+                  border: "1px solid rgba(255,255,255,0.12)",
+                  borderRadius: 8,
+                  color: "#fff",
+                  fontSize: 13,
+                }}
+                formatter={(value, name) => {
+                  const count = Number(value ?? 0);
+                  return [
+                    `${count} word${count !== 1 ? "s" : ""}`,
+                    String(name),
+                  ];
+                }}
+              />
+            </PieChart>
+          </ResponsiveContainer>
+          {/* Centred total */}
+          <Box
+            sx={{
+              position: "absolute",
+              top: "50%",
+              left: "50%",
+              transform: "translate(-50%, -50%)",
+              textAlign: "center",
+              pointerEvents: "none",
+            }}
+          >
+            <Typography
+              sx={{
+                color: "white",
+                fontWeight: 700,
+                fontSize: "1.3rem",
+                lineHeight: 1,
+              }}
+            >
+              {total}
+            </Typography>
+            <Typography
+              sx={{ color: "rgba(255,255,255,0.5)", fontSize: "0.65rem" }}
+            >
+              words
+            </Typography>
+          </Box>
+        </Box>
+      )}
+
+      {/* Custom legend — always shows all buckets including zero-count */}
+      <Box sx={{ mt: 1.5 }}>
+        {items.map((item, idx) => (
+          <LegendItem
+            key={item.label}
+            color={colors[idx % colors.length]}
+            label={item.label}
+            count={item.count}
+          />
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+// ─── Modal ───────────────────────────────────────────────────────────────────
+
+interface VocabularyStatsModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const VocabularyStatsModal: React.FC<VocabularyStatsModalProps> = ({
+  open,
+  onClose,
+}) => {
+  const { data, loading, error } = useVocabularyDistribution(open);
+
+  const priorityItems: ChartEntry[] = (
+    data?.priority_distribution ?? []
+  ).map((item: PriorityDistributionItem) => ({
+    label: item.label,
+    count: item.count,
+  }));
+
+  const learnedItems: ChartEntry[] = (
+    data?.learned_times_distribution ?? []
+  ).map((item: LearnedTimesDistributionItem) => ({
+    label: item.label,
+    count: item.count,
+  }));
+
+  const allEmpty =
+    data !== null &&
+    priorityItems.every((i) => i.count === 0) &&
+    learnedItems.every((i) => i.count === 0);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="md"
+      fullWidth
+      aria-labelledby="vocab-stats-title"
+      PaperProps={{
+        sx: {
+          background:
+            "linear-gradient(135deg, rgba(17,24,39,0.97) 0%, rgba(31,41,55,0.97) 100%)",
+          backdropFilter: "blur(20px)",
+          border: "1px solid rgba(255,255,255,0.1)",
+          borderRadius: 3,
+          color: "white",
+        },
+      }}
+    >
+      <DialogTitle
+        id="vocab-stats-title"
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          pb: 1,
+        }}
+      >
+        <Typography sx={{ fontWeight: 700, fontSize: "1.05rem" }}>
+          Vocabulary Statistics
+        </Typography>
+        <IconButton
+          onClick={onClose}
+          aria-label="Close vocabulary statistics"
+          size="small"
+          sx={{ color: "rgba(255,255,255,0.6)" }}
+        >
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent>
+        {loading && <LoadingSpinner />}
+
+        {!loading && error && <ErrorAlert message={error} />}
+
+        {!loading && !error && allEmpty && (
+          <Box sx={{ textAlign: "center", py: 6 }}>
+            <Typography sx={{ color: "rgba(255,255,255,0.5)", mb: 1 }}>
+              No vocabulary data yet
+            </Typography>
+            <Typography
+              sx={{ color: "rgba(255,255,255,0.3)", fontSize: "0.8rem" }}
+            >
+              Add words to your active vocabulary to see statistics here.
+            </Typography>
+          </Box>
+        )}
+
+        {!loading && !error && !allEmpty && data && (
+          <Box
+            sx={{
+              display: "flex",
+              gap: 2,
+              flexDirection: { xs: "column", sm: "row" },
+              pt: 1,
+              pb: 2,
+            }}
+          >
+            <DonutChart
+              title="Words by Priority"
+              items={priorityItems}
+              colors={PRIORITY_COLORS}
+              ariaLabel="Priority distribution donut chart"
+            />
+            <DonutChart
+              title="Words by Times Learned"
+              items={learnedItems}
+              colors={LEARNED_COLORS}
+              ariaLabel="Learned-times distribution donut chart"
+            />
+          </Box>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default VocabularyStatsModal;

--- a/frontend/src/components/VocabularyView.test.tsx
+++ b/frontend/src/components/VocabularyView.test.tsx
@@ -34,6 +34,7 @@ vi.mock('../hooks/useVocabulary', () => ({
     deleteVocabularyItem: vi.fn(),
     lookupVocabularyItem: vi.fn(),
   })),
+  useVocabularyDistribution: vi.fn(() => ({ data: null, loading: false, error: null })),
 }));
 
 // Mock the useApi hook
@@ -88,6 +89,16 @@ vi.mock("./AddEditVocabularyModal", () => ({
       </div>
     ) : null,
 }));
+
+// Track open prop of VocabularyStatsModal for assertion
+let lastStatsModalOpen = false;
+vi.mock("./VocabularyStatsModal", () => ({
+  default: ({ open, onClose }: { open: boolean; onClose: () => void }) => {
+    lastStatsModalOpen = open;
+    return open ? <div data-testid="stats-modal"><button onClick={onClose}>Close Stats</button></div> : null;
+  },
+}));
+
 
 import VocabularyView from "./VocabularyView";
 import { useRecentVocabulary, useVocabularyStats } from '../hooks/useVocabulary';
@@ -1090,6 +1101,76 @@ describe("VocabularyView", () => {
         word_phrase: "hej",
         translation: "hello",
       })
+    );
+  });
+});
+describe("VocabularyView — stats button", () => {
+  beforeEach(() => {
+    lastStatsModalOpen = false;
+    mockUseRecentVocabulary.mockReturnValue({
+      recentVocabulary: [],
+      loading: false,
+      loadingMore: false,
+      error: null,
+      refetch: vi.fn(),
+      loadMore: vi.fn(),
+      hasMore: false,
+      isEditModalOpen: false,
+      editingItem: null,
+      openEditModal: vi.fn(),
+      closeEditModal: vi.fn(),
+      updateVocabularyItem: vi.fn(),
+      createVocabularyItem: vi.fn(),
+      deleteVocabularyItem: vi.fn(),
+      lookupVocabularyItem: vi.fn(),
+    });
+    mockUseVocabularyStats.mockReturnValue({
+      stats: {
+        words_in_learn_count: 0,
+        words_skipped_count: 0,
+        overall_words_count: 0,
+        words_prioritized_count: 0,
+      },
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+  });
+
+  it("renders the stats icon button with accessible label", () => {
+    renderWithAuthProvider(<VocabularyView />);
+    expect(
+      screen.getByRole("button", { name: "Open vocabulary statistics" })
+    ).toBeInTheDocument();
+  });
+
+  it("opens the stats modal when the stats button is clicked", async () => {
+    renderWithAuthProvider(<VocabularyView />);
+    expect(screen.queryByTestId("stats-modal")).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open vocabulary statistics" })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("stats-modal")).toBeInTheDocument();
+    });
+    expect(lastStatsModalOpen).toBe(true);
+  });
+
+  it("closes the stats modal when onClose is called", async () => {
+    renderWithAuthProvider(<VocabularyView />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open vocabulary statistics" })
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("stats-modal")).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Close Stats" }));
+    await waitFor(() =>
+      expect(screen.queryByTestId("stats-modal")).not.toBeInTheDocument()
     );
   });
 });

--- a/frontend/src/components/VocabularyView.tsx
+++ b/frontend/src/components/VocabularyView.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { Box, IconButton, Tooltip, Typography } from "@mui/material";
 import { alpha, useTheme } from "@mui/material/styles";
+import BarChartIcon from "@mui/icons-material/BarChart";
 import TrendingUpIcon from "@mui/icons-material/TrendingUp";
 import { useRecentVocabulary, useVocabularyStats } from "../hooks/useVocabulary";
 import {
@@ -13,6 +14,7 @@ import {
   CustomButton,
 } from "./ui";
 import AddEditVocabularyModal from "./AddEditVocabularyModal";
+import VocabularyStatsModal from "./VocabularyStatsModal";
 
 const statCards = [
   { key: "words_in_learn_count", label: "Words Studied" },
@@ -29,6 +31,7 @@ const VocabularyView: React.FC = () => {
   const [isInitialLoad, setIsInitialLoad] = useState(true);
   const [boostingItemIds, setBoostingItemIds] = useState<Set<number>>(new Set());
   const [boostError, setBoostError] = useState<string | null>(null);
+  const [statsModalOpen, setStatsModalOpen] = useState(false);
   const boostingItemIdsRef = useRef<Set<number>>(new Set());
   const {
     stats,
@@ -163,7 +166,34 @@ const VocabularyView: React.FC = () => {
 
   return (
     <Box sx={{ py: 8 }}>
-      <SectionTitle>Recent Vocabulary</SectionTitle>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 2,
+          mb: 4,
+        }}
+      >
+        <SectionTitle marginBottom={0}>Recent Vocabulary</SectionTitle>
+        <Tooltip title="Vocabulary statistics">
+          <IconButton
+            aria-label="Open vocabulary statistics"
+            onClick={() => setStatsModalOpen(true)}
+            sx={{
+              color: "rgba(255,255,255,0.6)",
+              border: "1px solid rgba(255,255,255,0.15)",
+              borderRadius: 1.5,
+              "&:hover": {
+                color: "white",
+                borderColor: "rgba(255,255,255,0.35)",
+              },
+            }}
+          >
+            <BarChartIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      </Box>
 
       {statsError ? (
         <ErrorAlert message={statsError} />
@@ -433,6 +463,10 @@ const VocabularyView: React.FC = () => {
         onDelete={handleDelete}
         onLookup={lookupVocabularyItem}
         onLookupFound={openEditModal}
+      />
+      <VocabularyStatsModal
+        open={statsModalOpen}
+        onClose={() => setStatsModalOpen(false)}
       />
     </Box>
   );

--- a/frontend/src/hooks/useVocabulary.test.ts
+++ b/frontend/src/hooks/useVocabulary.test.ts
@@ -1406,3 +1406,153 @@ describe('improveVocabularyItem', () => {
     await expect(improveVocabularyItem(mockApi, 'hej', VOCABULARY_IMPROVEMENT_MODES.ALL_FIELDS)).rejects.toThrow('Network error');
   });
 });
+
+// ─── useVocabularyDistribution ────────────────────────────────────────────────
+
+import { useVocabularyDistribution } from './useVocabulary';
+
+const makeDistributionResponse = () => ({
+  priority_distribution: Array.from({ length: 10 }, (_, i) => ({
+    priority: i,
+    label: `Priority ${i}`,
+    count: i === 0 ? 3 : 0,
+  })),
+  learned_times_distribution: [
+    { label: 'Never', count: 5 },
+    { label: '1\u201310', count: 2 },
+    { label: '11\u201330', count: 0 },
+    { label: '>30', count: 0 },
+  ],
+});
+
+describe('useVocabularyDistribution', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('does not fetch when open is false', () => {
+    renderHook(() => useVocabularyDistribution(false));
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('fetches once when open transitions to true', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(makeDistributionResponse()),
+    });
+
+    const { result } = renderHook(() => useVocabularyDistribution(true));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/vocabulary/distribution'),
+      expect.any(Object)
+    );
+    expect(result.current.data).not.toBeNull();
+  });
+
+  it('refetches when open transitions from false to true again', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(makeDistributionResponse()),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(makeDistributionResponse()),
+      });
+
+    const { result, rerender } = renderHook(
+      ({ open }: { open: boolean }) => useVocabularyDistribution(open),
+      { initialProps: { open: true } }
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    rerender({ open: false });
+    rerender({ open: true });
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2));
+  });
+
+  it('discards stale response when reopen occurs before first request resolves', async () => {
+    const { promise: slowPromise, resolve: resolveFirst } = createDeferred<object>();
+
+    mockFetch
+      .mockReturnValueOnce(
+        // Request 1 — will resolve late (stale)
+        { ok: true, json: () => slowPromise }
+      )
+      .mockResolvedValueOnce({
+        // Request 2 — resolves immediately
+        ok: true,
+        json: () => Promise.resolve(makeDistributionResponse()),
+      });
+
+    const { result, rerender } = renderHook(
+      ({ open }: { open: boolean }) => useVocabularyDistribution(open),
+      { initialProps: { open: true } }
+    );
+
+    // Close and reopen before request 1 finishes
+    rerender({ open: false });
+    rerender({ open: true });
+
+    // Wait for request 2 to finish
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Now resolve request 1 with different data
+    const staleData = {
+      priority_distribution: Array.from({ length: 10 }, (_, i) => ({
+        priority: i, label: `Stale ${i}`, count: 99,
+      })),
+      learned_times_distribution: [
+        { label: 'Never', count: 99 },
+        { label: '1\u201310', count: 99 },
+        { label: '11\u201330', count: 99 },
+        { label: '>30', count: 99 },
+      ],
+    };
+    await act(async () => { resolveFirst(staleData); });
+
+    // Data should NOT have been overwritten by the stale response
+    expect(result.current.data?.priority_distribution[0]?.count).not.toBe(99);
+  });
+
+  it('does not update state when a request resolves after the modal closes', async () => {
+    const { promise, resolve } = createDeferred<object>();
+    mockFetch.mockReturnValueOnce({ ok: true, json: () => promise });
+
+    const { result, rerender } = renderHook(
+      ({ open }: { open: boolean }) => useVocabularyDistribution(open),
+      { initialProps: { open: true } }
+    );
+    expect(result.current.loading).toBe(true);
+
+    rerender({ open: false });
+    await act(async () => { resolve(makeDistributionResponse()); });
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('sets error on network failure and clears loading', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+    const { result } = renderHook(() => useVocabularyDistribution(true));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe('Network error');
+    expect(result.current.data).toBeNull();
+  });
+
+  it('sets generic error message on non-Error rejection', async () => {
+    mockFetch.mockRejectedValueOnce('plain string failure');
+
+    const { result } = renderHook(() => useVocabularyDistribution(true));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe('Failed to load vocabulary statistics');
+  });
+});

--- a/frontend/src/hooks/useVocabulary.ts
+++ b/frontend/src/hooks/useVocabulary.ts
@@ -2,6 +2,22 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useApi } from "../utils/api";
 import type { VocabularyImprovementMode } from "../constants";
 
+export interface PriorityDistributionItem {
+  priority: number;
+  label: string;
+  count: number;
+}
+
+export interface LearnedTimesDistributionItem {
+  label: string;
+  count: number;
+}
+
+export interface VocabularyDistribution {
+  priority_distribution: PriorityDistributionItem[];
+  learned_times_distribution: LearnedTimesDistributionItem[];
+}
+
 export interface SavedVocabularyItem {
   id: number;
   user_id: number;
@@ -342,4 +358,54 @@ export const improveVocabularyItem = async (
     word_phrase: wordPhrase,
     mode: mode,
   });
+};
+
+/**
+ * Fetch vocabulary distribution (priority + learned-times) lazily.
+ *
+ * Fetches only when `open` is true, and fires a fresh request on every
+ * false→true transition. Uses a request-ID counter so stale responses
+ * (from a request started before the modal was closed and reopened) are
+ * silently discarded, preventing them from overwriting newer data.
+ */
+export const useVocabularyDistribution = (open: boolean) => {
+  const [data, setData] = useState<VocabularyDistribution | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const requestIdRef = useRef(0);
+  const { get } = useApi();
+
+  useEffect(() => {
+    if (!open) {
+      requestIdRef.current += 1;
+      setLoading(false);
+      return;
+    }
+    const id = ++requestIdRef.current;
+    setLoading(true);
+    setError(null);
+    get<VocabularyDistribution>("/api/vocabulary/distribution")
+      .then((result) => {
+        if (id === requestIdRef.current) setData(result);
+      })
+      .catch((err: unknown) => {
+        if (id === requestIdRef.current)
+          setError(
+            err instanceof Error
+              ? err.message
+              : "Failed to load vocabulary statistics"
+          );
+      })
+      .finally(() => {
+        if (id === requestIdRef.current) setLoading(false);
+      });
+
+    return () => {
+      if (id === requestIdRef.current) {
+        requestIdRef.current += 1;
+      }
+    };
+  }, [open, get]);
+
+  return { data, loading, error };
 };

--- a/src/runestone/api/endpoints.py
+++ b/src/runestone/api/endpoints.py
@@ -19,6 +19,7 @@ from runestone.api.schemas import (
     GrammarSearchResult,
     OCRResult,
     Vocabulary,
+    VocabularyDistributionResponse,
     VocabularyImproveRequest,
     VocabularyImproveResponse,
     VocabularyItemCreate,
@@ -284,6 +285,29 @@ async def get_vocabulary_stats(
         raise HTTPException(
             status_code=500,
             detail="An error occurred while retrieving vocabulary stats. Please try again later.",
+        )
+
+
+@router.get(
+    "/vocabulary/distribution",
+    response_model=VocabularyDistributionResponse,
+    responses={
+        200: {"description": "Vocabulary distribution retrieved successfully"},
+        500: {"model": ErrorResponse, "description": "Database error"},
+    },
+)
+async def get_vocabulary_distribution(
+    service: Annotated[VocabularyService, Depends(get_vocabulary_service)],
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> VocabularyDistributionResponse:
+    """Return priority and learned-times distributions for the current user's active vocabulary."""
+    try:
+        return await service.get_vocabulary_distribution(current_user.id)
+    except Exception:
+        logger.exception("retrieve vocabulary distribution failed")
+        raise HTTPException(
+            status_code=500,
+            detail="An error occurred while retrieving vocabulary distribution. Please try again later.",
         )
 
 

--- a/src/runestone/api/schemas.py
+++ b/src/runestone/api/schemas.py
@@ -40,6 +40,9 @@ __all__ = [
     "GrammarSearchResult",
     "GrammarSearchResponse",
     "VocabularyStatsResponse",
+    "VocabularyDistributionResponse",
+    "PriorityDistributionItem",
+    "LearnedTimesDistributionItem",
     "UserProfileResponse",
     "UserProfileUpdate",
     "MemoryMaintenanceStatusResponse",
@@ -183,6 +186,32 @@ class VocabularyStatsResponse(BaseModel):
     words_skipped_count: int
     overall_words_count: int
     words_prioritized_count: int
+
+
+class PriorityDistributionItem(BaseModel):
+    """One bucket in the priority distribution (one per priority value 0–9)."""
+
+    priority: int
+    label: str  # resolved by the repository from VOCABULARY_PRIORITY_LABELS
+    count: int
+
+
+class LearnedTimesDistributionItem(BaseModel):
+    """One bucket in the learned-times distribution."""
+
+    label: str  # "Never" | "1–10" | "11–30" | ">30"
+    count: int
+
+
+class VocabularyDistributionResponse(BaseModel):
+    """Distribution of active vocabulary words by priority and learned-times buckets.
+
+    Both lists always contain the full fixed set of buckets (including zero-count entries)
+    so that chart colours and legend order remain stable regardless of data sparsity.
+    """
+
+    priority_distribution: list[PriorityDistributionItem]  # 10 items, ordered 0→9
+    learned_times_distribution: list[LearnedTimesDistributionItem]  # 4 items, fixed order
 
 
 class UserProfileResponse(BaseModel):

--- a/src/runestone/constants.py
+++ b/src/runestone/constants.py
@@ -21,6 +21,21 @@ VOCABULARY_PRIORITY_LEGACY_TRUE_BACKFILL = 5
 VOCABULARY_PRIORITY_LOW = 9
 VOCABULARY_PRIORITY_DEFAULT = VOCABULARY_PRIORITY_LOW
 
+# Human-readable labels for vocabulary priority values (0 = highest, 9 = lowest/default).
+# The service layer uses this mapping when building distribution responses.
+VOCABULARY_PRIORITY_LABELS: dict[int, str] = {
+    0: "Highest (0)",
+    1: "Very High (1)",
+    2: "High (2)",
+    3: "Above Average (3)",
+    4: "Average (4)",
+    5: "Below Average (5)",
+    6: "Low (6)",
+    7: "Very Low (7)",
+    8: "Minimal (8)",
+    9: "Default (9)",
+}
+
 
 class TeacherEmotion(str, Enum):
     """Canonical teacher avatar emotions shared across backend layers."""

--- a/src/runestone/db/vocabulary_repository.py
+++ b/src/runestone/db/vocabulary_repository.py
@@ -565,3 +565,29 @@ class VocabularyRepository:
         result = await self.db.execute(stmt)
         stats = result.mappings().one()
         return VocabularyStatsResponse(**stats)
+
+    async def get_vocabulary_distribution(self, user_id: int) -> tuple[dict[int, int], dict[str, int]]:
+        """Aggregate active vocabulary counts by priority and learned-times bucket."""
+        active_filter = and_(Vocabulary.user_id == user_id, Vocabulary.in_learn.is_(True))
+
+        priority_stmt = (
+            select(Vocabulary.priority_learn, func.count(Vocabulary.id).label("cnt"))
+            .where(active_filter)
+            .group_by(Vocabulary.priority_learn)
+        )
+        priority_result = await self.db.execute(priority_stmt)
+        priority_counts: dict[int, int] = {row.priority_learn: row.cnt for row in priority_result.all()}
+
+        bucket_expr = case(
+            (Vocabulary.learned_times == 0, "Never"),
+            (Vocabulary.learned_times <= 10, "1\u201310"),
+            (Vocabulary.learned_times <= 30, "11\u201330"),
+            else_=">30",
+        ).label("bucket")
+        learned_stmt = (
+            select(bucket_expr, func.count(Vocabulary.id).label("cnt")).where(active_filter).group_by(bucket_expr)
+        )
+        learned_result = await self.db.execute(learned_stmt)
+        learned_counts: dict[str, int] = {row.bucket: row.cnt for row in learned_result.all()}
+
+        return priority_counts, learned_counts

--- a/src/runestone/db/vocabulary_repository.py
+++ b/src/runestone/db/vocabulary_repository.py
@@ -578,10 +578,11 @@ class VocabularyRepository:
         priority_result = await self.db.execute(priority_stmt)
         priority_counts: dict[int, int] = {row.priority_learn: row.cnt for row in priority_result.all()}
 
+        learned_times = func.coalesce(Vocabulary.learned_times, 0)
         bucket_expr = case(
-            (Vocabulary.learned_times == 0, "Never"),
-            (Vocabulary.learned_times <= 10, "1\u201310"),
-            (Vocabulary.learned_times <= 30, "11\u201330"),
+            (learned_times == 0, "Never"),
+            (learned_times <= 10, "1\u201310"),
+            (learned_times <= 30, "11\u201330"),
             else_=">30",
         ).label("bucket")
         learned_stmt = (

--- a/src/runestone/services/vocabulary_service.py
+++ b/src/runestone/services/vocabulary_service.py
@@ -10,9 +10,10 @@ from typing import List
 from langchain_core.exceptions import OutputParserException
 from langchain_core.language_models.chat_models import BaseChatModel
 
-from ..api.schemas import ImprovementMode
+from ..api.schemas import ImprovementMode, LearnedTimesDistributionItem, PriorityDistributionItem
 from ..api.schemas import Vocabulary as VocabularySchema
 from ..api.schemas import (
+    VocabularyDistributionResponse,
     VocabularyImproveRequest,
     VocabularyImproveResponse,
     VocabularyItemCreate,
@@ -20,6 +21,7 @@ from ..api.schemas import (
     VocabularyUpdate,
 )
 from ..config import Settings
+from ..constants import VOCABULARY_PRIORITY_LABELS
 from ..core.constants import VOCABULARY_BATCH_SIZE
 from ..core.exceptions import VocabularyItemExists
 from ..core.logging_config import get_logger
@@ -136,6 +138,26 @@ class VocabularyService:
     async def get_vocabulary_stats(self, user_id: int) -> VocabularyStatsResponse:
         """Return active vocabulary counters for the Vocabulary tab."""
         return await self.repo.get_vocabulary_stats(user_id)
+
+    async def get_vocabulary_distribution(self, user_id: int) -> VocabularyDistributionResponse:
+        """Return priority and learned-times distributions for active vocabulary."""
+        priority_counts, learned_counts = await self.repo.get_vocabulary_distribution(user_id)
+        learned_bucket_order = ("Never", "1\u201310", "11\u201330", ">30")
+
+        return VocabularyDistributionResponse(
+            priority_distribution=[
+                PriorityDistributionItem(
+                    priority=priority,
+                    label=VOCABULARY_PRIORITY_LABELS[priority],
+                    count=priority_counts.get(priority, 0),
+                )
+                for priority in range(10)
+            ],
+            learned_times_distribution=[
+                LearnedTimesDistributionItem(label=label, count=learned_counts.get(label, 0))
+                for label in learned_bucket_order
+            ],
+        )
 
     async def update_vocabulary_item(self, item_id: int, update: VocabularyUpdate, user_id: int) -> VocabularySchema:
         """Update a vocabulary item and return the updated record."""

--- a/tests/api/test_vocabulary_distribution_endpoint.py
+++ b/tests/api/test_vocabulary_distribution_endpoint.py
@@ -1,0 +1,210 @@
+"""
+Tests for GET /api/vocabulary/distribution endpoint.
+
+Covers authentication, bucket correctness, in_learn filtering,
+user isolation, and response shape invariants.
+"""
+
+import pytest
+
+from runestone.constants import VOCABULARY_PRIORITY_LABELS
+from runestone.db.models import Vocabulary as VocabularyModel
+
+
+class TestVocabularyDistributionEndpoint:
+    """Tests for the vocabulary distribution endpoint."""
+
+    pytestmark = pytest.mark.anyio
+
+    async def test_unauthenticated_returns_403(self, client_no_db):
+        """Unauthenticated request is rejected with 403."""
+        response = await client_no_db.get("/api/vocabulary/distribution")
+        assert response.status_code == 403
+
+    async def test_empty_vocab_returns_all_zero_buckets(self, client):
+        """Authenticated user with no vocabulary gets all-zero buckets."""
+        response = await client.get("/api/vocabulary/distribution")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert len(data["priority_distribution"]) == 10
+        assert all(item["count"] == 0 for item in data["priority_distribution"])
+        assert len(data["learned_times_distribution"]) == 4
+        assert all(item["count"] == 0 for item in data["learned_times_distribution"])
+
+    async def test_in_learn_false_excluded(self, client):
+        """Words added with in_learn=false do not appear in any distribution bucket."""
+        payload = {
+            "items": [
+                {"word_phrase": "ord1", "translation": "word1", "in_learn": False, "priority_learn": 0},
+                {"word_phrase": "ord2", "translation": "word2", "in_learn": False, "priority_learn": 9},
+            ],
+            "enrich": False,
+        }
+        post_resp = await client.post("/api/vocabulary", json=payload)
+        assert post_resp.status_code == 200
+
+        response = await client.get("/api/vocabulary/distribution")
+        assert response.status_code == 200
+        data = response.json()
+
+        assert all(item["count"] == 0 for item in data["priority_distribution"])
+        assert all(item["count"] == 0 for item in data["learned_times_distribution"])
+
+    async def test_priority_distribution_counts(self, client):
+        """Words at priorities 0, 3, 9 each land in their respective buckets."""
+        payload = {
+            "items": [
+                {"word_phrase": "p0", "translation": "t", "in_learn": True, "priority_learn": 0},
+                {"word_phrase": "p3", "translation": "t", "in_learn": True, "priority_learn": 3},
+                {"word_phrase": "p9", "translation": "t", "in_learn": True, "priority_learn": 9},
+            ],
+            "enrich": False,
+        }
+        await client.post("/api/vocabulary", json=payload)
+
+        response = await client.get("/api/vocabulary/distribution")
+        assert response.status_code == 200
+        data = response.json()
+
+        dist = {item["priority"]: item["count"] for item in data["priority_distribution"]}
+        assert dist[0] == 1
+        assert dist[3] == 1
+        assert dist[9] == 1
+        # All other priorities should be 0
+        for p in range(10):
+            if p not in (0, 3, 9):
+                assert dist[p] == 0
+
+    async def test_learned_times_bucket_counts(self, client):
+        """Words at boundary learned_times values land in the correct bucket."""
+        # Insert rows directly so we can control learned_times
+        client.db.add(
+            VocabularyModel(
+                user_id=client.user.id,
+                word_phrase="never",
+                translation="t",
+                in_learn=True,
+                learned_times=0,
+                priority_learn=9,
+            )
+        )
+        client.db.add(
+            VocabularyModel(
+                user_id=client.user.id,
+                word_phrase="few",
+                translation="t",
+                in_learn=True,
+                learned_times=5,
+                priority_learn=9,
+            )
+        )
+        client.db.add(
+            VocabularyModel(
+                user_id=client.user.id,
+                word_phrase="mid",
+                translation="t",
+                in_learn=True,
+                learned_times=20,
+                priority_learn=9,
+            )
+        )
+        client.db.add(
+            VocabularyModel(
+                user_id=client.user.id,
+                word_phrase="many",
+                translation="t",
+                in_learn=True,
+                learned_times=50,
+                priority_learn=9,
+            )
+        )
+        await client.db.commit()
+
+        response = await client.get("/api/vocabulary/distribution")
+        assert response.status_code == 200
+        data = response.json()
+
+        lt_dist = {item["label"]: item["count"] for item in data["learned_times_distribution"]}
+        assert lt_dist["Never"] == 1
+        assert lt_dist["1\u201310"] == 1
+        assert lt_dist["11\u201330"] == 1
+        assert lt_dist[">30"] == 1
+
+    async def test_response_has_exactly_10_priority_items_in_order(self, client):
+        """priority_distribution always has 10 items ordered 0–9."""
+        response = await client.get("/api/vocabulary/distribution")
+        assert response.status_code == 200
+        data = response.json()
+
+        assert len(data["priority_distribution"]) == 10
+        priorities = [item["priority"] for item in data["priority_distribution"]]
+        assert priorities == list(range(10))
+
+    async def test_response_has_exactly_4_learned_times_items_in_order(self, client):
+        """learned_times_distribution always has 4 items in the fixed label order."""
+        response = await client.get("/api/vocabulary/distribution")
+        assert response.status_code == 200
+        data = response.json()
+
+        labels = [item["label"] for item in data["learned_times_distribution"]]
+        assert labels == ["Never", "1\u201310", "11\u201330", ">30"]
+
+    async def test_labels_match_constants(self, client):
+        """Each priority label in the response matches VOCABULARY_PRIORITY_LABELS."""
+        response = await client.get("/api/vocabulary/distribution")
+        assert response.status_code == 200
+        data = response.json()
+
+        for item in data["priority_distribution"]:
+            assert item["label"] == VOCABULARY_PRIORITY_LABELS[item["priority"]]
+
+    async def test_user_isolation(self, client_with_overrides, db_with_test_user):
+        """Each user only sees their own vocabulary in the distribution."""
+        import uuid
+
+        from runestone.auth.dependencies import get_current_user
+        from runestone.db.models import User
+
+        async for client_a, _ in client_with_overrides():
+            # Add 2 words for user A
+            await client_a.post(
+                "/api/vocabulary",
+                json={
+                    "items": [
+                        {"word_phrase": "user-a-word1", "translation": "t", "in_learn": True, "priority_learn": 0},
+                        {"word_phrase": "user-a-word2", "translation": "t", "in_learn": True, "priority_learn": 9},
+                    ],
+                    "enrich": False,
+                },
+            )
+
+            # Verify user A sees their 2 words
+            response_a = await client_a.get("/api/vocabulary/distribution")
+            assert response_a.status_code == 200
+            data_a = response_a.json()
+            total_a = sum(item["count"] for item in data_a["priority_distribution"])
+            assert total_a == 2
+
+            # Create user B in the same DB session (no words)
+            user_b = User(
+                name="User B",
+                email=f"user-b-{uuid.uuid4()}@example.com",
+                hashed_password="$2b$12$LQv3c1yqBWVHxkd0LHAkCOYz6TtxMQJqhN8/LewdBPjYQmP7XzL6",
+                timezone="UTC",
+                pages_recognised_count=0,
+                active=True,
+            )
+            client_a.db.add(user_b)
+            await client_a.db.commit()
+
+            # Temporarily switch the authenticated user to user B
+            client_a.app.dependency_overrides[get_current_user] = lambda: user_b
+            response_b = await client_a.get("/api/vocabulary/distribution")
+            assert response_b.status_code == 200
+            data_b = response_b.json()
+            # User B has no words → all zeros
+            assert all(item["count"] == 0 for item in data_b["priority_distribution"])
+            assert all(item["count"] == 0 for item in data_b["learned_times_distribution"])
+            break

--- a/tests/api/test_vocabulary_distribution_endpoint.py
+++ b/tests/api/test_vocabulary_distribution_endpoint.py
@@ -201,10 +201,13 @@ class TestVocabularyDistributionEndpoint:
 
             # Temporarily switch the authenticated user to user B
             client_a.app.dependency_overrides[get_current_user] = lambda: user_b
-            response_b = await client_a.get("/api/vocabulary/distribution")
-            assert response_b.status_code == 200
-            data_b = response_b.json()
-            # User B has no words → all zeros
-            assert all(item["count"] == 0 for item in data_b["priority_distribution"])
-            assert all(item["count"] == 0 for item in data_b["learned_times_distribution"])
+            try:
+                response_b = await client_a.get("/api/vocabulary/distribution")
+                assert response_b.status_code == 200
+                data_b = response_b.json()
+                # User B has no words → all zeros
+                assert all(item["count"] == 0 for item in data_b["priority_distribution"])
+                assert all(item["count"] == 0 for item in data_b["learned_times_distribution"])
+            finally:
+                client_a.app.dependency_overrides.pop(get_current_user, None)
             break

--- a/tests/db/test_vocabulary_repository.py
+++ b/tests/db/test_vocabulary_repository.py
@@ -12,6 +12,7 @@ from sqlalchemy import func, select
 from runestone.api.schemas import VocabularyItemCreate
 from runestone.db.models import User
 from runestone.db.models import Vocabulary as VocabularyModel
+from runestone.db.vocabulary_repository import VocabularyRepository
 
 
 @pytest.fixture
@@ -1842,3 +1843,99 @@ class TestVocabularyRepositoryStats:
         assert stats.words_skipped_count == 1
         assert stats.overall_words_count == 3
         assert stats.words_prioritized_count == 1
+
+
+class TestGetVocabularyDistribution:
+    """Tests for VocabularyRepository.get_vocabulary_distribution."""
+
+    pytestmark = pytest.mark.anyio
+
+    async def test_empty_vocabulary(self, db_with_test_user):
+        """No active words produce empty aggregate mappings."""
+        db, test_user = db_with_test_user
+        repo = VocabularyRepository(db)
+
+        priority_counts, learned_counts = await repo.get_vocabulary_distribution(test_user.id)
+
+        assert priority_counts == {}
+        assert learned_counts == {}
+
+    async def test_in_learn_false_excluded(self, db_with_test_user):
+        """Words with in_learn=False are not counted in any bucket."""
+        db, test_user = db_with_test_user
+        repo = VocabularyRepository(db)
+
+        db.add(
+            VocabularyModel(user_id=test_user.id, word_phrase="w1", translation="t", in_learn=False, priority_learn=0)
+        )
+        db.add(
+            VocabularyModel(user_id=test_user.id, word_phrase="w2", translation="t", in_learn=False, priority_learn=9)
+        )
+        await db.commit()
+
+        priority_counts, learned_counts = await repo.get_vocabulary_distribution(test_user.id)
+
+        assert priority_counts == {}
+        assert learned_counts == {}
+
+    async def test_priority_extremes_and_learned_times_boundaries(self, db_with_test_user):
+        """Repository returns only observed priority and learned-times aggregates."""
+        db, test_user = db_with_test_user
+        repo = VocabularyRepository(db)
+
+        learned_times_values = (0, 1, 10, 11, 30, 31)
+        for index, learned_times in enumerate(learned_times_values):
+            db.add(
+                VocabularyModel(
+                    user_id=test_user.id,
+                    word_phrase=f"w{index}",
+                    translation="t",
+                    in_learn=True,
+                    priority_learn=0 if index == 0 else 9,
+                    learned_times=learned_times,
+                )
+            )
+        await db.commit()
+
+        priority_counts, learned_counts = await repo.get_vocabulary_distribution(test_user.id)
+
+        assert priority_counts == {0: 1, 9: 5}
+        assert learned_counts == {"Never": 1, "1\u201310": 2, "11\u201330": 2, ">30": 1}
+
+    async def test_user_isolation(self, db_with_test_user):
+        """User B sees all-zero distribution even when user A has words."""
+        db, user_a = db_with_test_user
+        repo = VocabularyRepository(db)
+
+        from runestone.auth.security import hash_password
+
+        user_b = User(email="user-b-isolation@example.com", hashed_password=hash_password("pw"), name="User B")
+        db.add(user_b)
+        db.add(VocabularyModel(user_id=user_a.id, word_phrase="w1", translation="t", in_learn=True, priority_learn=3))
+        await db.commit()
+
+        priority_counts, learned_counts = await repo.get_vocabulary_distribution(user_b.id)
+
+        assert priority_counts == {}
+        assert learned_counts == {}
+
+    async def test_mixed_in_learn(self, db_with_test_user):
+        """2 in_learn=True + 1 in_learn=False → total active count is 2."""
+        db, test_user = db_with_test_user
+        repo = VocabularyRepository(db)
+
+        db.add(
+            VocabularyModel(user_id=test_user.id, word_phrase="w1", translation="t", in_learn=True, priority_learn=0)
+        )
+        db.add(
+            VocabularyModel(user_id=test_user.id, word_phrase="w2", translation="t", in_learn=True, priority_learn=9)
+        )
+        db.add(
+            VocabularyModel(user_id=test_user.id, word_phrase="w3", translation="t", in_learn=False, priority_learn=5)
+        )
+        await db.commit()
+
+        priority_counts, learned_counts = await repo.get_vocabulary_distribution(test_user.id)
+
+        assert sum(priority_counts.values()) == 2
+        assert sum(learned_counts.values()) == 2

--- a/tests/services/test_services_vocabulary_service.py
+++ b/tests/services/test_services_vocabulary_service.py
@@ -1442,3 +1442,66 @@ class TestVocabularyService:
         actions = {result1[0]["action"], result2[0]["action"]}
         assert "created" in actions
         assert actions.issubset({"created", "already_prioritized", "prioritized", "restored"})
+
+
+class TestGetVocabularyDistribution:
+    """Tests for VocabularyService.get_vocabulary_distribution."""
+
+    pytestmark = pytest.mark.anyio
+
+    @pytest.fixture(autouse=True)
+    async def _seed_user(self, db_session):
+        """Seed a user so FK constraints are satisfied."""
+        user = UserModel(
+            name="Dist",
+            surname="User",
+            email="dist@example.com",
+            hashed_password="$2b$12$LQv3c1yqBWVHxkd0LHAkCOYz6TtxMQJqhN8/LewdBPjYQmP7XzL6",
+            timezone="UTC",
+            pages_recognised_count=0,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        self._user_id = user.id
+
+    @pytest.fixture
+    def service(self, vocabulary_repository):
+        """Create a VocabularyService instance."""
+        from runestone.config import Settings
+
+        mock_settings = Mock(spec=Settings)
+        mock_settings.llm_provider = "openai"
+        mock_llm_model = AsyncMock()
+        mock_llm_model.ainvoke.return_value = AIMessage(content='{"translation": "mock"}')
+        return VocabularyService(vocabulary_repository, mock_settings, mock_llm_model)
+
+    async def test_delegates_to_repo(self, service, vocabulary_repository):
+        """Service completes and labels the repository's sparse aggregate data."""
+        from runestone.constants import VOCABULARY_PRIORITY_LABELS
+
+        vocabulary_repository.get_vocabulary_distribution = AsyncMock(
+            return_value=({0: 2, 9: 1}, {"Never": 3, ">30": 1})
+        )
+
+        result = await service.get_vocabulary_distribution(user_id=self._user_id)
+
+        assert [item.priority for item in result.priority_distribution] == list(range(10))
+        assert [item.label for item in result.priority_distribution] == [
+            VOCABULARY_PRIORITY_LABELS[priority] for priority in range(10)
+        ]
+        assert [item.count for item in result.priority_distribution] == [2, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+        assert [item.label for item in result.learned_times_distribution] == [
+            "Never",
+            "1\u201310",
+            "11\u201330",
+            ">30",
+        ]
+        assert [item.count for item in result.learned_times_distribution] == [3, 0, 0, 1]
+        vocabulary_repository.get_vocabulary_distribution.assert_awaited_once_with(self._user_id)
+
+    async def test_repo_exception_propagates(self, service, vocabulary_repository):
+        """RuntimeError raised by the repo propagates out of the service unchanged."""
+        vocabulary_repository.get_vocabulary_distribution = AsyncMock(side_effect=RuntimeError("db failure"))
+
+        with pytest.raises(RuntimeError, match="db failure"):
+            await service.get_vocabulary_distribution(user_id=self._user_id)


### PR DESCRIPTION
## Summary

- add an on-demand vocabulary distribution endpoint for active learning words
- add service-layer bucket completion and priority labels over raw repository aggregates
- add a statistics modal with priority and learned-times charts
- place the statistics action beside the Recent Vocabulary heading
- cover repository, service, endpoint, hook, and component behavior

## Why

Vocabulary distributions are useful for understanding learning progress, but their database aggregation should not add cost to the normal vocabulary page load. The new endpoint is fetched only when the statistics modal opens.

## Validation

- make frontend-lockfile-check
- make security-check
- make check-readiness (backend: 1,035 passed; frontend: 525 passed; production build passed)
- commit-time pre-commit suite

## Notes

The build retains existing unresolved-font and large-chunk warnings. A headed browser smoke test could not be completed because the local dev ports were occupied and browser tooling reached its execution quota; the changed view and modal have 40 focused passing component tests.