### PR TITLE
Make specialist history policy manager-owned

### DIFF
--- a/docs/agent-swarm-architecture.md
+++ b/docs/agent-swarm-architecture.md
@@ -176,6 +176,8 @@ Rules:
 - for `post_response`, populate only `post_response`
 - never speculate about future teacher behavior during pre-stage planning
 - use the actual teacher reply as a primary signal during post-stage planning
+- return routing items that only explain which specialist should run and why;
+  execution details such as specialist history windows are manager-owned policy
 
 #### WordKeeper
 
@@ -346,7 +348,9 @@ learning state still lives only in the normal memory-item statuses such as
 **PersonalMemoryKeeper** principles:
 
 - Append-only: Python uses only `append_personal_info_item`; the specialist never reads memory.
-- Receives `chat_history_size=2` so `run()` can extract `previous_teacher_message` to detect drill/exercise context; raw history is not exposed to the LLM.
+- Receives a manager-owned two-message history window so `run()` can extract
+  `previous_teacher_message` to detect drill/exercise context; raw history is not
+  exposed to the LLM.
 - Uses one structured extraction call to classify practice responses and extract at
   most five facts; Python validates the plan before appending.
 - Duplicate `personal_info` rows from append-first writes are an accepted tradeoff; reconciliation belongs to `memory_maintainer`.
@@ -591,6 +595,18 @@ Output:
   - `post_response`
   - `audit`
 
+Routing items contain only:
+
+- specialist `name`
+- routing `reason`
+
+`AgentsManager` owns deterministic specialist history policy:
+
+- `news_agent`: 2 messages
+- `word_keeper`: 0 messages
+- `learning_memory_keeper`: 0 messages
+- `personal_memory_keeper`: 2 messages
+
 ### TeacherAgent Contract
 
 Input:
@@ -657,7 +673,8 @@ Input:
 
 - `student_message`: student's current message
 - `teacher_response`: teacher's current response
-- `previous_teacher_message`: immediately preceding teacher message (extracted from `chat_history_size=2`; not exposed directly to the LLM)
+- `previous_teacher_message`: immediately preceding teacher message (extracted from
+  the manager-owned two-message history window; not exposed directly to the LLM)
 
 Output:
 
@@ -724,7 +741,9 @@ Decisions:
 - Split the single `MemoryKeeper` into two focused specialists to reduce prompt complexity and tool surface.
 - `LearningMemoryKeeper` owns all `area_to_improve` writes; receives zero chat history.
 - `PersonalMemoryKeeper` is append-only (single tool: `append_personal_info_item`); never reads memory.
-- `PersonalMemoryKeeper` receives `chat_history_size=2` so `run()` can extract `previous_teacher_message` for drill detection — raw history is not forwarded to the LLM.
+- `PersonalMemoryKeeper` receives a manager-owned two-message window so `run()` can
+  extract `previous_teacher_message` for drill detection — raw history is not
+  forwarded to the LLM.
 - Both specialists share `MEMORY_KEEPER_*` config; no new env vars needed.
 
 ### 2026-07-06: MemoryKeepers moved to deterministic structured output
@@ -733,6 +752,23 @@ Decisions:
 
 - Replace both tool-calling agent loops with one structured extraction per run.
 - Keep all authorization, target allowlisting, cardinality checks, and persistence in Python.
+
+### 2026-07-07: Specialist History Windows Moved Fully Into Manager Policy
+
+Source: superseded `docs/todo/specialist-history-size-determinism.md`
+
+Decisions:
+
+- Remove `chat_history_size` from coordinator prompts and the `RoutingItem` contract.
+- Keep coordinator output focused on specialist selection plus routing reason only.
+- Keep current effective history behavior unchanged by moving the policy fully into
+  `AgentsManager`.
+- Hardcode the current specialist windows as manager-owned constants:
+  `news_agent=2`, `word_keeper=0`, `learning_memory_keeper=0`,
+  `personal_memory_keeper=2`.
+- Continue passing the immediately previous teacher message to `word_keeper` and
+  deriving `previous_teacher_message` for `PersonalMemoryKeeper` without exposing raw
+  history to the model payload.
 - Pre-read only tagged learning targets when tags are present; otherwise supply at
   most 100 sanitized learning targets for semantic reconciliation.
 - Preserve append-only personal memory and classify drill responses from the

--- a/src/runestone/agents/coordinator.py
+++ b/src/runestone/agents/coordinator.py
@@ -33,11 +33,6 @@ Your sole job is to decide which specialist agents to route to for the current s
 - Never include `teacher` in any routing plan — the teacher is always invoked by the manager.
 - Never invent tool outputs. Tools run after planning.
 - Always emit valid JSON matching the CoordinatorPlan schema. No extra text outside the JSON.
