### PR TITLE
fix: auto-sync frontend lockfile before push

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -159,7 +159,7 @@ repos:
       - id: frontend-lockfile-check
         name: frontend-lockfile-check
         language: python
-        entry: python scripts/check_frontend_lockfile_sync.py
+        entry: python scripts/check_frontend_lockfile_sync.py --require-committed
         pass_filenames: false
-        files: ^frontend/package(-lock)?\.json$
+        files: ^(frontend/package(-lock)?\.json|scripts/check_frontend_lockfile_sync\.py)$
         stages: [pre-push]

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -13,8 +13,10 @@ WORKDIR /app
 # Copy package files
 COPY frontend/package*.json ./
 
-# Install dependencies
-RUN npm ci
+# Install dependencies with the npm version declared by the package
+RUN NPM_VERSION="$(node -p "require('./package.json').packageManager.split('@').pop()")" \
+    && npm install --global "npm@${NPM_VERSION}" \
+    && npm ci
 
 # Copy source code
 COPY frontend/ ./

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ install-frontend:
 # Regenerate package-lock.json to match package.json dependencies
 frontend-lockfile-sync:
 	@echo "🔄 Syncing frontend package-lock.json with package.json..."
-	@cd frontend && npm install --package-lock-only
+	@python3 scripts/check_frontend_lockfile_sync.py --sync
 
 # Install all dependencies concurrently
 install-all:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -118,7 +118,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -465,7 +464,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -489,19 +487,8 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -562,7 +549,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -606,7 +592,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1407,7 +1392,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.11.tgz",
       "integrity": "sha512-yq8bPc3LxOwKRWpcjRgDkYFmpM6aKlARfESTmOQcvLYFeJwtHte2tw6hJDrb8sk8wcvpDprHEHVaoUU0MslIkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "@mui/core-downloads-tracker": "^7.3.11",
@@ -2216,6 +2200,25 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "inBundle": true,
@@ -2397,7 +2400,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2566,7 +2570,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2577,7 +2580,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2655,7 +2657,6 @@
       "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.0",
         "@typescript-eslint/types": "8.61.0",
@@ -3048,7 +3049,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3099,6 +3099,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3249,7 +3250,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3663,7 +3663,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -3813,7 +3814,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4443,7 +4443,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -4876,6 +4875,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5151,7 +5151,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -5184,6 +5183,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5199,6 +5199,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5211,7 +5212,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -5245,7 +5247,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5255,7 +5256,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5267,15 +5267,13 @@
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
       "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -5368,8 +5366,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -5749,7 +5746,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5846,13 +5842,6 @@
         "typescript": ">=4.8.4"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5872,7 +5861,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5996,7 +5984,6 @@
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6113,7 +6100,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "frontend",
   "private": true,
   "version": "0.0.0",
+  "packageManager": "npm@10.8.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/check_frontend_lockfile_sync.py
+++ b/scripts/check_frontend_lockfile_sync.py
@@ -44,24 +44,50 @@ def package_files_are_committed() -> bool:
             str(PACKAGE_LOCK.relative_to(REPO_ROOT)),
         ],
         cwd=REPO_ROOT,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
         check=False,
     )
-    if result.returncode != 0:
+    if result.returncode == 1:
         print(
             "Commit frontend/package.json and frontend/package-lock.json before pushing.",
             file=sys.stderr,
         )
         return False
+    if result.returncode != 0:
+        print("Unable to verify committed frontend package files.", file=sys.stderr)
+        return False
     return True
