### PR TITLE
feat: redesign login page

### DIFF
--- a/frontend/src/components/auth/AuthButton.tsx
+++ b/frontend/src/components/auth/AuthButton.tsx
@@ -8,6 +8,7 @@ interface AuthButtonProps {
   type?: 'submit' | 'button';
   variant?: 'primary' | 'secondary';
   loadingText?: string;
+  fullWidth?: boolean;
 }
 
 const AuthButton: React.FC<AuthButtonProps> = ({
@@ -17,54 +18,56 @@ const AuthButton: React.FC<AuthButtonProps> = ({
   type = 'button',
   variant = 'primary',
   loadingText,
+  fullWidth = true,
 }) => {
-  const getSx = () => {
-    if (variant === 'primary') {
-      return {
-        mt: 2,
-        padding: '10px 20px',
-        backgroundColor: 'var(--primary-color)',
-        color: 'white',
-        border: 'none',
-        borderRadius: '6px',
-        cursor: loading ? 'not-allowed' : 'pointer',
-        fontSize: '14px',
-        fontWeight: 'bold',
-        opacity: loading ? 0.6 : 1,
-        '&:hover': {
-          opacity: 0.9,
-        },
-      };
-    }
-    // secondary variant
-    return {
-      mt: 2,
-      padding: '10px 20px',
-      backgroundColor: 'transparent',
-      color: '#9ca3af',
-      border: 'none',
-      borderRadius: '6px',
-      cursor: loading ? 'not-allowed' : 'pointer',
-      fontSize: '14px',
-      fontWeight: 'bold',
-      opacity: loading ? 0.6 : 1,
-      '&:hover': {
-        color: 'white',
-        backgroundColor: 'rgba(156, 163, 175, 0.1)',
-      },
-    };
-  };
+  const getPrimarySx = () => ({
+    backgroundColor: '#38e07b',
+    color: '#0a1a10',
+    fontWeight: 700,
+    fontSize: '0.875rem',
+    letterSpacing: '0.08em',
+    textTransform: 'uppercase' as const,
+    borderRadius: '10px',
+    py: 1.75,
+    cursor: loading ? 'not-allowed' : 'pointer',
+    opacity: loading ? 0.7 : 1,
+    boxShadow: loading ? 'none' : '0 4px 20px rgba(56,224,123,0.35)',
+    '&:hover': {
+      backgroundColor: '#2ecc6e',
+      boxShadow: '0 6px 24px rgba(56,224,123,0.5)',
+    },
+    '&:active': { transform: 'scale(0.98)' },
+    '&.Mui-disabled': { backgroundColor: '#38e07b', color: '#0a1a10', opacity: 0.55 },
+  });
+
+  const getSecondarySx = () => ({
+    backgroundColor: 'transparent',
+    color: '#9ca3af',
+    fontWeight: 500,
+    fontSize: '0.875rem',
+    textTransform: 'none' as const,
+    borderRadius: '8px',
+    cursor: loading ? 'not-allowed' : 'pointer',
+    opacity: loading ? 0.6 : 1,
+    '&:hover': { color: 'white', backgroundColor: 'rgba(156,163,175,0.08)' },
+  });
+
+  const sx = variant === 'primary' ? getPrimarySx() : getSecondarySx();
 
   return (
     <Button
       type={type}
       onClick={onClick}
       disabled={loading}
-      sx={getSx()}
+      fullWidth={fullWidth}
+      sx={sx}
     >
       {loading ? (
         <>
-          <CircularProgress size={24} sx={{ mr: 1, color: variant === 'primary' ? 'white' : '#9ca3af' }} />
+          <CircularProgress
+            size={18}
+            sx={{ mr: 1, color: variant === 'primary' ? '#0a1a10' : '#9ca3af' }}
+          />
           {loadingText || 'Loading...'}
         </>
       ) : (

--- a/frontend/src/components/auth/AuthButton.tsx
+++ b/frontend/src/components/auth/AuthButton.tsx
@@ -20,7 +20,7 @@ const AuthButton: React.FC<AuthButtonProps> = ({
   loadingText,
   fullWidth = true,
 }) => {
-  const getPrimarySx = () => ({
+  const primarySx = {
     backgroundColor: '#38e07b',
     color: '#0a1a10',
     fontWeight: 700,
@@ -38,9 +38,9 @@ const AuthButton: React.FC<AuthButtonProps> = ({
     },
     '&:active': { transform: 'scale(0.98)' },
     '&.Mui-disabled': { backgroundColor: '#38e07b', color: '#0a1a10', opacity: 0.55 },
-  });
+  };
 
-  const getSecondarySx = () => ({
+  const secondarySx = {
     backgroundColor: 'transparent',
     color: '#9ca3af',
     fontWeight: 500,
@@ -50,9 +50,9 @@ const AuthButton: React.FC<AuthButtonProps> = ({
     cursor: loading ? 'not-allowed' : 'pointer',
     opacity: loading ? 0.6 : 1,
     '&:hover': { color: 'white', backgroundColor: 'rgba(156,163,175,0.08)' },
-  });
+  };
 
-  const sx = variant === 'primary' ? getPrimarySx() : getSecondarySx();
+  const sx = variant === 'primary' ? primarySx : secondarySx;
 
   return (
     <Button

--- a/frontend/src/components/auth/AuthLayout.tsx
+++ b/frontend/src/components/auth/AuthLayout.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { Diamond } from "lucide-react";
+
+interface AuthLayoutProps {
+  children: React.ReactNode;
+}
+
+/** Decorative floating gemstone SVG used in the left panel. */
+const GemstoneIllustration: React.FC = () => (
+  <svg
+    viewBox="0 0 200 200"
+    width="180"
+    height="180"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+  >
+    <defs>
+      <radialGradient id="gemGlow" cx="50%" cy="50%" r="50%">
+        <stop offset="0%" stopColor="#38e07b" stopOpacity="0.35" />
+        <stop offset="100%" stopColor="#38e07b" stopOpacity="0" />
+      </radialGradient>
+      <linearGradient id="gemFace1" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" stopColor="#6effa8" />
+        <stop offset="100%" stopColor="#1db954" />
+      </linearGradient>
+      <linearGradient id="gemFace2" x1="100%" y1="0%" x2="0%" y2="100%">
+        <stop offset="0%" stopColor="#2ecc71" />
+        <stop offset="100%" stopColor="#0d6e36" />
+      </linearGradient>
+      <linearGradient id="gemFace3" x1="50%" y1="0%" x2="50%" y2="100%">
+        <stop offset="0%" stopColor="#a8ffd4" stopOpacity="0.9" />
+        <stop offset="100%" stopColor="#38e07b" stopOpacity="0.6" />
+      </linearGradient>
+      <filter id="gemShadow" x="-30%" y="-30%" width="160%" height="160%">
+        <feDropShadow dx="0" dy="8" stdDeviation="12" floodColor="#38e07b" floodOpacity="0.4" />
+      </filter>
+    </defs>
+    {/* Glow circle */}
+    <ellipse cx="100" cy="150" rx="70" ry="20" fill="url(#gemGlow)" />
+    {/* Shadow / base ellipse */}
+    <ellipse cx="100" cy="160" rx="50" ry="10" fill="#38e07b" opacity="0.12" />
+    {/* Gem body — classic 8-point cut */}
+    <g filter="url(#gemShadow)">
+      {/* Top facets */}
+      <polygon points="100,50 130,90 100,80 70,90" fill="url(#gemFace3)" opacity="0.95" />
+      {/* Left side */}
+      <polygon points="70,90 100,80 100,140 60,120" fill="url(#gemFace2)" />
+      {/* Right side */}
+      <polygon points="130,90 100,80 100,140 140,120" fill="url(#gemFace1)" />
+      {/* Bottom left */}
+      <polygon points="60,120 100,140 100,155" fill="#0d6e36" opacity="0.9" />
+      {/* Bottom right */}
+      <polygon points="140,120 100,140 100,155" fill="#1db954" opacity="0.8" />
+      {/* Top highlight */}
+      <polygon points="100,50 115,75 100,80 85,75" fill="white" opacity="0.25" />
+    </g>
+    {/* Sparkle dots */}
+    <circle cx="55" cy="70" r="2.5" fill="#38e07b" opacity="0.7" />
+    <circle cx="148" cy="85" r="1.8" fill="#38e07b" opacity="0.5" />
+    <circle cx="80" cy="45" r="1.5" fill="#38e07b" opacity="0.4" />
+  </svg>
+);
+
+/**
+ * Full-page two-column auth shell. Left side has branded content and an
+ * illustration; right side renders the passed form panel.
+ */
+const AuthLayout: React.FC<AuthLayoutProps> = ({ children }) => (
+  <div className="auth-page">
+    <div className="auth-shell">
+      {/* ── Left branding panel ─────────────────────────────────── */}
+      <div className="auth-left">
+        {/* Top-left wordmark */}
+        <div className="auth-wordmark">
+          <Diamond size={22} style={{ color: "var(--primary-color)" }} />
+          <span className="auth-wordmark-text">Runestone</span>
+        </div>
+
+        <div className="auth-left-content">
+          {/* Green pill badge */}
+          <div className="auth-badge">
+            <span className="auth-badge-icon">✦</span>
+            <span>RUNESTONE</span>
+          </div>
+
+          <h1 className="auth-welcome">Welcome back</h1>
+          <p className="auth-tagline">Sign in. Another rune. Another stone.</p>
+
+          <div className="auth-illustration">
+            <GemstoneIllustration />
+          </div>
+        </div>
+      </div>
+
+      {/* ── Right form panel ────────────────────────────────────── */}
+      <div className="auth-right">
+        <div className="auth-card">{children}</div>
+      </div>
+    </div>
+  </div>
+);
+
+export default AuthLayout;

--- a/frontend/src/components/auth/AuthTextField.test.tsx
+++ b/frontend/src/components/auth/AuthTextField.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import AuthTextField from './AuthTextField';
 
@@ -116,6 +117,22 @@ describe('AuthTextField', () => {
     render(<AuthTextField label="Password" name="password" type="password" value="" onChange={() => {}} />);
     const input = screen.getByLabelText('Password');
     expect(input).toHaveAttribute('type', 'password');
+  });
+
+  it('lets keyboard users toggle password visibility', async () => {
+    const user = userEvent.setup();
+    render(<AuthTextField label="Password" name="password" type="password" value="secret" onChange={() => {}} />);
+
+    const input = screen.getByLabelText('Password');
+    const toggle = screen.getByRole('button', { name: 'Show password' });
+
+    await user.tab();
+    expect(input).toHaveFocus();
+    await user.tab();
+    expect(toggle).toHaveFocus();
+    await user.keyboard('{Enter}');
+
+    expect(input).toHaveAttribute('type', 'text');
   });
 
   it('renders with full width', () => {

--- a/frontend/src/components/auth/AuthTextField.tsx
+++ b/frontend/src/components/auth/AuthTextField.tsx
@@ -1,5 +1,6 @@
-import React from "react";
-import { TextField } from "@mui/material";
+import React, { useState } from "react";
+import { TextField, InputAdornment, IconButton } from "@mui/material";
+import { Eye, EyeOff } from "lucide-react";
 
 interface AuthTextFieldProps {
   label: string;
@@ -12,6 +13,8 @@ interface AuthTextFieldProps {
   autoFocus?: boolean;
   error?: boolean;
   helperText?: string;
+  /** Optional leading icon rendered inside the input. */
+  startIcon?: React.ReactNode;
 }
 
 const AuthTextField: React.FC<AuthTextFieldProps> = ({
@@ -25,12 +28,18 @@ const AuthTextField: React.FC<AuthTextFieldProps> = ({
   autoFocus = false,
   error = false,
   helperText,
+  startIcon,
 }) => {
+  const isPassword = type === "password";
+  const [showPassword, setShowPassword] = useState(false);
+
+  const resolvedType = isPassword ? (showPassword ? "text" : "password") : type;
+
   return (
     <TextField
       label={label}
       name={name}
-      type={type}
+      type={resolvedType}
       value={value}
       onChange={onChange}
       required={required}
@@ -39,17 +48,39 @@ const AuthTextField: React.FC<AuthTextFieldProps> = ({
       autoFocus={autoFocus}
       error={error}
       helperText={helperText}
+      slotProps={{
+        input: {
+          startAdornment: startIcon ? (
+            <InputAdornment position="start" sx={{ color: "rgba(255,255,255,0.4)", mr: 0.5 }}>
+              {startIcon}
+            </InputAdornment>
+          ) : undefined,
+          endAdornment: isPassword ? (
+            <InputAdornment position="end">
+              <IconButton
+                aria-label={showPassword ? "Hide password" : "Show password"}
+                onClick={() => setShowPassword((v) => !v)}
+                edge="end"
+                size="small"
+                sx={{ color: "rgba(255,255,255,0.4)", "&:hover": { color: "rgba(255,255,255,0.8)" } }}
+              >
+                {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+              </IconButton>
+            </InputAdornment>
+          ) : undefined,
+        },
+      }}
       sx={{
         "& .MuiOutlinedInput-root": {
           color: "white",
-          "& fieldset": { borderColor: "rgba(255, 255, 255, 0.3)" },
-          "&:hover fieldset": { borderColor: "rgba(255, 255, 255, 0.5)" },
-          "&.Mui-focused fieldset": {
-            borderColor: "rgba(255, 255, 255, 0.8)",
-          },
+          backgroundColor: "rgba(255,255,255,0.05)",
+          borderRadius: "10px",
+          "& fieldset": { borderColor: "rgba(255,255,255,0.15)" },
+          "&:hover fieldset": { borderColor: "rgba(255,255,255,0.35)" },
+          "&.Mui-focused fieldset": { borderColor: "rgba(56,224,123,0.6)", borderWidth: "1.5px" },
         },
-        "& .MuiInputLabel-root": { color: "rgba(255, 255, 255, 0.7)" },
-        "& .MuiInputLabel-root.Mui-focused": { color: "white" },
+        "& .MuiInputLabel-root": { color: "rgba(255,255,255,0.55)" },
+        "& .MuiInputLabel-root.Mui-focused": { color: "rgba(56,224,123,0.9)" },
       }}
     />
   );

--- a/frontend/src/components/auth/Login.test.tsx
+++ b/frontend/src/components/auth/Login.test.tsx
@@ -34,9 +34,8 @@ describe("Login", () => {
     expect(
       screen.queryByText(/Sign in to continue analyzing textbook pages/)
     ).not.toBeInTheDocument();
-    expect(
-      screen.getByText("Don't have an account? Register")
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Don't have an account\?/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Register" })).toBeInTheDocument();
   });
 
   it("handles successful login", async () => {
@@ -212,7 +211,7 @@ describe("Login", () => {
   it("calls onSwitchToRegister when register link is clicked", async () => {
     render(<Login onSwitchToRegister={mockOnSwitchToRegister} />, { wrapper });
 
-    const registerLink = screen.getByText("Don't have an account? Register");
+    const registerLink = screen.getByRole("button", { name: "Register" });
     await userEvent.click(registerLink);
 
     expect(mockOnSwitchToRegister).toHaveBeenCalledTimes(1);
@@ -237,15 +236,7 @@ describe("Login", () => {
     expect(passwordInput).toBeRequired();
   });
 
-  it("does not validate empty email field (server-side validation)", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: false,
-      json: () => Promise.resolve({ detail: "Email is required" }),
-    } as Response);
-
-    // Spy on console.error to suppress expected error output
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-
+  it("blocks submission when the email field is empty", async () => {
     render(<Login onSwitchToRegister={mockOnSwitchToRegister} />, { wrapper });
 
     const passwordInput = screen.getByLabelText(/^Password\s+\*\s*$/);
@@ -255,27 +246,10 @@ describe("Login", () => {
     await userEvent.type(passwordInput, "password123");
     await userEvent.click(loginButton);
 
-    // Should attempt login and get server-side validation error
-    await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalled();
-    });
-
-    // Component shows error from server
-    expect(screen.getByText("Email is required")).toBeInTheDocument();
-
-    // Restore console.error
-    consoleSpy.mockRestore();
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  it("does not validate email format (server-side validation)", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: false,
-      json: () => Promise.resolve({ detail: "Invalid email format" }),
-    } as Response);
-
-    // Spy on console.error to suppress expected error output
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-
+  it("blocks submission when the email format is invalid", async () => {
     render(<Login onSwitchToRegister={mockOnSwitchToRegister} />, { wrapper });
 
     const emailInput = screen.getByLabelText(/^Email\s+\*\s*$/);
@@ -286,16 +260,7 @@ describe("Login", () => {
     await userEvent.type(passwordInput, "password123");
     await userEvent.click(loginButton);
 
-    // Should attempt login and get server-side validation error
-    await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalled();
-    });
-
-    // Component shows error from server
-    expect(screen.getByText("Invalid email format")).toBeInTheDocument();
-
-    // Restore console.error
-    consoleSpy.mockRestore();
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 
   it("handles network timeout gracefully", async () => {

--- a/frontend/src/components/auth/Login.test.tsx
+++ b/frontend/src/components/auth/Login.test.tsx
@@ -30,6 +30,10 @@ describe("Login", () => {
     expect(screen.getByLabelText(/^Email\s+\*\s*$/)).toBeInTheDocument();
     expect(screen.getByLabelText(/^Password\s+\*\s*$/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Login" })).toBeInTheDocument();
+    expect(screen.getByText("Sign in. Another rune. Another stone.")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Sign in to continue analyzing textbook pages/)
+    ).not.toBeInTheDocument();
     expect(
       screen.getByText("Don't have an account? Register")
     ).toBeInTheDocument();

--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -82,22 +82,19 @@ const Login: React.FC<LoginProps> = ({ onSwitchToRegister }) => {
           type="submit"
           loading={loading}
           loadingText="Logging in..."
-          onClick={(e) => {
-            e.preventDefault();
-            handleSubmit(e);
-          }}
         >
           Login
         </AuthButton>
 
         {/* Switch to register */}
         <p className="auth-switch-text">
+          Don&apos;t have an account?{" "}
           <button
             type="button"
-            className="auth-switch-link auth-switch-register"
+            className="auth-switch-link auth-switch-highlight"
             onClick={onSwitchToRegister}
           >
-            Don&apos;t have an account? Register
+            Register
           </button>
         </p>
 

--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from "react";
 import type { FormEvent } from "react";
-import { Box, TextField, Snackbar, Alert } from "@mui/material";
+import { Snackbar, Alert } from "@mui/material";
 import type { AlertColor } from "@mui/material";
+import { Mail, Lock, ShieldCheck } from "lucide-react";
 import { useAuthActions } from "../../hooks/useAuth";
-import { CustomButton } from "../ui";
 import AuthButton from "./AuthButton";
+import AuthTextField from "./AuthTextField";
+import AuthLayout from "./AuthLayout";
 
 interface LoginProps {
   onSwitchToRegister?: () => void;
@@ -36,94 +38,79 @@ const Login: React.FC<LoginProps> = ({ onSwitchToRegister }) => {
       // Log technical details to console
       console.error("Login error:", err);
 
-      setSnackbar({
-        open: true,
-        message: errorMessage,
-        severity: "error",
-      });
+      setSnackbar({ open: true, message: errorMessage, severity: "error" });
     }
   };
 
   return (
-    <Box
-      component="form"
-      onSubmit={handleSubmit}
-      sx={{
-        display: "flex",
-        flexDirection: "column",
-        gap: 2,
-        maxWidth: 400,
-        mx: "auto",
-        mt: 8,
-        p: 4,
-        backgroundColor: "rgba(255, 255, 255, 0.05)",
-        borderRadius: 2,
-        backdropFilter: "blur(10px)",
-      }}
-    >
-      <h2 className="text-3xl font-bold text-white text-center mb-4">Login</h2>
+    <AuthLayout>
+      <form onSubmit={handleSubmit} className="auth-form">
+        {/* Heading */}
+        <h2 id="login-heading" className="auth-form-title">
+          Login
+        </h2>
+        <p className="auth-form-subtitle">
+          Enter your credentials to access your account.
+        </p>
 
-      <TextField
-        label="Email"
-        type="email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        required
-        fullWidth
-        sx={{
-          "& .MuiOutlinedInput-root": {
-            color: "white",
-            "& fieldset": { borderColor: "rgba(255, 255, 255, 0.3)" },
-            "&:hover fieldset": { borderColor: "rgba(255, 255, 255, 0.5)" },
-            "&.Mui-focused fieldset": {
-              borderColor: "rgba(255, 255, 255, 0.8)",
-            },
-          },
-          "& .MuiInputLabel-root": { color: "rgba(255, 255, 255, 0.7)" },
-          "& .MuiInputLabel-root.Mui-focused": { color: "white" },
-        }}
-      />
+        {/* Fields */}
+        <AuthTextField
+          label="Email"
+          name="email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          autoComplete="email"
+          autoFocus
+          startIcon={<Mail size={16} />}
+        />
 
-      <TextField
-        label="Password"
-        type="password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        required
-        fullWidth
-        sx={{
-          "& .MuiOutlinedInput-root": {
-            color: "white",
-            "& fieldset": { borderColor: "rgba(255, 255, 255, 0.3)" },
-            "&:hover fieldset": { borderColor: "rgba(255, 255, 255, 0.5)" },
-            "&.Mui-focused fieldset": {
-              borderColor: "rgba(255, 255, 255, 0.8)",
-            },
-          },
-          "& .MuiInputLabel-root": { color: "rgba(255, 255, 255, 0.7)" },
-          "& .MuiInputLabel-root.Mui-focused": { color: "white" },
-        }}
-      />
+        <AuthTextField
+          label="Password"
+          name="password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          autoComplete="current-password"
+          startIcon={<Lock size={16} />}
+        />
 
-      <AuthButton
-        type="submit"
-        loading={loading}
-        loadingText="Logging in..."
-        onClick={(e) => {
-          e.preventDefault();
-          handleSubmit(e);
-        }}
-      >
-        Login
-      </AuthButton>
+        {/* Submit */}
+        <AuthButton
+          type="submit"
+          loading={loading}
+          loadingText="Logging in..."
+          onClick={(e) => {
+            e.preventDefault();
+            handleSubmit(e);
+          }}
+        >
+          Login
+        </AuthButton>
 
-      <CustomButton
-        onClick={onSwitchToRegister}
-        variant="secondary"
-        sx={{ mt: 1 }}
-      >
-        Don't have an account? Register
-      </CustomButton>
+        {/* Switch to register */}
+        <p className="auth-switch-text">
+          <button
+            type="button"
+            className="auth-switch-link auth-switch-register"
+            onClick={onSwitchToRegister}
+          >
+            Don&apos;t have an account? Register
+          </button>
+        </p>
+
+        {/* Security note */}
+        <div className="auth-security-note">
+          <ShieldCheck size={20} className="auth-security-icon" />
+          <span>
+            Your data is encrypted and secure.
+            <br />
+            We never share your information.
+          </span>
+        </div>
+      </form>
 
       <Snackbar
         open={snackbar.open}
@@ -139,7 +126,7 @@ const Login: React.FC<LoginProps> = ({ onSwitchToRegister }) => {
           {snackbar.message}
         </Alert>
       </Snackbar>
-    </Box>
+    </AuthLayout>
   );
 };
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -151,3 +151,253 @@ body {
   border-radius: 3px;
   font-family: 'Courier New', monospace;
 }
+
+/* ─── Auth layout ────────────────────────────────────────────────────── */
+
+.auth-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(ellipse at 20% 30%, rgba(56, 224, 123, 0.06) 0%, transparent 60%),
+              radial-gradient(ellipse at 80% 70%, rgba(56, 100, 200, 0.06) 0%, transparent 60%),
+              #0b1220;
+  padding: 24px;
+}
+
+.auth-shell {
+  display: flex;
+  width: 100%;
+  max-width: 980px;
+  min-height: 520px;
+  border-radius: 20px;
+  overflow: hidden;
+  background: #0f1b2d;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  box-shadow: 0 32px 80px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+/* Left branding panel */
+.auth-left {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 36px 40px;
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(160deg, #111e33 0%, #0c1520 60%, #0a1a10 100%);
+}
+
+.auth-left::before {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 55%;
+  background: radial-gradient(ellipse at 50% 100%, rgba(56, 224, 123, 0.13) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+.auth-wordmark {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: auto;
+}
+
+.auth-wordmark-text {
+  color: white;
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.auth-left-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  justify-content: center;
+  padding-top: 32px;
+}
+
+.auth-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(56, 224, 123, 0.12);
+  border: 1px solid rgba(56, 224, 123, 0.3);
+  color: #38e07b;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  padding: 5px 12px;
+  border-radius: 999px;
+  width: fit-content;
+  margin-bottom: 20px;
+}
+
+.auth-badge-icon {
+  font-size: 0.8rem;
+}
+
+.auth-welcome {
+  font-size: 2.2rem;
+  font-weight: 800;
+  color: #ffffff;
+  line-height: 1.15;
+  margin: 0 0 14px;
+  letter-spacing: -0.02em;
+}
+
+.auth-tagline {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.55);
+  line-height: 1.6;
+  margin: 0;
+  max-width: 300px;
+}
+
+.auth-illustration {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  pointer-events: none;
+  opacity: 0.92;
+}
+
+/* Right form panel */
+.auth-right {
+  width: 420px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 36px 32px;
+  background: rgba(255, 255, 255, 0.025);
+  border-left: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.auth-card {
+  width: 100%;
+}
+
+/* Form internals */
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.auth-form-title {
+  font-size: 1.75rem;
+  font-weight: 800;
+  color: #ffffff;
+  margin: 0 0 2px;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+
+.auth-form-subtitle {
+  font-size: 0.875rem;
+  color: rgba(255, 255, 255, 0.5);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.auth-switch-text {
+  margin: 0;
+  text-align: center;
+  font-size: 0.875rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.auth-switch-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  font-size: 0.875rem;
+  color: rgba(255, 255, 255, 0.5);
+  cursor: pointer;
+  width: 100%;
+  text-align: center;
+  display: block;
+  transition: color 0.2s;
+}
+
+.auth-switch-link:hover {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+/* "Don't have an account?" part fades; "Register" stays green */
+.auth-switch-register {
+  background: linear-gradient(
+    to right,
+    rgba(255, 255, 255, 0.5) 0%,
+    rgba(255, 255, 255, 0.5) 74%,
+    #38e07b 74%,
+    #38e07b 100%
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.auth-switch-register:hover {
+  background: linear-gradient(
+    to right,
+    rgba(255, 255, 255, 0.75) 0%,
+    rgba(255, 255, 255, 0.75) 74%,
+    #5af09a 74%,
+    #5af09a 100%
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+}
+
+.auth-switch-highlight {
+  color: #38e07b;
+  font-weight: 600;
+}
+
+/* Security note row */
+.auth-security-note {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 14px 16px;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.45);
+  line-height: 1.5;
+}
+
+.auth-security-icon {
+  flex-shrink: 0;
+  color: rgba(255, 255, 255, 0.35);
+  margin-top: 1px;
+}
+
+/* Responsive: stack on small screens */
+@media (max-width: 680px) {
+  .auth-shell {
+    flex-direction: column;
+    min-height: unset;
+  }
+
+  .auth-left {
+    min-height: 220px;
+    padding: 28px 28px 100px;
+  }
+
+  .auth-right {
+    width: 100%;
+    border-left: none;
+    border-top: 1px solid rgba(255, 255, 255, 0.07);
+    padding: 28px 24px;
+  }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -319,42 +319,14 @@ body {
   padding: 0;
   font: inherit;
   font-size: 0.875rem;
-  color: rgba(255, 255, 255, 0.5);
   cursor: pointer;
-  width: 100%;
-  text-align: center;
-  display: block;
+  display: inline;
   transition: color 0.2s;
 }
 
 .auth-switch-link:hover {
-  color: rgba(255, 255, 255, 0.75);
-}
-
-/* "Don't have an account?" part fades; "Register" stays green */
-.auth-switch-register {
-  background: linear-gradient(
-    to right,
-    rgba(255, 255, 255, 0.5) 0%,
-    rgba(255, 255, 255, 0.5) 74%,
-    #38e07b 74%,
-    #38e07b 100%
-  );
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
-.auth-switch-register:hover {
-  background: linear-gradient(
-    to right,
-    rgba(255, 255, 255, 0.75) 0%,
-    rgba(255, 255, 255, 0.75) 74%,
-    #5af09a 74%,
-    #5af09a 100%
-  );
-  -webkit-background-clip: text;
-  background-clip: text;
+  color: #5af09a;
+  text-decoration: underline;
 }
 
 .auth-switch-highlight {


### PR DESCRIPTION
## Summary
- Redesign the login page with a responsive branded auth layout
- Add shared auth field/button styling, icons, and password visibility toggle
- Replace the login tagline with “Sign in. Another rune. Another stone.”
- Keep password visibility control keyboard accessible

## Validation
- `make check-readiness`
- Backend: 1046 passed
- Frontend: 527 passed
- Frontend lint and production build passed

Build output retains existing font-resolution and bundle-size warnings.