-
-## Chat History Window
-- Set `chat_history_size` to a small non-negative integer
-  (e.g. 0, 2, 4, 6) to keep specialist inputs stable and testable.
-- Default to `2` for most specialists unless a specific routing rule below says otherwise.
 """
 
 
@@ -75,8 +70,6 @@ COORDINATOR_PRE_RESPONSE_PROMPT = (
   (e.g. "next task", "let's continue", "another exercise", "I'm done").
 - Words were already saved in earlier turns — do not re-trigger on later turns.
 
-Set `chat_history_size` to `0` for `word_keeper`.
-
 ### news_agent (pre)
 **Route when:** The student's current message asks about a specific real-time or current-events topic that requires
 live data — such as news about a subject, place, or event, current weather, or any other factual query that cannot
@@ -89,8 +82,6 @@ be answered from static knowledge.
 **Do NOT route when:**
 - The topic is vague or unspecified (e.g. "give me some news", "any news?"). Let the teacher clarify on the next turn.
 - The student is asking a grammar or vocabulary question with no real-time component.
-
-For all normal news_agent cases, set `chat_history_size` to `2`.
 """
 )
 
@@ -125,8 +116,6 @@ COORDINATOR_POST_RESPONSE_PROMPT = (
 - The teacher merely explains grammar rules using instructional verbs like "kom ihåg" or "tänk på".
 - The teacher only corrects a misspelled/invalid word (vocabulary event, not learning memory).
 
-Set `chat_history_size` to `0` for `learning_memory_keeper`.
-
 ### personal_memory_keeper (post)
 **Route when:**
 - The student's `message` contains a clear, durable personal fact (for example: native language,
@@ -139,8 +128,6 @@ Set `chat_history_size` to `0` for `learning_memory_keeper`.
 - The student is just practicing sentences or doing drills.
 - The student is writing fictional examples or translating practice sentences (e.g. in response to a teacher exercise).
 - The signal is about learning progress (area_to_improve) — route `learning_memory_keeper`.
-
-Set `chat_history_size` to `2` for `personal_memory_keeper`.
 """
 )
 

--- a/src/runestone/agents/manager.py
+++ b/src/runestone/agents/manager.py
@@ -52,8 +52,13 @@ class AgentsManager:
     COORDINATOR_MAX_HISTORY_MESSAGES = 5
     POST_TASK_TIMEOUT_SECONDS = 25
     STARTER_MEMORY_AREA_LIMIT = 5
-    NO_CHAT_HISTORY_SPECIALISTS = frozenset({"word_keeper", "learning_memory_keeper"})
-    PERSONAL_MEMORY_KEEPER_HISTORY_SIZE = 2
+    DEFAULT_SPECIALIST_HISTORY_SIZE = 0
+    SPECIALIST_HISTORY_SIZES = {
+        "news_agent": 2,
+        "word_keeper": 0,
+        "learning_memory_keeper": 0,
+        "personal_memory_keeper": 2,
+    }
 
     def __init__(
         self,
@@ -108,26 +113,28 @@ class AgentsManager:
             logger.warning("allowed_origins configuration issue: %s", e)
 
     @classmethod
-    def _effective_specialist_history_size(cls, specialist_name: str, requested_history_size: int) -> int:
+    def _effective_specialist_history_size(cls, specialist_name: str) -> int:
         """
-        Apply manager-owned history-window overrides for specialists.
+        Return the manager-owned history-window policy for a specialist.
 
-        Some post/pre specialists should never receive raw chat history because their
-        trigger inputs are already passed through dedicated context fields:
+        Most specialists are deterministic single-turn consumers. The current exceptions
+        are kept as explicit orchestration policy here instead of as coordinator output.
+        That keeps the coordinator contract focused on "which specialist" and "why"
+        while the manager owns execution details.
+
+        Some specialists should never receive raw chat history because their trigger
+        inputs are already passed through dedicated context fields:
         - `word_keeper` uses the current save request plus the immediately previous
           teacher message when needed.
         - `learning_memory_keeper` acts only on the current student message and the
           current turn's teacher response — chat history is always forced to zero.
-        - `personal_memory_keeper` receives `chat_history_size=2` so its `run()` method
+        - `personal_memory_keeper` receives a two-message window so its `run()` method
           can extract the immediately preceding teacher message (`previous_teacher_message`)
           to detect and filter out drill/exercise responses. It does NOT expose raw history
           to the agent — only the extracted field reaches the LLM payload.
+        - `news_agent` keeps a tiny recent window for immediate follow-up news requests.
         """
-        if specialist_name in cls.NO_CHAT_HISTORY_SPECIALISTS:
-            return 0
-        if specialist_name == "personal_memory_keeper":
-            return cls.PERSONAL_MEMORY_KEEPER_HISTORY_SIZE
-        return requested_history_size
+        return cls.SPECIALIST_HISTORY_SIZES.get(specialist_name, cls.DEFAULT_SPECIALIST_HISTORY_SIZE)
 
     # ------------------------------------------------------------------
     # Phase methods (public, individually testable)
@@ -484,7 +491,6 @@ class AgentsManager:
                     RoutingItem(
                         name="word_keeper",
                         reason="teacher emitted vocabulary_candidates",
-                        chat_history_size=0,
                     )
                 ],
                 message=message,
@@ -722,10 +728,7 @@ class AgentsManager:
 
         async def _invoke(item, specialist):
             started = time.monotonic()
-            effective_history_size = self._effective_specialist_history_size(
-                item.name,
-                item.chat_history_size,
-            )
+            effective_history_size = self._effective_specialist_history_size(item.name)
 
             history_window = history[-effective_history_size:] if effective_history_size else []
             if effective_history_size and len(history) > effective_history_size:

--- a/src/runestone/agents/schemas.py
+++ b/src/runestone/agents/schemas.py
@@ -196,12 +196,6 @@ class RoutingItem(BaseModel):
 
     name: str = Field(..., description="Specialist name to invoke")
     reason: str = Field(..., description="Why this specialist should run")
-    chat_history_size: int = Field(
-        ...,
-        description="Number of most recent chat messages to pass to the specialist",
-        ge=0,
-        le=20,
-    )
 
 
 class CoordinatorPlan(BaseModel):

--- a/tests/agents/test_coordinator.py
+++ b/tests/agents/test_coordinator.py
@@ -78,7 +78,7 @@ def test_word_keeper_prompt_eligibility():
     assert "Words were already saved in earlier turns — do not re-trigger on later turns." in (
         COORDINATOR_PRE_RESPONSE_PROMPT
     )
-    assert "Set `chat_history_size` to `0` for `word_keeper`." in COORDINATOR_PRE_RESPONSE_PROMPT
+    assert "chat_history_size" not in COORDINATOR_PRE_RESPONSE_PROMPT
 
 
 def test_memory_reader_is_absent_from_pre_prompt():
@@ -88,8 +88,7 @@ def test_memory_reader_is_absent_from_pre_prompt():
 def test_learning_and_personal_memory_keeper_prompts():
     assert "learning_memory_keeper" in COORDINATOR_POST_RESPONSE_PROMPT
     assert "personal_memory_keeper" in COORDINATOR_POST_RESPONSE_PROMPT
-    assert "Set `chat_history_size` to `0` for `learning_memory_keeper`." in COORDINATOR_POST_RESPONSE_PROMPT
-    assert "Set `chat_history_size` to `2` for `personal_memory_keeper`." in COORDINATOR_POST_RESPONSE_PROMPT
+    assert "chat_history_size" not in COORDINATOR_POST_RESPONSE_PROMPT
     assert "The student's `message` contains a clear, durable personal fact" in COORDINATOR_POST_RESPONSE_PROMPT
     assert "forget/remove" in COORDINATOR_POST_RESPONSE_PROMPT
 
@@ -109,7 +108,7 @@ def test_news_prompt_requires_known_topic():
     assert "asks for `news`/`nyheter`" in COORDINATOR_PRE_RESPONSE_PROMPT
     assert "Ska vi lasa nyheter om Sverige?" in COORDINATOR_PRE_RESPONSE_PROMPT
     assert "The topic is vague or unspecified" in COORDINATOR_PRE_RESPONSE_PROMPT
-    assert "For all normal news_agent cases, set `chat_history_size` to `2`." in COORDINATOR_PRE_RESPONSE_PROMPT
+    assert "chat_history_size" not in COORDINATOR_PRE_RESPONSE_PROMPT
 
 
 def test_grammar_is_absent_from_coordinator_prompt():
@@ -147,8 +146,8 @@ def test_word_keeper_prompt_limits_pre_stage_to_explicit_save_requests():
 async def test_plan_success(coordinator_agent, mock_chat_model):
     """Test successful plan generation."""
     raw_plan = CoordinatorPlan(
-        pre_response=[RoutingItem(name="word_keeper", reason="Test", chat_history_size=2)],
-        post_response=[RoutingItem(name="learning_memory_keeper", reason="Test", chat_history_size=2)],
+        pre_response=[RoutingItem(name="word_keeper", reason="Test")],
+        post_response=[RoutingItem(name="learning_memory_keeper", reason="Test")],
         audit={"trace": "ok"},
     )
     mock_llm = mock_chat_model.with_structured_output.return_value
@@ -163,7 +162,7 @@ async def test_plan_success(coordinator_agent, mock_chat_model):
     )
 
     assert plan == CoordinatorPlan(
-        pre_response=[RoutingItem(name="word_keeper", reason="Test", chat_history_size=2)],
+        pre_response=[RoutingItem(name="word_keeper", reason="Test")],
         post_response=[],
         audit={"trace": "ok"},
     )
@@ -184,8 +183,8 @@ async def test_plan_success(coordinator_agent, mock_chat_model):
 @pytest.mark.anyio
 async def test_plan_pre_turn_only_returns_pre_items(coordinator_agent, mock_chat_model):
     expected_plan = CoordinatorPlan(
-        pre_response=[RoutingItem(name="word_keeper", reason="Test", chat_history_size=2)],
-        post_response=[RoutingItem(name="word_keeper", reason="Should be dropped", chat_history_size=2)],
+        pre_response=[RoutingItem(name="word_keeper", reason="Test")],
+        post_response=[RoutingItem(name="word_keeper", reason="Should be dropped")],
         audit={"trace": "ok"},
     )
     mock_llm = mock_chat_model.with_structured_output.return_value
@@ -204,10 +203,8 @@ async def test_plan_pre_turn_only_returns_pre_items(coordinator_agent, mock_chat
 @pytest.mark.anyio
 async def test_plan_post_turn_only_returns_post_items_and_passes_teacher_response(coordinator_agent, mock_chat_model):
     expected_plan = CoordinatorPlan(
-        pre_response=[RoutingItem(name="word_keeper", reason="Should be dropped", chat_history_size=2)],
-        post_response=[
-            RoutingItem(name="learning_memory_keeper", reason="Teacher confirmed mastery", chat_history_size=2)
-        ],
+        pre_response=[RoutingItem(name="word_keeper", reason="Should be dropped")],
+        post_response=[RoutingItem(name="learning_memory_keeper", reason="Teacher confirmed mastery")],
         audit={"trace": "ok"},
     )
     mock_llm = mock_chat_model.with_structured_output.return_value
@@ -312,9 +309,7 @@ async def test_plan_post_turn_passes_student_message_for_memory_change_request(c
     mock_llm = mock_chat_model.with_structured_output.return_value
     mock_llm.ainvoke.return_value = CoordinatorPlan(
         pre_response=[],
-        post_response=[
-            RoutingItem(name="personal_memory_keeper", reason="Student asked to forget memory", chat_history_size=2)
-        ],
+        post_response=[RoutingItem(name="personal_memory_keeper", reason="Student asked to forget memory")],
         audit={"trace": "ok"},
     )
 

--- a/tests/agents/test_manager.py
+++ b/tests/agents/test_manager.py
@@ -536,7 +536,7 @@ async def test_prepare_pre_turn_passes_bounded_history_into_news_agent(
 ):
     manager = _make_manager(mock_settings)
     manager.coordinator.plan_pre_turn = AsyncMock(
-        return_value=_make_plan(pre=[RoutingItem(name="news_agent", reason="topic", chat_history_size=2)])
+        return_value=_make_plan(pre=[RoutingItem(name="news_agent", reason="topic")])
     )
 
     class _CaptureSpecialist(BaseSpecialist):
@@ -1248,9 +1248,7 @@ def test_load_current_recall_words_returns_empty_on_user_mismatch(mock_settings,
 async def test_run_post_turn_runs_post_specialists(mock_settings, mock_user, mock_side_effect_service):
     manager = _make_manager(mock_settings)
     manager.coordinator.plan_post_turn = AsyncMock(
-        return_value=_make_plan(
-            post=[RoutingItem(name="learning_memory_keeper", reason="save memory", chat_history_size=0)]
-        )
+        return_value=_make_plan(post=[RoutingItem(name="learning_memory_keeper", reason="save memory")])
     )
 
     class _ActionSpecialist(BaseSpecialist):
@@ -1387,7 +1385,7 @@ async def test_run_post_turn_persists_coordinator_and_direct_word_keeper_results
 ):
     manager = _make_manager(mock_settings)
     manager.coordinator.plan_post_turn = AsyncMock(
-        return_value=_make_plan(post=[RoutingItem(name="learning_memory_keeper", reason="memory", chat_history_size=0)])
+        return_value=_make_plan(post=[RoutingItem(name="learning_memory_keeper", reason="memory")])
     )
 
     class _NamedSpecialist(BaseSpecialist):
@@ -1431,7 +1429,7 @@ async def test_run_post_turn_forces_learning_memory_keeper_history_to_zero(
     capture = _LearningMemoryKeeperCaptureSpecialist()
     manager.registry.register(capture, overwrite=True)
     manager.coordinator.plan_post_turn = AsyncMock(
-        return_value=_make_plan(post=[RoutingItem(name="learning_memory_keeper", reason="memory", chat_history_size=2)])
+        return_value=_make_plan(post=[RoutingItem(name="learning_memory_keeper", reason="memory")])
     )
 
     await manager.run_post_turn(
@@ -1470,7 +1468,7 @@ async def test_run_post_turn_forces_personal_memory_keeper_history_to_two(
     capture = _PersonalMemoryKeeperCaptureSpecialist()
     manager.registry.register(capture, overwrite=True)
     manager.coordinator.plan_post_turn = AsyncMock(
-        return_value=_make_plan(post=[RoutingItem(name="personal_memory_keeper", reason="memory", chat_history_size=0)])
+        return_value=_make_plan(post=[RoutingItem(name="personal_memory_keeper", reason="memory")])
     )
 
     history = [
@@ -1895,9 +1893,10 @@ async def test_specialist_history_is_truncated(
 ):
     manager = _make_manager(mock_settings)
     capture = _CaptureHistorySpecialist()
-    manager.registry.register(capture)
+    capture.name = "news_agent"
+    manager.registry.register(capture, overwrite=True)
     manager.coordinator.plan_pre_turn = AsyncMock(
-        return_value=_make_plan(pre=[RoutingItem(name="capture_history", reason="test", chat_history_size=1)])
+        return_value=_make_plan(pre=[RoutingItem(name="news_agent", reason="test")])
     )
 
     side_effect_service = MagicMock(spec=AgentSideEffectService)
@@ -1919,8 +1918,7 @@ async def test_specialist_history_is_truncated(
     )
 
     assert capture.seen_history is not None
-    assert len(capture.seen_history) == 1
-    assert capture.seen_history[0].content == "m3"
+    assert [message.content for message in capture.seen_history] == ["m2", "m3"]
 
 
 @pytest.mark.anyio
@@ -1929,9 +1927,10 @@ async def test_specialist_history_truncation_logs_warning(
 ):
     manager = _make_manager(mock_settings)
     capture = _CaptureHistorySpecialist()
-    manager.registry.register(capture)
+    capture.name = "news_agent"
+    manager.registry.register(capture, overwrite=True)
     manager.coordinator.plan_pre_turn = AsyncMock(
-        return_value=_make_plan(pre=[RoutingItem(name="capture_history", reason="test", chat_history_size=1)])
+        return_value=_make_plan(pre=[RoutingItem(name="news_agent", reason="test")])
     )
 
     side_effect_service = MagicMock(spec=AgentSideEffectService)
@@ -1953,7 +1952,7 @@ async def test_specialist_history_truncation_logs_warning(
             side_effect_service=side_effect_service,
         )
 
-    assert "specialist history truncated specialist=capture_history" in caplog.text
+    assert "specialist history truncated specialist=news_agent" in caplog.text
 
 
 @pytest.mark.anyio
@@ -1969,7 +1968,7 @@ async def test_word_keeper_receives_latest_teacher_message_without_history(
     capture.name = "word_keeper"
     manager.registry.register(capture, overwrite=True)
     manager.coordinator.plan_pre_turn = AsyncMock(
-        return_value=_make_plan(pre=[RoutingItem(name="word_keeper", reason="save words", chat_history_size=0)])
+        return_value=_make_plan(pre=[RoutingItem(name="word_keeper", reason="save words")])
     )
 
     history = [
@@ -2007,7 +2006,7 @@ async def test_word_keeper_does_not_receive_non_adjacent_teacher_message(
     capture.name = "word_keeper"
     manager.registry.register(capture, overwrite=True)
     manager.coordinator.plan_pre_turn = AsyncMock(
-        return_value=_make_plan(pre=[RoutingItem(name="word_keeper", reason="save words", chat_history_size=0)])
+        return_value=_make_plan(pre=[RoutingItem(name="word_keeper", reason="save words")])
     )
 
     history = [


### PR DESCRIPTION
## Summary
- make specialist history windows manager-owned policy instead of coordinator output
- remove `chat_history_size` from the routing contract and align tests with the new behavior
- update durable swarm architecture docs and retire the consumed todo note

## Validation
- uv run pytest tests/agents/test_coordinator.py tests/agents/test_manager.py -v
- make check-readiness