+
+
+def npm_command(pinned_version: str) -> list[str] | None:
+    """Use matching local npm when available, otherwise return a pinned npx command."""
+    npm_executable = shutil.which("npm")
+    if npm_executable is not None:
+        try:
+            version_result = subprocess.run(
+                [npm_executable, "--version"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError:
+            version_result = None
+        if (
+            version_result is not None
+            and version_result.returncode == 0
+            and version_result.stdout.strip() == pinned_version
+        ):
+            return [npm_executable]
+
+    npx_executable = shutil.which("npx")
+    if npx_executable is None:
+        return None
+    return [npx_executable, "--yes", f"npm@{pinned_version}"]
 
 
 def sync_lockfile(*, fail_on_change: bool, require_committed: bool = False) -> int:
     """Regenerate the lockfile and enforce the requested consistency checks."""
-    npx_executable = shutil.which("npx")
-    if npx_executable is None:
-        print("npx is required to synchronize the frontend lockfile.", file=sys.stderr)
-        return 1
-
     try:
         npm_version = pinned_npm_version()
         original_lockfile = PACKAGE_LOCK.read_bytes() if PACKAGE_LOCK.exists() else None
@@ -69,11 +95,14 @@ def sync_lockfile(*, fail_on_change: bool, require_committed: bool = False) -> i
         print(str(error), file=sys.stderr)
         return 1
 
+    command = npm_command(npm_version)
+    if command is None:
+        print("npm or npx is required to synchronize the frontend lockfile.", file=sys.stderr)
+        return 1
+
     result = subprocess.run(
-        [
-            npx_executable,
-            "--yes",
-            f"npm@{npm_version}",
+        command
+        + [
             "install",
             "--package-lock-only",
             "--ignore-scripts",
@@ -85,6 +114,10 @@ def sync_lockfile(*, fail_on_change: bool, require_committed: bool = False) -> i
     )
     if result.returncode != 0:
         return result.returncode
+
+    if not PACKAGE_LOCK.exists():
+        print("npm did not generate frontend/package-lock.json.", file=sys.stderr)
+        return 1
 
     if fail_on_change and PACKAGE_LOCK.read_bytes() != original_lockfile:
         print(

--- a/scripts/check_frontend_lockfile_sync.py
+++ b/scripts/check_frontend_lockfile_sync.py
@@ -1,43 +1,122 @@
 #!/usr/bin/env python3
-"""Validate that the frontend lockfile can satisfy npm ci on a clean checkout."""
+"""Keep the frontend lockfile synchronized with its package manifest."""
 
 from __future__ import annotations
 
+import argparse
+import json
 import shutil
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 FRONTEND_DIR = REPO_ROOT / "frontend"
-PACKAGE_FILES = ("package.json", "package-lock.json")
+PACKAGE_JSON = FRONTEND_DIR / "package.json"
+PACKAGE_LOCK = FRONTEND_DIR / "package-lock.json"
+
+
+def pinned_npm_version() -> str:
+    """Return the npm version declared for frontend dependency operations."""
+    package_data = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
+    package_manager = package_data.get("packageManager", "")
+    name, separator, version = package_manager.rpartition("@")
+    if separator == "" or name != "npm" or not version:
+        raise ValueError('frontend/package.json must define "packageManager": "npm@<version>"')
+    return version
+
+
+def package_files_are_committed() -> bool:
+    """Return whether the package manifest and lockfile match the current commit."""
+    git_executable = shutil.which("git")
+    if git_executable is None:
+        print("git is required to verify committed frontend package files.", file=sys.stderr)
+        return False
+
+    result = subprocess.run(
+        [
+            git_executable,
+            "diff",
+            "--quiet",
+            "HEAD",
+            "--",
+            str(PACKAGE_JSON.relative_to(REPO_ROOT)),
+            str(PACKAGE_LOCK.relative_to(REPO_ROOT)),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+    )
+    if result.returncode != 0:
+        print(
+            "Commit frontend/package.json and frontend/package-lock.json before pushing.",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def sync_lockfile(*, fail_on_change: bool, require_committed: bool = False) -> int:
+    """Regenerate the lockfile and enforce the requested consistency checks."""
+    npx_executable = shutil.which("npx")
+    if npx_executable is None:
+        print("npx is required to synchronize the frontend lockfile.", file=sys.stderr)
+        return 1
+
+    try:
+        npm_version = pinned_npm_version()
+        original_lockfile = PACKAGE_LOCK.read_bytes() if PACKAGE_LOCK.exists() else None
+    except (json.JSONDecodeError, OSError, ValueError) as error:
+        print(str(error), file=sys.stderr)
+        return 1
+
+    result = subprocess.run(
+        [
+            npx_executable,
+            "--yes",
+            f"npm@{npm_version}",
+            "install",
+            "--package-lock-only",
+            "--ignore-scripts",
+            "--no-audit",
+            "--no-fund",
+        ],
+        cwd=FRONTEND_DIR,
+        check=False,
+    )
+    if result.returncode != 0:
+        return result.returncode
+
+    if fail_on_change and PACKAGE_LOCK.read_bytes() != original_lockfile:
+        print(
+            "frontend/package-lock.json was updated; commit it and retry.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if require_committed and not package_files_are_committed():
+        return 1
+
+    return 0
 
 
 def main() -> int:
-    """Run npm ci in an isolated temp directory using only the package files."""
-    npm_executable = shutil.which("npm")
-    if npm_executable is None:
-        print("npm is required to validate frontend lockfile sync.", file=sys.stderr)
-        return 1
-
-    with tempfile.TemporaryDirectory(prefix="runestone-frontend-lockfile-") as temp_dir:
-        temp_frontend_dir = Path(temp_dir)
-        for filename in PACKAGE_FILES:
-            shutil.copy2(FRONTEND_DIR / filename, temp_frontend_dir / filename)
-
-        result = subprocess.run(
-            [
-                npm_executable,
-                "ci",
-                "--ignore-scripts",
-                "--no-audit",
-                "--no-fund",
-            ],
-            cwd=temp_frontend_dir,
-            check=False,
-        )
-        return result.returncode
+    """Synchronize the lockfile, failing by default when it had been stale."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--sync",
+        action="store_true",
+        help="Update package-lock.json without failing when it changes.",
+    )
+    parser.add_argument(
+        "--require-committed",
+        action="store_true",
+        help="Fail when the package manifest or lockfile differs from HEAD.",
+    )
+    args = parser.parse_args()
+    return sync_lockfile(
+        fail_on_change=not args.sync,
+        require_committed=args.require_committed,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_frontend_lockfile_sync.py
+++ b/tests/test_frontend_lockfile_sync.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import subprocess
+
+from scripts import check_frontend_lockfile_sync
+
+
+def test_pinned_npm_version_reads_package_manager(tmp_path, monkeypatch) -> None:
+    package_json = tmp_path / "package.json"
+    package_json.write_text('{"packageManager": "npm@10.8.2"}', encoding="utf-8")
+    monkeypatch.setattr(check_frontend_lockfile_sync, "PACKAGE_JSON", package_json)
+
+    assert check_frontend_lockfile_sync.pinned_npm_version() == "10.8.2"
+
+
+def test_check_updates_stale_lockfile_and_fails(tmp_path, monkeypatch, capsys) -> None:
+    package_lock = tmp_path / "package-lock.json"
+    package_lock.write_text("old", encoding="utf-8")
+    monkeypatch.setattr(check_frontend_lockfile_sync, "FRONTEND_DIR", tmp_path)
+    monkeypatch.setattr(check_frontend_lockfile_sync, "PACKAGE_LOCK", package_lock)
+    monkeypatch.setattr(check_frontend_lockfile_sync, "pinned_npm_version", lambda: "10.8.2")
+    monkeypatch.setattr(check_frontend_lockfile_sync.shutil, "which", lambda _: "/usr/bin/npx")
+
+    def run(command, *, cwd, check):
+        assert command[:3] == ["/usr/bin/npx", "--yes", "npm@10.8.2"]
+        assert cwd == tmp_path
+        assert check is False
+        package_lock.write_text("new", encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(check_frontend_lockfile_sync.subprocess, "run", run)
+
+    assert check_frontend_lockfile_sync.sync_lockfile(fail_on_change=True) == 1
+    assert "commit it and retry" in capsys.readouterr().err
+
+
+def test_explicit_sync_accepts_lockfile_change(tmp_path, monkeypatch) -> None:
+    package_lock = tmp_path / "package-lock.json"
+    package_lock.write_text("old", encoding="utf-8")
+    monkeypatch.setattr(check_frontend_lockfile_sync, "FRONTEND_DIR", tmp_path)
+    monkeypatch.setattr(check_frontend_lockfile_sync, "PACKAGE_LOCK", package_lock)
+    monkeypatch.setattr(check_frontend_lockfile_sync, "pinned_npm_version", lambda: "10.8.2")
+    monkeypatch.setattr(check_frontend_lockfile_sync.shutil, "which", lambda _: "/usr/bin/npx")
+
+    def run(command, *, cwd, check):
+        package_lock.write_text("new", encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(check_frontend_lockfile_sync.subprocess, "run", run)
+
+    assert check_frontend_lockfile_sync.sync_lockfile(fail_on_change=False) == 0
+
+
+def test_pre_push_rejects_uncommitted_package_files(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(check_frontend_lockfile_sync.shutil, "which", lambda _: "/usr/bin/git")
+    monkeypatch.setattr(
+        check_frontend_lockfile_sync.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 1),
+    )
+
+    assert check_frontend_lockfile_sync.package_files_are_committed() is False
+    assert "before pushing" in capsys.readouterr().err

--- a/tests/test_frontend_lockfile_sync.py
+++ b/tests/test_frontend_lockfile_sync.py
@@ -13,13 +13,65 @@ def test_pinned_npm_version_reads_package_manager(tmp_path, monkeypatch) -> None
     assert check_frontend_lockfile_sync.pinned_npm_version() == "10.8.2"
 
 
+def test_npm_command_uses_matching_local_npm(monkeypatch) -> None:
+    monkeypatch.setattr(
+        check_frontend_lockfile_sync.shutil,
+        "which",
+        lambda command: "/usr/bin/npm" if command == "npm" else None,
+    )
+    monkeypatch.setattr(
+        check_frontend_lockfile_sync.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, stdout="10.8.2\n"),
+    )
+
+    assert check_frontend_lockfile_sync.npm_command("10.8.2") == ["/usr/bin/npm"]
+
+
+def test_npm_command_falls_back_to_pinned_npx(monkeypatch) -> None:
+    monkeypatch.setattr(
+        check_frontend_lockfile_sync.shutil,
+        "which",
+        lambda command: "/usr/bin/npx" if command == "npx" else None,
+    )
+
+    assert check_frontend_lockfile_sync.npm_command("10.8.2") == [
+        "/usr/bin/npx",
+        "--yes",
+        "npm@10.8.2",
+    ]
+
+
+def test_npm_command_falls_back_when_local_npm_version_differs(monkeypatch) -> None:
+    monkeypatch.setattr(
+        check_frontend_lockfile_sync.shutil,
+        "which",
+        lambda command: f"/usr/bin/{command}" if command in {"npm", "npx"} else None,
+    )
+    monkeypatch.setattr(
+        check_frontend_lockfile_sync.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, stdout="11.6.2\n"),
+    )
+
+    assert check_frontend_lockfile_sync.npm_command("10.8.2") == [
+        "/usr/bin/npx",
+        "--yes",
+        "npm@10.8.2",
+    ]
+
+
 def test_check_updates_stale_lockfile_and_fails(tmp_path, monkeypatch, capsys) -> None:
     package_lock = tmp_path / "package-lock.json"
     package_lock.write_text("old", encoding="utf-8")
     monkeypatch.setattr(check_frontend_lockfile_sync, "FRONTEND_DIR", tmp_path)
     monkeypatch.setattr(check_frontend_lockfile_sync, "PACKAGE_LOCK", package_lock)
     monkeypatch.setattr(check_frontend_lockfile_sync, "pinned_npm_version", lambda: "10.8.2")
-    monkeypatch.setattr(check_frontend_lockfile_sync.shutil, "which", lambda _: "/usr/bin/npx")
+    monkeypatch.setattr(
+        check_frontend_lockfile_sync.shutil,
+        "which",
+        lambda command: "/usr/bin/npx" if command == "npx" else None,
+    )
 
     def run(command, *, cwd, check):
         assert command[:3] == ["/usr/bin/npx", "--yes", "npm@10.8.2"]
@@ -40,7 +92,11 @@ def test_explicit_sync_accepts_lockfile_change(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(check_frontend_lockfile_sync, "FRONTEND_DIR", tmp_path)
     monkeypatch.setattr(check_frontend_lockfile_sync, "PACKAGE_LOCK", package_lock)
     monkeypatch.setattr(check_frontend_lockfile_sync, "pinned_npm_version", lambda: "10.8.2")
-    monkeypatch.setattr(check_frontend_lockfile_sync.shutil, "which", lambda _: "/usr/bin/npx")
+    monkeypatch.setattr(
+        check_frontend_lockfile_sync.shutil,
+        "which",
+        lambda command: "/usr/bin/npx" if command == "npx" else None,
+    )
 
     def run(command, *, cwd, check):
         package_lock.write_text("new", encoding="utf-8")
@@ -51,13 +107,44 @@ def test_explicit_sync_accepts_lockfile_change(tmp_path, monkeypatch) -> None:
     assert check_frontend_lockfile_sync.sync_lockfile(fail_on_change=False) == 0
 
 
+def test_sync_fails_cleanly_when_npm_does_not_create_lockfile(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.setattr(check_frontend_lockfile_sync, "FRONTEND_DIR", tmp_path)
+    monkeypatch.setattr(check_frontend_lockfile_sync, "PACKAGE_LOCK", tmp_path / "package-lock.json")
+    monkeypatch.setattr(check_frontend_lockfile_sync, "pinned_npm_version", lambda: "10.8.2")
+    monkeypatch.setattr(check_frontend_lockfile_sync, "npm_command", lambda _: ["/usr/bin/npm"])
+    monkeypatch.setattr(
+        check_frontend_lockfile_sync.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0),
+    )
+
+    assert check_frontend_lockfile_sync.sync_lockfile(fail_on_change=True) == 1
+    assert "did not generate" in capsys.readouterr().err
+
+
 def test_pre_push_rejects_uncommitted_package_files(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(check_frontend_lockfile_sync.shutil, "which", lambda _: "/usr/bin/git")
+
+    def run(command, *, cwd, stdout, stderr, check):
+        assert cwd == check_frontend_lockfile_sync.REPO_ROOT
+        assert stdout is subprocess.DEVNULL
+        assert stderr is subprocess.DEVNULL
+        assert check is False
+        return subprocess.CompletedProcess(command, 1)
+
+    monkeypatch.setattr(check_frontend_lockfile_sync.subprocess, "run", run)
+
+    assert check_frontend_lockfile_sync.package_files_are_committed() is False
+    assert "before pushing" in capsys.readouterr().err
+
+
+def test_pre_push_reports_git_verification_failure(monkeypatch, capsys) -> None:
     monkeypatch.setattr(check_frontend_lockfile_sync.shutil, "which", lambda _: "/usr/bin/git")
     monkeypatch.setattr(
         check_frontend_lockfile_sync.subprocess,
         "run",
-        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 1),
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 128),
     )
 
     assert check_frontend_lockfile_sync.package_files_are_committed() is False
-    assert "before pushing" in capsys.readouterr().err
+    assert "Unable to verify" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- replace the Docker-based lockfile workflow with a host-side pinned npm sync
- update stale package-lock.json content for the current package.json
- make pre-push update stale lockfiles, abort, and require the package files to be committed
- align the frontend image with the npm version declared in package.json
- add focused tests for version parsing, sync behavior, and the pre-push commit guard

Replacement for #209.

## Validation
- make check-readiness
- 1,039 backend tests passed
- 526 frontend tests passed
- frontend production build passed
- repeated pinned-npm lockfile sync passed cleanly