### PR TITLE
feat: add recall web controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ The API will be available at `http://localhost:8010` with the following endpoint
 - `GET /api/health`: Health check endpoint
 - `GET /api/grammar/search`: Search grammar cheatsheets (RAG)
 - `GET /api/grammar/page/{path}`: Read a specific grammar cheatsheet
+- `GET /api/recall`: Read the authenticated user's recall delivery status and ordered queue
+- `POST /api/recall/bump`: Replace the authenticated user's recall queue
+- `POST /api/recall/words/{vocabulary_id}/postpone`: Postpone a queued word
+- `POST /api/recall/words/{vocabulary_id}/remove`: Soft-remove a queued word from learning
 
 API documentation is available at `http://localhost:8010/docs`.
 
@@ -162,6 +166,7 @@ The web interface will be available at `http://localhost:5173` with the followin
 - **📊 Real-time Results**: View formatted analysis results with grammar explanations and vocabulary
 - **🔄 Processing Status**: Visual feedback during image processing
 - **🧠 Agent Memory Modal**: View, add, edit, and delete memory items by category
+- **🤖 Recall Queue Controls**: Inspect, refresh, postpone, and soft-remove selected recall words
 - **📱 Responsive Design**: Works on desktop and mobile devices
 
 **Quick Start:**
@@ -172,7 +177,8 @@ The web interface will be available at `http://localhost:5173` with the followin
 
 ### Rune Recall Feature
 
-Runestone includes a Telegram bot for automated vocabulary recall and command processing:
+Runestone includes a Telegram bot for automated vocabulary recall and command processing, plus an
+authenticated Recall page for managing the existing queue:
 
 ```bash
 # Start the Rune Recall Telegram Bot Worker
@@ -186,6 +192,16 @@ The bot will:
 - Poll for incoming commands every 5 seconds
 - Send vocabulary recall words at configured intervals (default: every 60 minutes)
 - Process user interactions via Telegram
+
+The web Recall page is available from the authenticated desktop and mobile navigation, or through
+the `?view=recall` deep link. It shows the ordered queue and read-only Telegram delivery status.
+Users can refresh the complete selection, postpone a queued word, or soft-remove a queued word from
+learning. Every mutation returns and displays the complete authoritative queue, including any
+replacement words selected during refill.
+
+Telegram remains responsible for activation. A user without recall state must link their Telegram
+username in Profile and send `/start` to the bot. The web page does not provide Start, Stop, or
+delivery-toggle controls, but queue management remains available when delivery is disabled.
 
 ### Vocabulary Priority Model
 

--- a/docs/recall-state-persistence.md
+++ b/docs/recall-state-persistence.md
@@ -41,23 +41,120 @@ Application DTOs still expose the queue as `daily_selection`, but this is a tran
 The queue and `next_word_index` are related but stored separately: queue rows define the stable order, and the cursor points into that order.
 
 - Creating the first selection replaces the queue and resets the cursor to `0`.
-- `/bump_words` raises every active queued word's numeric learning-priority value, replaces the
-  complete queue, and resets the cursor to `0`. The priority changes and queue replacement share
-  the command transaction, and bumped vocabulary IDs remain excluded from that replacement.
+- `/bump_words` and the web `Refresh selection` action invoke the same service workflow. While the
+  recall-state row is locked, the workflow raises every active queued word's numeric
+  learning-priority value, excludes the bumped vocabulary IDs from replacement selection, replaces
+  the complete queue, and resets the cursor to `0`. The priority changes and queue replacement
+  share the outer command or request transaction.
 - Topping up a short queue appends new words after the existing positions and leaves the cursor unchanged.
 - A successful Telegram send updates the vocabulary learning timestamp and advances `next_word_index` in one database commit. Cursor advancement wraps against the authoritative queue length, so a completed cycle resumes at position `0`. A failed send rolls back and does not advance it.
 - Removing, postponing, or discarding an invalid word compacts the remaining positions to `0..n-1` and adjusts the cursor to keep the same logical next word where possible.
 - If a removed word was before the cursor, the cursor decreases by one. If the queue becomes empty, or the adjusted cursor is outside the shortened queue, it resets to `0`.
-- `/remove` also marks the vocabulary item as not being learned and lowers its learning priority.
-- `/postpone` raises the numeric learning-priority value, removes the item from the current queue, and then attempts to backfill the queue to `WORDS_PER_DAY`. The postponed vocabulary ID is excluded from that refill, so a small candidate pool cannot immediately select the same word again.
+- Telegram `/remove` and the web `Remove from learning` action also mark the vocabulary item as not being learned and lower its learning priority. The web action requires the vocabulary item to belong to the current queue.
+- Telegram `/postpone` and the web `Postpone` action raise the numeric learning-priority value, remove the item from the current queue, and then attempt to backfill the queue to `WORDS_PER_DAY`. The postponed vocabulary ID is excluded from that refill, so a small candidate pool cannot immediately select the same word again. The web action requires the vocabulary item to belong to the current queue.
 
 The backend vocabulary endpoints temporarily own cross-service orchestration for both hard deletion and explicit soft deletion (`PUT` with `in_learn=false`). They ask `RecallService` to remove and compact any queued reference, ask `VocabularyService` to mutate the owned vocabulary item, then ask `RecallService` to refill a shortened queue when removal changed it. All phases use the same request-scoped session and are committed once; a not-found item, vocabulary-update failure, or refill failure rolls back the complete operation. Deleting vocabulary for a user without recall state remains a normal vocabulary mutation without queue maintenance.
 
 For example, given queue `[A, B, C]` with `next_word_index = 2`, removing `A` produces `[B, C]` with `next_word_index = 1`, so `C` remains the next word. Removing `C` instead produces `[A, B]` with `next_word_index = 0` because the previous cursor is now past the end.
 
+## Authenticated Web Controls
+
+The authenticated web application exposes Recall as a top-level desktop and mobile view. The
+`?view=recall` deep link restores the page and sets the document title to `Runestone | Recall`. It
+shows the ordered queue, available word text, translation and example fields, selected-word count,
+and whether Telegram delivery is enabled. Delivery status is read-only: the page does not start,
+stop, enable, or disable delivery.
+
+A user without `recall_user_states` receives an unconfigured empty response and is directed to link
+their Telegram username in Profile and send `/start` to the bot. This Telegram interaction
+establishes the destination chat id; the web transport does not attempt to create that linkage.
+Existing queues remain manageable when delivery is disabled or outside the worker's delivery
+window.
+
+The recall API is mounted at `/api/recall` and always derives ownership from the authenticated
+Runestone user:
+
+| Method | Path | Behavior |
+| --- | --- | --- |
+| `GET` | `/api/recall` | Return configuration state, read-only delivery status, and the ordered queue. |
+| `POST` | `/api/recall/bump` | Deprioritize the locked active queue, replace it through the shared bump workflow, reset the cursor, and return the complete queue. |
+| `POST` | `/api/recall/words/{vocabulary_id}/postpone` | Require current queue membership, remove and deprioritize the item, exclude it from immediate best-effort refill, and return the complete queue. |
+| `POST` | `/api/recall/words/{vocabulary_id}/remove` | Require current queue membership, set the owned item to `in_learn=false` and lowest urgency, best-effort refill the shortened queue, and return the complete queue. |
+
+Every route derives the user id from the authenticated account; the client cannot supply a user id
+or Telegram username. Word mutations accept the vocabulary id returned by the queue response,
+rather than resolving display text. A configured response has this shape:
+
+```json
+{
+  "configured": true,
+  "delivery_enabled": true,
+  "words": [
+    {
+      "id": 42,
+      "word_phrase": "kontanter",
+      "translation": "cash",
+      "example_phrase": "Jag betalar med kontanter."
+    }
+  ]
+}
+```
+
+`translation` and `example_phrase` are nullable. The response does not expose the user id, Telegram
+username, chat id, or next-word cursor. An unconfigured read returns `200` with:
+
+```json
+{
+  "configured": false,
+  "delivery_enabled": false,
+  "words": []
+}
+```
+
+Unauthenticated and inactive-account requests retain the shared `401`/`403` authentication
+behavior. Mutations return `409` with Telegram onboarding guidance until recall is configured; a
+vocabulary id outside the authenticated user's current queue returns `404` without revealing
+another user's ownership. Unexpected read failures return `500` with the generic detail
+`Failed to retrieve recall selection`. Mutation, commit, and other unexpected failures roll back
+and return `500` with the generic detail `Failed to update recall selection` while the server logs
+diagnostic context.
+
+The frontend does not update the queue optimistically. It replaces local state with the complete
+successful mutation response because postpone and remove may refill with different words and bump
+replaces the entire queue. Failed mutations preserve the previously loaded queue and show an error;
+successful mutations show action feedback. The hook prevents duplicate mutation submissions, and
+the page disables conflicting actions while showing progress for the active full-queue or row
+operation. Loading, initial-load error with retry, unconfigured, configured-empty, and populated
+states are distinct.
+
+Refresh, postpone, and remove are compact icon-only actions with accessible names. Per-word names
+include the displayed word, such as `Postpone kontanter` and `Remove kontanter from learning`.
+Their hover and keyboard-focus tooltips explain the complete outcomes:
+
+- `Refresh selection: lowers the priority of all current words and replaces the selection.`
+- `Postpone: moves this word out of the current selection and lowers its recall priority.`
+- `Remove from learning: stops learning this word and removes it from the current selection.`
+
+The actions do not use confirmation dialogs or separate information buttons. The
+`Remove from learning` action is a soft deactivation, not the hard delete exposed by the Vocabulary
+API.
+
+The first web version does not edit vocabulary fields, reorder the queue, expose or set the
+next-delivery cursor, or synchronize an already-open page through real-time push updates. Telegram
+commands and scheduled delivery can therefore change the authoritative queue after a page has
+loaded; the next web load or successful mutation response refreshes the displayed snapshot.
+
 ## Transactions And Concurrency
 
 Repository mutations lock the relevant `recall_user_states` row with `SELECT ... FOR UPDATE` before replacing or appending queue rows, removing a word, or changing the cursor. Full queue replacement, queue compaction, cursor adjustment, and related vocabulary changes are performed through the same request- or job-scoped database session.
+
+Each authenticated web mutation owns one request transaction. The endpoint calls the shared
+`RecallService` workflow with services and repositories assembled over the same request-scoped
+`AsyncSession`, commits exactly once after queue invariants and the response snapshot are prepared,
+and rolls back every domain or persistence failure. The recall-state row lock serializes web
+mutations with Telegram commands and scheduled delivery for that user. A web mutation may briefly
+wait while scheduled delivery holds the same user's lock across a Telegram send. The read endpoint
+is transaction-neutral and does not commit.
 
 Scheduled delivery checks its configured delivery window before opening a database session. It then enumerates active recall states in one short-lived session and opens a fresh session for each user delivery. Within that per-user session, delivery acquires the user's recall-state row lock before validating enabled state and chat linkage, loading or creating the selection, resolving invalid items, and choosing the next word. After taking that lock it performs a fresh scalar read of `users.active`, bypassing any identity-mapped `User` object, so deactivation between enumeration and delivery prevents the send. The lock remains held across the injected Telegram send callback. This serializes delivery with other workers and queue mutations for that user, preventing two replicas from sending from the same cursor concurrently, while a failed transaction for one user cannot contaminate later users. Invalid-item cleanup and an exhausted selection's replacement also occur while holding that lock.
 
@@ -77,6 +174,7 @@ The main consumers are:
 
 - `TelegramCommandProcessor` for `/start`, `/stop`, `/state`, `/postpone`, `/remove`, and `/bump_words`;
 - `TelegramRecallDelivery` for scheduled queue selection and delivery;
+- the authenticated recall API for read-only delivery status and queue management by Runestone user id;
 - request-scoped `ChatService`, which loads ordered recall words through its injected `RecallService` and supplies the resulting plain list to `AgentsManager` for Teacher context. This separate best-effort read path rolls back only after a database failure because `ChatService` intentionally continues on the same request session; successful reads remain transaction-neutral.
 
 Telegram polling fetches and sorts updates before opening a database session. Structurally irrelevant updates are acknowledged without a session. Each relevant update opens at most one fresh transaction provider, applies the command, and prepares immutable outgoing message data. Only after the provider commits and closes does the processor call Telegram. Successful reads and mutations do not commit or roll back independently.

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -55,8 +55,14 @@ vi.mock('./hooks/useImageProcessing', () => ({
   }),
 }));
 
+vi.mock('./components/RecallView', () => ({
+  default: () => <div>Recall test view</div>,
+}));
+
 describe('App', () => {
   beforeEach(() => {
+    window.history.replaceState({}, '', '/');
+    document.title = '';
     mockProcessImage.mockClear();
     mockRecognizeImage.mockClear();
     mockAnalyzeText.mockClear();
@@ -87,6 +93,36 @@ describe('App', () => {
 
     // Check for header element
     expect(document.querySelector('header')).toBeInTheDocument();
+  });
+
+  it('restores the Recall deep link and updates the document title', async () => {
+    window.history.replaceState({}, '', '/?view=recall');
+
+    render(<App />, { wrapper });
+
+    expect(screen.getByText('Recall test view')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(document.title).toBe('Runestone | Recall');
+    });
+    expect(window.location.search).toBe('?view=recall');
+  });
+
+  it('shows Recall in desktop and mobile navigation and navigates to it', async () => {
+    const user = userEvent.setup();
+    render(<App />, { wrapper });
+
+    expect(screen.getAllByText('Recall')).toHaveLength(2);
+    await user.click(screen.getAllByRole('button', { name: 'Recall' })[0]);
+
+    expect(screen.getByText('Recall test view')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(window.location.search).toBe('?view=recall');
+      expect(document.title).toBe('Runestone | Recall');
+    });
+    expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+      'runestone_current_view',
+      'recall'
+    );
   });
 
   it('should call only recognizeImage when analysis mode is set to OCR only', async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import Header from "./components/Header";
 import FileUpload from "./components/FileUpload";
 import ResultsDisplay from "./components/ResultsDisplay";
 import VocabularyView from "./components/VocabularyView";
+import RecallView from "./components/RecallView";
 import GrammarView from "./components/GrammarView";
 import ChatView from "./components/ChatView";
 import Login from "./components/auth/Login";
@@ -13,20 +14,28 @@ import { BrainCircuit } from "lucide-react";
 import { Box } from "@mui/material";
 import { useAuth } from "./context/AuthContext";
 import { analyzerShellGradients, buildAnalyzerShellSx } from "./components/ui";
+import type { ViewType } from "./types/navigation";
 
 type AuthView = "login" | "register";
-type ViewType = "analyzer" | "vocabulary" | "grammar" | "chat" | "profile";
 
 const VIEW_NAMES: Record<ViewType, string> = {
   analyzer: "Analyzer",
   vocabulary: "Vocabulary",
+  recall: "Recall",
   grammar: "Grammar",
   chat: "Chat",
   profile: "Profile",
 };
 
 const STORAGE_KEY = "runestone_current_view";
-const VALID_VIEWS: ViewType[] = ["analyzer", "vocabulary", "grammar", "chat", "profile"];
+const VALID_VIEWS: ViewType[] = [
+  "analyzer",
+  "vocabulary",
+  "recall",
+  "grammar",
+  "chat",
+  "profile",
+];
 
 function getInitialView(): ViewType {
   if (typeof window === "undefined") return "analyzer";
@@ -212,6 +221,8 @@ function App() {
               </>
             ) : currentView === "vocabulary" ? (
               <VocabularyView />
+            ) : currentView === "recall" ? (
+              <RecallView />
             ) : currentView === "grammar" ? (
               <GrammarView />
             ) : currentView === "chat" ? (

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import { Typography, Box, IconButton, Drawer, List, ListItem, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
-import { Diamond, User, LogOut, MessageCircle, BookOpen, ScrollText, Menu, X } from 'lucide-react';
+import { Diamond, User, LogOut, MessageCircle, BookOpen, ScrollText, Menu, X, Repeat2 } from 'lucide-react';
 import { CustomButton } from './ui';
 import { useAuth } from '../context/AuthContext';
+import type { ViewType } from '../types/navigation';
 
 interface HeaderProps {
-  currentView: 'analyzer' | 'vocabulary' | 'grammar' | 'chat' | 'profile';
-  onViewChange: (view: 'analyzer' | 'vocabulary' | 'grammar' | 'chat' | 'profile') => void;
+  currentView: ViewType;
+  onViewChange: (view: ViewType) => void;
 }
 
 const Header: React.FC<HeaderProps> = ({ currentView, onViewChange }) => {
@@ -17,11 +18,10 @@ const Header: React.FC<HeaderProps> = ({ currentView, onViewChange }) => {
     setMobileOpen(!mobileOpen);
   };
 
-  type ViewType = 'analyzer' | 'vocabulary' | 'grammar' | 'chat' | 'profile';
-
   const navItems: { id: ViewType; label: string; icon: React.ReactNode }[] = [
     { id: 'analyzer', label: 'Analyzer', icon: <Diamond size={20} /> },
     { id: 'vocabulary', label: 'Vocabulary', icon: <BookOpen size={20} /> },
+    { id: 'recall', label: 'Recall', icon: <Repeat2 size={20} /> },
     { id: 'grammar', label: 'Grammar', icon: <ScrollText size={20} /> },
     { id: 'chat', label: 'Chat', icon: <MessageCircle size={20} /> },
     { id: 'profile', label: 'Profile', icon: <User size={20} /> },

--- a/frontend/src/components/RecallView.test.tsx
+++ b/frontend/src/components/RecallView.test.tsx
@@ -1,0 +1,279 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import RecallView from "./RecallView";
+
+const mockUseRecall = vi.hoisted(() => vi.fn());
+
+vi.mock("../hooks/useRecall", () => ({
+  useRecall: mockUseRecall,
+}));
+
+const refreshSelection = vi.fn().mockResolvedValue(undefined);
+const postponeWord = vi.fn().mockResolvedValue(undefined);
+const removeWord = vi.fn().mockResolvedValue(undefined);
+const refetch = vi.fn().mockResolvedValue(undefined);
+const clearFeedback = vi.fn();
+
+const populatedRecall = {
+  configured: true,
+  delivery_enabled: true,
+  words: [
+    {
+      id: 42,
+      word_phrase: "kontanter",
+      translation: "cash",
+      example_phrase: "Jag betalar med kontanter.",
+    },
+    {
+      id: 43,
+      word_phrase: "lagom",
+    },
+  ],
+};
+
+const setHookState = (overrides: Record<string, unknown> = {}) => {
+  mockUseRecall.mockReturnValue({
+    recall: populatedRecall,
+    loading: false,
+    pendingAction: null,
+    error: null,
+    success: null,
+    refetch,
+    refreshSelection,
+    postponeWord,
+    removeWord,
+    clearFeedback,
+    ...overrides,
+  });
+};
+
+describe("RecallView", () => {
+  beforeEach(() => {
+    setHookState();
+  });
+
+  it("renders loading and initial error states with a retry action", async () => {
+    const user = userEvent.setup();
+    setHookState({ recall: null, loading: true });
+    const { rerender } = render(<RecallView />);
+
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    expect(screen.getByText("Loading recall selection…")).toBeInTheDocument();
+
+    setHookState({
+      recall: null,
+      loading: false,
+      error: "Recall request failed",
+    });
+    rerender(<RecallView />);
+
+    expect(screen.getByText("Recall request failed")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+    expect(refetch).toHaveBeenCalledOnce();
+  });
+
+  it("renders the unconfigured onboarding state", () => {
+    setHookState({
+      recall: {
+        configured: false,
+        delivery_enabled: false,
+        words: [],
+      },
+    });
+
+    render(<RecallView />);
+
+    expect(screen.getByText("Recall is not configured")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Link your Telegram username in Profile/)
+    ).toBeInTheDocument();
+    expect(screen.getByText("/start")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Refresh selection" })
+    ).toBeDisabled();
+  });
+
+  it("renders the configured empty state and leaves refresh available", () => {
+    setHookState({
+      recall: {
+        configured: true,
+        delivery_enabled: false,
+        words: [],
+      },
+    });
+
+    render(<RecallView />);
+
+    expect(screen.getByText("No words selected")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "There are currently no eligible vocabulary words for recall."
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText("Delivery disabled")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Refresh selection" })
+    ).toBeEnabled();
+  });
+
+  it("keeps queue management available while delivery is disabled", () => {
+    setHookState({
+      recall: {
+        ...populatedRecall,
+        delivery_enabled: false,
+      },
+    });
+
+    render(<RecallView />);
+
+    expect(screen.getByText("Delivery disabled")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Refresh selection" })
+    ).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: "Postpone kontanter" })
+    ).toBeEnabled();
+    expect(
+      screen.getByRole("button", {
+        name: "Remove kontanter from learning",
+      })
+    ).toBeEnabled();
+  });
+
+  it("renders an ordered queue with optional word details", () => {
+    render(<RecallView />);
+
+    expect(screen.getByRole("list")).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+    expect(screen.getByText("kontanter")).toBeInTheDocument();
+    expect(screen.getByText("cash")).toBeInTheDocument();
+    expect(
+      screen.getByText("Jag betalar med kontanter.")
+    ).toBeInTheDocument();
+    expect(screen.getByText("lagom")).toBeInTheDocument();
+  });
+
+  it("uses compact accessible action buttons with the agreed tooltips", async () => {
+    const user = userEvent.setup();
+    render(<RecallView />);
+
+    const refresh = screen.getByRole("button", {
+      name: "Refresh selection",
+    });
+    const postpone = screen.getByRole("button", {
+      name: "Postpone kontanter",
+    });
+    const remove = screen.getByRole("button", {
+      name: "Remove kontanter from learning",
+    });
+
+    expect(refresh).toHaveTextContent("");
+    expect(postpone).toHaveTextContent("");
+    expect(remove).toHaveTextContent("");
+
+    await user.hover(refresh);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Refresh selection: lowers the priority of all current words and replaces the selection."
+    );
+    await user.unhover(refresh);
+
+    await user.hover(postpone);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Postpone: moves this word out of the current selection and lowers its recall priority."
+    );
+    await user.unhover(postpone);
+
+    await user.hover(remove);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Remove from learning: stops learning this word and removes it from the current selection."
+    );
+  });
+
+  it("exposes every action tooltip to keyboard focus", async () => {
+    const user = userEvent.setup();
+    render(<RecallView />);
+
+    const actions = [
+      {
+        button: screen.getByRole("button", {
+          name: "Refresh selection",
+        }),
+        tooltip:
+          "Refresh selection: lowers the priority of all current words and replaces the selection.",
+      },
+      {
+        button: screen.getByRole("button", {
+          name: "Postpone kontanter",
+        }),
+        tooltip:
+          "Postpone: moves this word out of the current selection and lowers its recall priority.",
+      },
+      {
+        button: screen.getByRole("button", {
+          name: "Remove kontanter from learning",
+        }),
+        tooltip:
+          "Remove from learning: stops learning this word and removes it from the current selection.",
+      },
+    ];
+
+    for (const action of actions) {
+      await user.tab();
+      expect(action.button).toHaveFocus();
+      expect(
+        await screen.findByRole("tooltip", { name: action.tooltip })
+      ).toBeVisible();
+    }
+  });
+
+  it("dispatches refresh, postpone, and remove without confirmation", async () => {
+    const user = userEvent.setup();
+    const confirmSpy = vi.spyOn(window, "confirm");
+    render(<RecallView />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Refresh selection" })
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Postpone kontanter" })
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: "Remove kontanter from learning",
+      })
+    );
+
+    expect(refreshSelection).toHaveBeenCalledOnce();
+    expect(postponeWord).toHaveBeenCalledWith(42, "kontanter");
+    expect(removeWord).toHaveBeenCalledWith(42, "kontanter");
+    expect(confirmSpy).not.toHaveBeenCalled();
+  });
+
+  it("shows row-level progress and disables conflicting actions", () => {
+    setHookState({
+      pendingAction: { type: "postpone", vocabularyId: 42 },
+    });
+
+    render(<RecallView />);
+
+    expect(
+      screen.getByRole("button", { name: "Postpone kontanter" })
+    ).toContainElement(screen.getByRole("progressbar"));
+    for (const button of screen.getAllByRole("button")) {
+      expect(button).toBeDisabled();
+    }
+  });
+
+  it("renders mutation feedback", () => {
+    setHookState({
+      success: "Recall selection refreshed.",
+      error: "Could not postpone word",
+    });
+
+    render(<RecallView />);
+
+    expect(screen.getByText("Recall selection refreshed.")).toBeInTheDocument();
+    expect(screen.getByText("Could not postpone word")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/RecallView.tsx
+++ b/frontend/src/components/RecallView.tsx
@@ -1,0 +1,351 @@
+import {
+  Box,
+  Chip,
+  CircularProgress,
+  IconButton,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  InfoOutlined,
+  Refresh,
+  RemoveCircleOutline,
+  Snooze,
+} from "@mui/icons-material";
+import { useRecall } from "../hooks/useRecall";
+import {
+  CustomButton,
+  ErrorAlert,
+  SectionTitle,
+  Snackbar,
+  SurfaceCard,
+} from "./ui";
+
+const REFRESH_TOOLTIP =
+  "Refresh selection: lowers the priority of all current words and replaces the selection.";
+const POSTPONE_TOOLTIP =
+  "Postpone: moves this word out of the current selection and lowers its recall priority.";
+const REMOVE_TOOLTIP =
+  "Remove from learning: stops learning this word and removes it from the current selection.";
+
+const RecallView = () => {
+  const {
+    recall,
+    loading,
+    pendingAction,
+    error,
+    success,
+    refetch,
+    refreshSelection,
+    postponeWord,
+    removeWord,
+    clearFeedback,
+  } = useRecall();
+  const isMutating = pendingAction !== null;
+
+  if (loading && recall === null) {
+    return (
+      <Box
+        sx={{
+          minHeight: 320,
+          display: "grid",
+          placeItems: "center",
+          color: "rgba(255,255,255,0.7)",
+        }}
+      >
+        <Stack alignItems="center" spacing={2}>
+          <CircularProgress size={32} />
+          <Typography>Loading recall selection…</Typography>
+        </Stack>
+      </Box>
+    );
+  }
+
+  if (recall === null) {
+    return (
+      <Box sx={{ py: 8 }}>
+        <ErrorAlert
+          message={error ?? "Failed to load recall selection"}
+          sx={{ mt: 0 }}
+        />
+        <Box sx={{ mt: 2, textAlign: "center" }}>
+          <CustomButton
+            type="button"
+            variant="secondary"
+            onClick={() => void refetch()}
+          >
+            Try again
+          </CustomButton>
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ py: { xs: 4, md: 8 }, maxWidth: 900, mx: "auto" }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 2,
+          mb: 4,
+        }}
+      >
+        <Box>
+          <SectionTitle marginBottom={0}>Recall</SectionTitle>
+          <Typography sx={{ color: "rgba(255,255,255,0.64)", mt: 0.75 }}>
+            Manage the words selected for your next recall sessions.
+          </Typography>
+        </Box>
+        <Tooltip title={REFRESH_TOOLTIP}>
+          <span>
+            <IconButton
+              aria-label="Refresh selection"
+              disabled={!recall.configured || isMutating}
+              onClick={() => void refreshSelection()}
+              sx={{
+                color: "rgba(255,255,255,0.78)",
+                border: "1px solid rgba(255,255,255,0.16)",
+                borderRadius: 1.5,
+                "&:hover": {
+                  color: "white",
+                  borderColor: "rgba(255,255,255,0.36)",
+                  backgroundColor: "rgba(255,255,255,0.07)",
+                },
+              }}
+            >
+              {pendingAction?.type === "refresh" ? (
+                <CircularProgress size={20} color="inherit" />
+              ) : (
+                <Refresh fontSize="small" />
+              )}
+            </IconButton>
+          </span>
+        </Tooltip>
+      </Box>
+
+      <SurfaceCard padding={2} sx={{ mb: 2 }}>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 2,
+            flexWrap: "wrap",
+          }}
+        >
+          <Box>
+            <Typography
+              sx={{
+                color: "rgba(255,255,255,0.62)",
+                fontSize: "0.76rem",
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+              }}
+            >
+              Selected words
+            </Typography>
+            <Typography sx={{ color: "white", fontSize: "1.7rem", fontWeight: 700 }}>
+              {recall.words.length}
+            </Typography>
+          </Box>
+          <Chip
+            label={
+              recall.configured
+                ? `Delivery ${recall.delivery_enabled ? "enabled" : "disabled"}`
+                : "Not configured"
+            }
+            color={
+              recall.configured && recall.delivery_enabled
+                ? "success"
+                : "default"
+            }
+            variant="outlined"
+            sx={{
+              color: "rgba(255,255,255,0.78)",
+              borderColor:
+                recall.configured && recall.delivery_enabled
+                  ? "rgba(52,211,153,0.55)"
+                  : "rgba(255,255,255,0.2)",
+            }}
+          />
+        </Box>
+      </SurfaceCard>
+
+      {!recall.configured ? (
+        <SurfaceCard>
+          <Stack alignItems="center" spacing={1.5} sx={{ textAlign: "center", py: 3 }}>
+            <InfoOutlined sx={{ color: "rgba(255,255,255,0.58)", fontSize: 34 }} />
+            <Typography variant="h6" sx={{ color: "white", fontWeight: 650 }}>
+              Recall is not configured
+            </Typography>
+            <Typography sx={{ color: "rgba(255,255,255,0.66)", maxWidth: 560 }}>
+              Link your Telegram username in Profile, then send{" "}
+              <Box component="span" sx={{ color: "white", fontFamily: "monospace" }}>
+                /start
+              </Box>{" "}
+              to the bot to create your recall selection.
+            </Typography>
+          </Stack>
+        </SurfaceCard>
+      ) : recall.words.length === 0 ? (
+        <SurfaceCard>
+          <Stack alignItems="center" spacing={1} sx={{ textAlign: "center", py: 3 }}>
+            <Typography variant="h6" sx={{ color: "white", fontWeight: 650 }}>
+              No words selected
+            </Typography>
+            <Typography sx={{ color: "rgba(255,255,255,0.66)" }}>
+              There are currently no eligible vocabulary words for recall.
+            </Typography>
+          </Stack>
+        </SurfaceCard>
+      ) : (
+        <Stack component="ol" spacing={1.25} sx={{ listStyle: "none", p: 0, m: 0 }}>
+          {recall.words.map((word, index) => {
+            const postponing =
+              pendingAction?.type === "postpone" &&
+              pendingAction.vocabularyId === word.id;
+            const removing =
+              pendingAction?.type === "remove" &&
+              pendingAction.vocabularyId === word.id;
+
+            return (
+              <Box
+                component="li"
+                key={word.id}
+              >
+                <SurfaceCard
+                  padding={2}
+                  sx={{
+                    "&:hover": { borderColor: "rgba(255,255,255,0.18)" },
+                  }}
+                >
+                  <Box
+                    sx={{
+                      display: "grid",
+                      gridTemplateColumns: "auto minmax(0, 1fr) auto",
+                      gap: { xs: 1.25, sm: 2 },
+                      alignItems: "center",
+                    }}
+                  >
+                    <Typography
+                      aria-hidden="true"
+                      sx={{
+                        color: "rgba(255,255,255,0.38)",
+                        fontSize: "0.78rem",
+                        fontWeight: 700,
+                        width: 20,
+                        textAlign: "center",
+                      }}
+                    >
+                      {index + 1}
+                    </Typography>
+                    <Box sx={{ minWidth: 0 }}>
+                      <Typography
+                        sx={{
+                          color: "white",
+                          fontWeight: 700,
+                          fontSize: { xs: "1rem", sm: "1.08rem" },
+                          overflowWrap: "anywhere",
+                        }}
+                      >
+                        {word.word_phrase}
+                      </Typography>
+                      {word.translation && (
+                        <Typography
+                          sx={{
+                            color: "rgba(255,255,255,0.7)",
+                            mt: 0.25,
+                            overflowWrap: "anywhere",
+                          }}
+                        >
+                          {word.translation}
+                        </Typography>
+                      )}
+                      {word.example_phrase && (
+                        <Typography
+                          sx={{
+                            color: "rgba(255,255,255,0.5)",
+                            fontSize: "0.86rem",
+                            fontStyle: "italic",
+                            mt: 0.75,
+                            overflowWrap: "anywhere",
+                          }}
+                        >
+                          {word.example_phrase}
+                        </Typography>
+                      )}
+                    </Box>
+                    <Stack direction="row" spacing={0.5}>
+                      <Tooltip title={POSTPONE_TOOLTIP}>
+                        <span>
+                          <IconButton
+                            aria-label={`Postpone ${word.word_phrase}`}
+                            disabled={isMutating}
+                            onClick={() =>
+                              void postponeWord(word.id, word.word_phrase)
+                            }
+                            size="small"
+                            sx={{ color: "rgba(255,255,255,0.68)" }}
+                          >
+                            {postponing ? (
+                              <CircularProgress size={18} color="inherit" />
+                            ) : (
+                              <Snooze fontSize="small" />
+                            )}
+                          </IconButton>
+                        </span>
+                      </Tooltip>
+                      <Tooltip title={REMOVE_TOOLTIP}>
+                        <span>
+                          <IconButton
+                            aria-label={`Remove ${word.word_phrase} from learning`}
+                            disabled={isMutating}
+                            onClick={() =>
+                              void removeWord(word.id, word.word_phrase)
+                            }
+                            size="small"
+                            sx={{
+                              color: "rgba(248,113,113,0.72)",
+                              "&:hover": {
+                                color: "#fca5a5",
+                                backgroundColor: "rgba(239,68,68,0.1)",
+                              },
+                            }}
+                          >
+                            {removing ? (
+                              <CircularProgress size={18} color="inherit" />
+                            ) : (
+                              <RemoveCircleOutline fontSize="small" />
+                            )}
+                          </IconButton>
+                        </span>
+                      </Tooltip>
+                    </Stack>
+                  </Box>
+                </SurfaceCard>
+              </Box>
+            );
+          })}
+        </Stack>
+      )}
+
+      <Snackbar
+        open={Boolean(success)}
+        message={success ?? ""}
+        severity="success"
+        onClose={clearFeedback}
+      />
+      <Snackbar
+        open={Boolean(error)}
+        message={error ?? ""}
+        severity="error"
+        onClose={clearFeedback}
+      />
+    </Box>
+  );
+};
+
+export default RecallView;

--- a/frontend/src/hooks/useRecall.test.ts
+++ b/frontend/src/hooks/useRecall.test.ts
@@ -1,0 +1,188 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useRecall } from "./useRecall";
+import type { RecallState } from "../types/recall";
+
+const { mockGet, mockPost } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPost: vi.fn(),
+}));
+
+vi.mock("../utils/api", () => ({
+  useApi: () => ({
+    get: mockGet,
+    post: mockPost,
+  }),
+}));
+
+const initialRecall: RecallState = {
+  configured: true,
+  delivery_enabled: true,
+  words: [
+    {
+      id: 1,
+      word_phrase: "hej",
+      translation: "hello",
+      example_phrase: null,
+    },
+  ],
+};
+
+const createDeferred = <T,>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+};
+
+describe("useRecall", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockPost.mockReset();
+    mockGet.mockResolvedValue(initialRecall);
+  });
+
+  it("loads the current recall state on mount", async () => {
+    const { result } = renderHook(() => useRecall());
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockGet).toHaveBeenCalledOnce();
+    expect(mockGet).toHaveBeenCalledWith("/api/recall");
+    expect(result.current.recall).toEqual(initialRecall);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("reports an initial load error and can retry", async () => {
+    mockGet
+      .mockRejectedValueOnce(new Error("Network unavailable"))
+      .mockResolvedValueOnce(initialRecall);
+    const { result } = renderHook(() => useRecall());
+
+    await waitFor(() => {
+      expect(result.current.error).toBe("Network unavailable");
+    });
+    expect(result.current.recall).toBeNull();
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(result.current.recall).toEqual(initialRecall);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("replaces the full queue with the authoritative postpone response", async () => {
+    const authoritativeResponse: RecallState = {
+      ...initialRecall,
+      words: [
+        {
+          id: 8,
+          word_phrase: "ersättare",
+          translation: "replacement",
+          example_phrase: null,
+        },
+      ],
+    };
+    mockPost.mockResolvedValueOnce(authoritativeResponse);
+    const { result } = renderHook(() => useRecall());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.postponeWord(1, "hej");
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/api/recall/words/1/postpone"
+    );
+    expect(result.current.recall).toEqual(authoritativeResponse);
+    expect(result.current.success).toBe("Postponed hej.");
+    expect(result.current.pendingAction).toBeNull();
+  });
+
+  it("sends the selected vocabulary id when removing from learning", async () => {
+    const authoritativeResponse: RecallState = {
+      ...initialRecall,
+      words: [],
+    };
+    mockPost.mockResolvedValueOnce(authoritativeResponse);
+    const { result } = renderHook(() => useRecall());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.removeWord(1, "hej");
+    });
+
+    expect(mockPost).toHaveBeenCalledWith("/api/recall/words/1/remove");
+    expect(result.current.recall).toEqual(authoritativeResponse);
+    expect(result.current.success).toBe("Removed hej from learning.");
+  });
+
+  it("retains the current queue when a mutation fails", async () => {
+    mockPost.mockRejectedValueOnce(new Error("Word is no longer selected"));
+    const { result } = renderHook(() => useRecall());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.postponeWord(1, "hej");
+    });
+
+    expect(result.current.recall).toEqual(initialRecall);
+    expect(result.current.error).toBe("Word is no longer selected");
+    expect(result.current.success).toBeNull();
+    expect(result.current.pendingAction).toBeNull();
+  });
+
+  it("prevents duplicate mutation submissions", async () => {
+    const deferred = createDeferred<RecallState>();
+    mockPost.mockReturnValueOnce(deferred.promise);
+    const { result } = renderHook(() => useRecall());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let firstRequest!: Promise<void>;
+    act(() => {
+      firstRequest = result.current.refreshSelection();
+      void result.current.refreshSelection();
+    });
+
+    expect(mockPost).toHaveBeenCalledOnce();
+    expect(mockPost).toHaveBeenCalledWith("/api/recall/bump");
+    expect(result.current.pendingAction).toEqual({ type: "refresh" });
+
+    deferred.resolve({
+      ...initialRecall,
+      words: [{ id: 9, word_phrase: "ny" }],
+    });
+    await act(async () => {
+      await firstRequest;
+    });
+
+    expect(result.current.recall?.words).toEqual([
+      { id: 9, word_phrase: "ny" },
+    ]);
+    expect(result.current.pendingAction).toBeNull();
+  });
+
+  it("clears feedback explicitly", async () => {
+    mockPost.mockRejectedValueOnce(new Error("Mutation failed"));
+    const { result } = renderHook(() => useRecall());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await act(async () => {
+      await result.current.refreshSelection();
+    });
+
+    act(() => {
+      result.current.clearFeedback();
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.success).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useRecall.ts
+++ b/frontend/src/hooks/useRecall.ts
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type {
+  RecallPendingAction,
+  RecallState,
+} from "../types/recall";
+import { useApi } from "../utils/api";
+
+interface UseRecallReturn {
+  recall: RecallState | null;
+  loading: boolean;
+  pendingAction: RecallPendingAction | null;
+  error: string | null;
+  success: string | null;
+  refetch: () => Promise<void>;
+  refreshSelection: () => Promise<void>;
+  postponeWord: (vocabularyId: number, wordPhrase: string) => Promise<void>;
+  removeWord: (vocabularyId: number, wordPhrase: string) => Promise<void>;
+  clearFeedback: () => void;
+}
+
+export const useRecall = (): UseRecallReturn => {
+  const [recall, setRecall] = useState<RecallState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [pendingAction, setPendingAction] =
+    useState<RecallPendingAction | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const mutationInFlightRef = useRef(false);
+  const hasFetchedRef = useRef(false);
+  const { get, post } = useApi();
+
+  const refetch = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setRecall(await get<RecallState>("/api/recall"));
+    } catch (requestError) {
+      setError(
+        requestError instanceof Error
+          ? requestError.message
+          : "Failed to load recall selection"
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [get]);
+
+  useEffect(() => {
+    if (hasFetchedRef.current) {
+      return;
+    }
+    hasFetchedRef.current = true;
+    void refetch();
+  }, [refetch]);
+
+  const runMutation = useCallback(
+    async (
+      endpoint: string,
+      action: RecallPendingAction,
+      successMessage: string
+    ) => {
+      if (mutationInFlightRef.current) {
+        return;
+      }
+
+      mutationInFlightRef.current = true;
+      setPendingAction(action);
+      setError(null);
+      setSuccess(null);
+      try {
+        const updated = await post<RecallState>(endpoint);
+        setRecall(updated);
+        setSuccess(successMessage);
+      } catch (requestError) {
+        setError(
+          requestError instanceof Error
+            ? requestError.message
+            : "Failed to update recall selection"
+        );
+      } finally {
+        mutationInFlightRef.current = false;
+        setPendingAction(null);
+      }
+    },
+    [post]
+  );
+
+  const refreshSelection = useCallback(
+    () =>
+      runMutation(
+        "/api/recall/bump",
+        { type: "refresh" },
+        "Recall selection refreshed."
+      ),
+    [runMutation]
+  );
+
+  const postponeWord = useCallback(
+    (vocabularyId: number, wordPhrase: string) =>
+      runMutation(
+        `/api/recall/words/${vocabularyId}/postpone`,
+        { type: "postpone", vocabularyId },
+        `Postponed ${wordPhrase}.`
+      ),
+    [runMutation]
+  );
+
+  const removeWord = useCallback(
+    (vocabularyId: number, wordPhrase: string) =>
+      runMutation(
+        `/api/recall/words/${vocabularyId}/remove`,
+        { type: "remove", vocabularyId },
+        `Removed ${wordPhrase} from learning.`
+      ),
+    [runMutation]
+  );
+
+  const clearFeedback = useCallback(() => {
+    setError(null);
+    setSuccess(null);
+  }, []);
+
+  return {
+    recall,
+    loading,
+    pendingAction,
+    error,
+    success,
+    refetch,
+    refreshSelection,
+    postponeWord,
+    removeWord,
+    clearFeedback,
+  };
+};

--- a/frontend/src/types/navigation.ts
+++ b/frontend/src/types/navigation.ts
@@ -1,0 +1,7 @@
+export type ViewType =
+  | "analyzer"
+  | "vocabulary"
+  | "recall"
+  | "grammar"
+  | "chat"
+  | "profile";

--- a/frontend/src/types/recall.ts
+++ b/frontend/src/types/recall.ts
@@ -1,0 +1,17 @@
+export interface RecallWord {
+  id: number;
+  word_phrase: string;
+  translation?: string | null;
+  example_phrase?: string | null;
+}
+
+export interface RecallState {
+  configured: boolean;
+  delivery_enabled: boolean;
+  words: RecallWord[];
+}
+
+export type RecallPendingAction =
+  | { type: "refresh" }
+  | { type: "postpone"; vocabularyId: number }
+  | { type: "remove"; vocabularyId: number };

--- a/integration_tests/recall/run_recall_workflow.py
+++ b/integration_tests/recall/run_recall_workflow.py
@@ -1371,7 +1371,7 @@ class RecallWorkflow:
 
         state = await self.reset()
         old_ids = {word.id for word in state.daily_selection}
-        bumped = await self.recall_service.bump_words(state)
+        bumped = await self.recall_service.bump_words(state.user_id)
         await self.db.commit()
         require(old_ids.isdisjoint({word.id for word in bumped.daily_selection}), "full bump reused old IDs")
         require(len(bumped.daily_selection) == settings.words_per_day, "full bump did not fill queue")
@@ -1381,7 +1381,7 @@ class RecallWorkflow:
         current_ids = {word.id for word in state.daily_selection}
         alternatives = {self.fixtures[settings.words_per_day].id, self.fixtures[settings.words_per_day + 1].id}
         await self.configure_fixture_pool(alternatives, cooldown_ids=current_ids)
-        insufficient = await self.recall_service.bump_words(state)
+        insufficient = await self.recall_service.bump_words(state.user_id)
         await self.db.commit()
         require(
             {word.id for word in insufficient.daily_selection} == alternatives,
@@ -1391,7 +1391,7 @@ class RecallWorkflow:
 
         state = await self.reset()
         await self.configure_fixture_pool(set(), cooldown_ids={fixture.id for fixture in self.fixtures})
-        empty = await self.recall_service.bump_words(state)
+        empty = await self.recall_service.bump_words(state.user_id)
         await self.db.commit()
         require(not empty.daily_selection and empty.next_word_index == 0, "no-alternative bump did not clear queue")
         await self.reset()
@@ -1809,7 +1809,7 @@ class RecallWorkflow:
         current = await self.recall_repository.get_recall_state(self.user_id)
         require(current is not None, "state disappeared before created-word bump")
         await self.configure_fixture_pool(set(), cooldown_ids={fixture.id for fixture in self.fixtures})
-        created_selection = await self.recall_service.bump_words(current)
+        created_selection = await self.recall_service.bump_words(current.user_id)
         await self.db.commit()
         require(
             [word.id for word in created_selection.daily_selection] == [created_id],
@@ -1939,7 +1939,7 @@ class RecallWorkflow:
         async def bump(service: RecallService, _vocabulary: VocabularyService) -> None:
             state = await service.recall_repository.get_recall_state(self.user_id)
             require(state is not None, "bump race state missing")
-            await service.bump_words(state)
+            await service.bump_words(state.user_id)
 
         async def postpone(service: RecallService, _vocabulary: VocabularyService) -> None:
             state = await service.recall_repository.get_recall_state(self.user_id)

--- a/src/runestone/api/main.py
+++ b/src/runestone/api/main.py
@@ -18,6 +18,7 @@ from runestone.api.chat_endpoints import router as chat_router
 from runestone.api.endpoints import grammar_router
 from runestone.api.endpoints import router as api_router
 from runestone.api.memory_endpoints import router as memory_router
+from runestone.api.recall_endpoints import router as recall_router
 from runestone.api.user_endpoints import router as user_router
 from runestone.config import settings
 from runestone.core.clients.voice.voice_factory import (
@@ -139,6 +140,13 @@ def create_application() -> FastAPI:
         memory_router,
         prefix="/api",
         tags=["memory"],
+    )
+
+    # Include recall router
+    app.include_router(
+        recall_router,
+        prefix="/api/recall",
+        tags=["recall"],
     )
 
     return app

--- a/src/runestone/api/recall_endpoints.py
+++ b/src/runestone/api/recall_endpoints.py
@@ -1,0 +1,166 @@
+"""Authenticated web transport for recall queue management."""
+
+from collections.abc import Awaitable, Callable
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from runestone.api.recall_schemas import RecallResponse, RecallWordResponse
+from runestone.auth.dependencies import get_current_user
+from runestone.core.exceptions import RecallOperationError, RecallQueueWordNotFoundError, RecallStateNotFoundError
+from runestone.core.logging_config import get_logger
+from runestone.db.database import get_db
+from runestone.db.models import User
+from runestone.dependencies import get_recall_service
+from runestone.recall.service import RecallService
+from runestone.recall.types import RecallState
+
+router = APIRouter()
+logger = get_logger(__name__)
+
+RECALL_NOT_CONFIGURED_DETAIL = (
+    "Recall is not configured. Link your Telegram username in Profile and send /start to the bot."
+)
+
+
+def _response_from_state(state: RecallState | None) -> RecallResponse:
+    if state is None:
+        return RecallResponse(configured=False, delivery_enabled=False, words=[])
+
+    return RecallResponse(
+        configured=True,
+        delivery_enabled=state.is_enabled,
+        words=[
+            RecallWordResponse(
+                id=word.id,
+                word_phrase=word.word_phrase,
+                translation=word.translation,
+                example_phrase=word.example_phrase,
+            )
+            for word in state.daily_selection
+        ],
+    )
+
+
+async def _run_mutation(
+    operation: Callable[[], Awaitable[RecallState]],
+    *,
+    db: AsyncSession,
+    user_id: int,
+) -> RecallResponse:
+    """Run one recall mutation in the request-owned transaction."""
+    try:
+        state = await operation()
+        response = _response_from_state(state)
+        await db.commit()
+        return response
+    except RecallStateNotFoundError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail=RECALL_NOT_CONFIGURED_DETAIL) from exc
+    except RecallQueueWordNotFoundError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=404, detail=exc.message) from exc
+    except RecallOperationError as exc:
+        await db.rollback()
+        logger.error("Recall mutation failed for user %s: %s", user_id, exc.details or exc.message)
+        raise HTTPException(status_code=500, detail="Failed to update recall selection") from exc
+    except Exception as exc:
+        await db.rollback()
+        logger.exception("Unexpected recall mutation failure for user %s", user_id)
+        raise HTTPException(status_code=500, detail="Failed to update recall selection") from exc
+
+
+@router.get(
+    "",
+    response_model=RecallResponse,
+    responses={
+        200: {"description": "Recall configuration and queue retrieved"},
+        401: {"description": "Not authenticated"},
+        403: {"description": "Inactive account"},
+    },
+)
+async def get_recall(
+    current_user: Annotated[User, Depends(get_current_user)],
+    service: Annotated[RecallService, Depends(get_recall_service)],
+) -> RecallResponse:
+    """Return the authenticated user's recall configuration and ordered queue."""
+    try:
+        return _response_from_state(await service.get_state_for_user(current_user.id))
+    except RecallOperationError as exc:
+        logger.error("Failed to load recall state for user %s: %s", current_user.id, exc.details or exc.message)
+        raise HTTPException(status_code=500, detail="Failed to retrieve recall selection") from exc
+    except Exception as exc:
+        logger.exception("Unexpected recall read failure for user %s", current_user.id)
+        raise HTTPException(status_code=500, detail="Failed to retrieve recall selection") from exc
+
+
+@router.post(
+    "/bump",
+    response_model=RecallResponse,
+    responses={
+        200: {"description": "Recall queue refreshed"},
+        404: {"description": "Queue word not found"},
+        409: {"description": "Recall not configured"},
+    },
+)
+async def bump_recall(
+    current_user: Annotated[User, Depends(get_current_user)],
+    service: Annotated[RecallService, Depends(get_recall_service)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> RecallResponse:
+    """Apply the shared bump workflow and return the authoritative queue."""
+
+    async def operation() -> RecallState:
+        state = await service.get_state_for_user(current_user.id)
+        if state is None:
+            raise RecallStateNotFoundError(current_user.id)
+        return await service.bump_words(state)
+
+    return await _run_mutation(operation, db=db, user_id=current_user.id)
+
+
+@router.post(
+    "/words/{vocabulary_id}/postpone",
+    response_model=RecallResponse,
+    responses={
+        200: {"description": "Recall word postponed"},
+        404: {"description": "Queue word not found"},
+        409: {"description": "Recall not configured"},
+    },
+)
+async def postpone_recall_word(
+    vocabulary_id: int,
+    current_user: Annotated[User, Depends(get_current_user)],
+    service: Annotated[RecallService, Depends(get_recall_service)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> RecallResponse:
+    """Postpone one current queue word by its owned vocabulary id."""
+    return await _run_mutation(
+        lambda: service.postpone_queue_word(current_user.id, vocabulary_id),
+        db=db,
+        user_id=current_user.id,
+    )
+
+
+@router.post(
+    "/words/{vocabulary_id}/remove",
+    response_model=RecallResponse,
+    responses={
+        200: {"description": "Recall word removed from learning"},
+        404: {"description": "Queue word not found"},
+        409: {"description": "Recall not configured"},
+    },
+)
+async def remove_recall_word(
+    vocabulary_id: int,
+    current_user: Annotated[User, Depends(get_current_user)],
+    service: Annotated[RecallService, Depends(get_recall_service)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> RecallResponse:
+    """Soft-deactivate one current queue word by its owned vocabulary id."""
+    return await _run_mutation(
+        lambda: service.remove_queue_word_from_learning(current_user.id, vocabulary_id),
+        db=db,
+        user_id=current_user.id,
+    )

--- a/src/runestone/api/recall_endpoints.py
+++ b/src/runestone/api/recall_endpoints.py
@@ -112,10 +112,7 @@ async def bump_recall(
     """Apply the shared bump workflow and return the authoritative queue."""
 
     async def operation() -> RecallState:
-        state = await service.get_state_for_user(current_user.id)
-        if state is None:
-            raise RecallStateNotFoundError(current_user.id)
-        return await service.bump_words(state)
+        return await service.bump_words(current_user.id)
 
     return await _run_mutation(operation, db=db, user_id=current_user.id)
 

--- a/src/runestone/api/recall_schemas.py
+++ b/src/runestone/api/recall_schemas.py
@@ -1,0 +1,20 @@
+"""API schemas for authenticated recall queue management."""
+
+from pydantic import BaseModel
+
+
+class RecallWordResponse(BaseModel):
+    """Display-safe vocabulary data for one recall queue entry."""
+
+    id: int
+    word_phrase: str
+    translation: str | None = None
+    example_phrase: str | None = None
+
+
+class RecallResponse(BaseModel):
+    """Current recall configuration and ordered queue."""
+
+    configured: bool
+    delivery_enabled: bool
+    words: list[RecallWordResponse]

--- a/src/runestone/core/exceptions.py
+++ b/src/runestone/core/exceptions.py
@@ -110,6 +110,17 @@ class WordNotInSelectionError(RecallOperationError):
         super().__init__(message=f"Word '{word_phrase}' not in today's selection")
 
 
+class RecallQueueWordNotFoundError(RecallOperationError):
+    """Raised when a vocabulary id is not in the current recall queue."""
+
+    def __init__(self, vocabulary_id: int):
+        self.vocabulary_id = vocabulary_id
+        super().__init__(
+            message="Recall word not found in current selection",
+            details=f"Vocabulary item {vocabulary_id} is not in the current recall queue",
+        )
+
+
 class UserNotFoundError(ValueError):
     """Raised when a user is not found."""
 

--- a/src/runestone/recall/service.py
+++ b/src/runestone/recall/service.py
@@ -7,6 +7,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from runestone.core.exceptions import (
     RecallOperationError,
+    RecallQueueWordNotFoundError,
     RecallStateNotFoundError,
     TelegramUsernameConflictError,
     WordNotFoundError,
@@ -62,6 +63,13 @@ class RecallService:
             self._disabled_state_for_user(user) if state is None else self._with_username(state, user.telegram_username)
         )
         return normalized_username, result
+
+    async def get_state_for_user(self, user_id: int) -> RecallState | None:
+        """Load one user's persisted recall state without transport-specific identity."""
+        try:
+            return await self.recall_repository.get_recall_state(user_id)
+        except SQLAlchemyError as exc:
+            raise RecallOperationError("Failed to load recall state", details=str(exc)) from exc
 
     async def enable_for_username(self, username: str, chat_id: int) -> RecallEnableResult:
         """Enable recall and report whether it was already enabled before this request."""
@@ -168,19 +176,53 @@ class RecallService:
             if not matching_word:
                 raise WordNotFoundError(word_phrase, state.telegram_username or str(state.user_id))
 
-            # 2. Mutate vocabulary and queue in the shared transaction, then refill.
-            await self.vocabulary_service.deactivate_item(matching_word.id, state.user_id)
-            removal = await self.recall_repository.remove_queue_word(state.user_id, matching_word.id)
-            refreshed = await self.recall_repository.get_recall_state(state.user_id) or current_state
-            if removal is not None:
-                refreshed = await self._maintain_daily_selection_locked(refreshed)
-
-            # The outer transaction provider commits after every invariant is restored.
-            return refreshed
+            # 2. Reuse the id-based mutation while the same aggregate lock is held.
+            return await self._remove_word_from_learning_locked(
+                current_state,
+                matching_word.id,
+                require_queue_membership=False,
+            )
         except (RecallOperationError, WordNotFoundError):
             raise
         except Exception as exc:
             raise RecallOperationError("Failed to remove word from recall state", details=str(exc)) from exc
+
+    async def remove_queue_word_from_learning(self, user_id: int, vocabulary_id: int) -> RecallState:
+        """Soft-deactivate one current queue item and restore queue invariants."""
+        try:
+            current_state = await self.recall_repository.get_recall_state_for_update(user_id)
+            if current_state is None:
+                raise RecallStateNotFoundError(user_id)
+            return await self._remove_word_from_learning_locked(
+                current_state,
+                vocabulary_id,
+                require_queue_membership=True,
+            )
+        except RecallOperationError:
+            raise
+        except Exception as exc:
+            raise RecallOperationError("Failed to remove word from recall state", details=str(exc)) from exc
+
+    async def _remove_word_from_learning_locked(
+        self,
+        state: RecallState,
+        vocabulary_id: int,
+        *,
+        require_queue_membership: bool,
+    ) -> RecallState:
+        """Deactivate one owned item while the caller holds its recall-state lock."""
+        if require_queue_membership and not self._queue_contains(state, vocabulary_id):
+            raise RecallQueueWordNotFoundError(vocabulary_id)
+
+        # Mutate vocabulary and queue in the shared transaction, then refill.
+        await self.vocabulary_service.deactivate_item(vocabulary_id, state.user_id)
+        removal = await self.recall_repository.remove_queue_word(state.user_id, vocabulary_id)
+        refreshed = await self.recall_repository.get_recall_state(state.user_id) or state
+        if removal is not None:
+            refreshed = await self._maintain_daily_selection_locked(refreshed)
+
+        # The outer transaction boundary commits after every invariant is restored.
+        return refreshed
 
     async def postpone_word(self, state: RecallState, word_phrase: str) -> RecallState:
         """Remove one queue item, lower its urgency, and backfill the queue."""
@@ -193,24 +235,46 @@ class RecallService:
             if not matching_word:
                 raise WordNotInSelectionError(word_phrase)
 
-            # 2. Require queue membership before lowering urgency, then refill.
-            removal = await self.recall_repository.remove_queue_word(state.user_id, matching_word.id)
-            if removal is None:
+            if not self._queue_contains(current_state, matching_word.id):
                 raise WordNotInSelectionError(word_phrase)
 
-            await self.vocabulary_service.deprioritize_item(matching_word.id, state.user_id)
-            refreshed = await self.recall_repository.get_recall_state(state.user_id) or current_state
-            refreshed = await self._maintain_daily_selection_locked(
-                refreshed,
-                additionally_excluded_word_ids=[matching_word.id],
-            )
-
-            # The outer transaction provider persists vocabulary, queue, cursor, and refill together.
-            return refreshed
+            # 2. Reuse the id-based mutation while the same aggregate lock is held.
+            return await self._postpone_queue_word_locked(current_state, matching_word.id)
         except RecallOperationError:
             raise
         except Exception as exc:
             raise RecallOperationError("Failed to postpone word", details=str(exc)) from exc
+
+    async def postpone_queue_word(self, user_id: int, vocabulary_id: int) -> RecallState:
+        """Postpone one current queue item selected by owned vocabulary id."""
+        try:
+            current_state = await self.recall_repository.get_recall_state_for_update(user_id)
+            if current_state is None:
+                raise RecallStateNotFoundError(user_id)
+            if not self._queue_contains(current_state, vocabulary_id):
+                raise RecallQueueWordNotFoundError(vocabulary_id)
+            return await self._postpone_queue_word_locked(current_state, vocabulary_id)
+        except RecallOperationError:
+            raise
+        except Exception as exc:
+            raise RecallOperationError("Failed to postpone word", details=str(exc)) from exc
+
+    async def _postpone_queue_word_locked(self, state: RecallState, vocabulary_id: int) -> RecallState:
+        """Postpone one queue item while the caller holds its recall-state lock."""
+        # Remove first so a missing membership cannot lower vocabulary priority.
+        removal = await self.recall_repository.remove_queue_word(state.user_id, vocabulary_id)
+        if removal is None:
+            raise RecallQueueWordNotFoundError(vocabulary_id)
+
+        await self.vocabulary_service.deprioritize_item(vocabulary_id, state.user_id)
+        refreshed = await self.recall_repository.get_recall_state(state.user_id) or state
+        refreshed = await self._maintain_daily_selection_locked(
+            refreshed,
+            additionally_excluded_word_ids=[vocabulary_id],
+        )
+
+        # The outer transaction boundary persists priority, queue, cursor, and refill together.
+        return refreshed
 
     async def load_current_recall_words(self, user_id: int) -> list[str]:
         """Best-effort load of the current ordered recall queue for Teacher context."""
@@ -381,6 +445,11 @@ class RecallService:
         if not state.daily_selection:
             return None
         return state.daily_selection[state.next_word_index % len(state.daily_selection)]
+
+    @staticmethod
+    def _queue_contains(state: RecallState, vocabulary_id: int) -> bool:
+        """Return whether an owned vocabulary id belongs to the loaded queue."""
+        return any(word.id == vocabulary_id for word in state.daily_selection)
 
     @staticmethod
     def _merge_queue_metadata(queued_word: RecallQueueWord, validated_word: RecallQueueWord) -> RecallQueueWord:

--- a/src/runestone/recall/service.py
+++ b/src/runestone/recall/service.py
@@ -128,14 +128,14 @@ class RecallService:
         except SQLAlchemyError as exc:
             raise RecallOperationError("Failed to load active recall states", details=str(exc)) from exc
 
-    async def bump_words(self, state: RecallState) -> RecallState:
-        """Deprioritize and replace the current queue with a fresh selection."""
+    async def bump_words(self, user_id: int) -> RecallState:
+        """Deprioritize and replace a user's current queue with a fresh selection."""
         try:
-            current_state = await self.recall_repository.get_recall_state_for_update(state.user_id)
+            current_state = await self.recall_repository.get_recall_state_for_update(user_id)
             if current_state is None:
-                raise RecallStateNotFoundError(state.user_id)
+                raise RecallStateNotFoundError(user_id)
             bumped_word_ids = [word.id for word in current_state.daily_selection]
-            await self.vocabulary_service.deprioritize_items(bumped_word_ids, state.user_id)
+            await self.vocabulary_service.deprioritize_items(bumped_word_ids, user_id)
             refreshed = await self._bump_words_locked(current_state)
             return refreshed
         except RecallOperationError:

--- a/src/runestone/telegram/commands.py
+++ b/src/runestone/telegram/commands.py
@@ -244,7 +244,7 @@ class TelegramCommandProcessor:
         state: RecallState,
         chat_id: int,
     ) -> CommandOutcome:
-        refreshed = await recall_service.bump_words(state)
+        refreshed = await recall_service.bump_words(state.user_id)
         count = len(refreshed.daily_selection)
         if count:
             return self._message_outcome(

--- a/tests/api/test_recall_endpoints.py
+++ b/tests/api/test_recall_endpoints.py
@@ -1,0 +1,262 @@
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from runestone.core.exceptions import RecallOperationError, RecallQueueWordNotFoundError, RecallStateNotFoundError
+from runestone.recall.types import RecallQueueWord, RecallState
+
+
+def make_state(
+    *,
+    user_id: int = 1,
+    is_enabled: bool = True,
+    words: list[RecallQueueWord] | None = None,
+) -> RecallState:
+    return RecallState(
+        user_id=user_id,
+        telegram_username="linked",
+        telegram_chat_id=123,
+        is_enabled=is_enabled,
+        next_word_index=2,
+        daily_selection=words or [],
+    )
+
+
+@pytest.fixture
+async def recall_api_client(client_with_overrides):
+    service = Mock()
+    service.get_state_for_user = AsyncMock()
+    service.bump_words = AsyncMock()
+    service.postpone_queue_word = AsyncMock()
+    service.remove_queue_word_from_learning = AsyncMock()
+
+    db = Mock(spec=AsyncSession)
+    db.commit = AsyncMock()
+    db.rollback = AsyncMock()
+
+    async def override_db():
+        yield db
+
+    async for client, _ in client_with_overrides(
+        recall_service=service,
+        db_override=override_db,
+    ):
+        yield client, service, db
+
+
+async def test_get_recall_returns_expected_unconfigured_state(recall_api_client):
+    client, service, db = recall_api_client
+    service.get_state_for_user.return_value = None
+
+    response = await client.get("/api/recall")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "configured": False,
+        "delivery_enabled": False,
+        "words": [],
+    }
+    service.get_state_for_user.assert_awaited_once_with(client.user.id)
+    db.commit.assert_not_awaited()
+    db.rollback.assert_not_awaited()
+
+
+async def test_get_recall_serializes_only_display_safe_queue_fields(recall_api_client):
+    client, service, db = recall_api_client
+    service.get_state_for_user.return_value = make_state(
+        user_id=client.user.id,
+        is_enabled=False,
+        words=[
+            RecallQueueWord(
+                id=42,
+                word_phrase="kontanter",
+                translation="cash",
+                example_phrase="Jag betalar med kontanter.",
+            )
+        ],
+    )
+
+    response = await client.get("/api/recall")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "configured": True,
+        "delivery_enabled": False,
+        "words": [
+            {
+                "id": 42,
+                "word_phrase": "kontanter",
+                "translation": "cash",
+                "example_phrase": "Jag betalar med kontanter.",
+            }
+        ],
+    }
+    assert "user_id" not in response.text
+    assert "telegram" not in response.text
+    assert "next_word_index" not in response.text
+    db.commit.assert_not_awaited()
+
+
+async def test_bump_recall_commits_once_and_returns_authoritative_queue(recall_api_client):
+    client, service, db = recall_api_client
+    previous = make_state(user_id=client.user.id, words=[RecallQueueWord(id=7, word_phrase="hej")])
+    updated = make_state(user_id=client.user.id, words=[RecallQueueWord(id=8, word_phrase="tack")])
+    service.get_state_for_user.return_value = previous
+    service.bump_words.return_value = updated
+
+    response = await client.post("/api/recall/bump")
+
+    assert response.status_code == 200
+    assert [word["id"] for word in response.json()["words"]] == [8]
+    service.get_state_for_user.assert_awaited_once_with(client.user.id)
+    service.bump_words.assert_awaited_once_with(previous)
+    db.commit.assert_awaited_once_with()
+    db.rollback.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("path", "service_method"),
+    [
+        ("/api/recall/words/42/postpone", "postpone_queue_word"),
+        ("/api/recall/words/42/remove", "remove_queue_word_from_learning"),
+    ],
+)
+async def test_word_mutations_use_authenticated_user_and_vocabulary_id(
+    recall_api_client,
+    path,
+    service_method,
+):
+    client, service, db = recall_api_client
+    updated = make_state(user_id=client.user.id, words=[RecallQueueWord(id=99, word_phrase="ny")])
+    getattr(service, service_method).return_value = updated
+
+    response = await client.post(path)
+
+    assert response.status_code == 200
+    assert [word["id"] for word in response.json()["words"]] == [99]
+    getattr(service, service_method).assert_awaited_once_with(client.user.id, 42)
+    db.commit.assert_awaited_once_with()
+    db.rollback.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("path", "configure_failure"),
+    [
+        ("/api/recall/bump", "bump"),
+        ("/api/recall/words/42/postpone", "postpone"),
+        ("/api/recall/words/42/remove", "remove"),
+    ],
+)
+async def test_mutations_map_unconfigured_recall_to_conflict(
+    recall_api_client,
+    path,
+    configure_failure,
+):
+    client, service, db = recall_api_client
+    if configure_failure == "bump":
+        service.get_state_for_user.return_value = None
+    elif configure_failure == "postpone":
+        service.postpone_queue_word.side_effect = RecallStateNotFoundError(client.user.id)
+    else:
+        service.remove_queue_word_from_learning.side_effect = RecallStateNotFoundError(client.user.id)
+
+    response = await client.post(path)
+
+    assert response.status_code == 409
+    assert "send /start" in response.json()["detail"]
+    db.commit.assert_not_awaited()
+    db.rollback.assert_awaited_once_with()
+
+
+@pytest.mark.parametrize(
+    ("path", "service_method"),
+    [
+        ("/api/recall/words/42/postpone", "postpone_queue_word"),
+        ("/api/recall/words/42/remove", "remove_queue_word_from_learning"),
+    ],
+)
+async def test_word_mutations_hide_queue_ownership_behind_not_found(
+    recall_api_client,
+    path,
+    service_method,
+):
+    _client, service, db = recall_api_client
+    getattr(service, service_method).side_effect = RecallQueueWordNotFoundError(42)
+
+    response = await _client.post(path)
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Recall word not found in current selection"
+    db.commit.assert_not_awaited()
+    db.rollback.assert_awaited_once_with()
+
+
+async def test_mutation_failure_rolls_back_and_returns_generic_detail(recall_api_client):
+    client, service, db = recall_api_client
+    service.postpone_queue_word.side_effect = RecallOperationError(
+        "Failed to postpone word",
+        details="sensitive database failure",
+    )
+
+    response = await client.post("/api/recall/words/42/postpone")
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Failed to update recall selection"
+    assert "sensitive" not in response.text
+    db.commit.assert_not_awaited()
+    db.rollback.assert_awaited_once_with()
+
+
+async def test_commit_failure_rolls_back_and_returns_generic_detail(recall_api_client):
+    client, service, db = recall_api_client
+    service.postpone_queue_word.return_value = make_state(user_id=client.user.id)
+    db.commit.side_effect = RuntimeError("commit unavailable")
+
+    response = await client.post("/api/recall/words/42/postpone")
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Failed to update recall selection"
+    service.postpone_queue_word.assert_awaited_once_with(client.user.id, 42)
+    db.commit.assert_awaited_once_with()
+    db.rollback.assert_awaited_once_with()
+
+
+async def test_get_failure_returns_generic_detail(recall_api_client):
+    client, service, _db = recall_api_client
+    service.get_state_for_user.side_effect = RecallOperationError(
+        "Failed to load recall state",
+        details="sensitive database failure",
+    )
+
+    response = await client.get("/api/recall")
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Failed to retrieve recall selection"
+    assert "sensitive" not in response.text
+
+
+async def test_unexpected_get_failure_returns_generic_detail(recall_api_client):
+    client, service, _db = recall_api_client
+    service.get_state_for_user.side_effect = RuntimeError("sensitive programming failure")
+
+    response = await client.get("/api/recall")
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Failed to retrieve recall selection"
+    assert "sensitive" not in response.text
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("get", "/api/recall"),
+        ("post", "/api/recall/bump"),
+        ("post", "/api/recall/words/42/postpone"),
+        ("post", "/api/recall/words/42/remove"),
+    ],
+)
+async def test_recall_routes_require_authentication(client_no_db, method, path):
+    response = await getattr(client_no_db, method)(path)
+
+    assert response.status_code == 403

--- a/tests/api/test_recall_endpoints.py
+++ b/tests/api/test_recall_endpoints.py
@@ -100,17 +100,15 @@ async def test_get_recall_serializes_only_display_safe_queue_fields(recall_api_c
 
 async def test_bump_recall_commits_once_and_returns_authoritative_queue(recall_api_client):
     client, service, db = recall_api_client
-    previous = make_state(user_id=client.user.id, words=[RecallQueueWord(id=7, word_phrase="hej")])
     updated = make_state(user_id=client.user.id, words=[RecallQueueWord(id=8, word_phrase="tack")])
-    service.get_state_for_user.return_value = previous
     service.bump_words.return_value = updated
 
     response = await client.post("/api/recall/bump")
 
     assert response.status_code == 200
     assert [word["id"] for word in response.json()["words"]] == [8]
-    service.get_state_for_user.assert_awaited_once_with(client.user.id)
-    service.bump_words.assert_awaited_once_with(previous)
+    service.get_state_for_user.assert_not_awaited()
+    service.bump_words.assert_awaited_once_with(client.user.id)
     db.commit.assert_awaited_once_with()
     db.rollback.assert_not_awaited()
 
@@ -155,7 +153,7 @@ async def test_mutations_map_unconfigured_recall_to_conflict(
 ):
     client, service, db = recall_api_client
     if configure_failure == "bump":
-        service.get_state_for_user.return_value = None
+        service.bump_words.side_effect = RecallStateNotFoundError(client.user.id)
     elif configure_failure == "postpone":
         service.postpone_queue_word.side_effect = RecallStateNotFoundError(client.user.id)
     else:

--- a/tests/recall/test_service.py
+++ b/tests/recall/test_service.py
@@ -309,7 +309,7 @@ async def test_bump_words_raises_specific_error_when_state_is_missing(recall_ser
     recall_service.recall_repository.get_recall_state_for_update.return_value = None
 
     with pytest.raises(RecallStateNotFoundError, match="Recall state not found"):
-        await recall_service.bump_words(make_state(user_id=7))
+        await recall_service.bump_words(7)
 
     recall_service.recall_repository.commit.assert_not_awaited()
     recall_service.recall_repository.rollback.assert_not_awaited()
@@ -318,7 +318,6 @@ async def test_bump_words_raises_specific_error_when_state_is_missing(recall_ser
 @pytest.mark.anyio
 async def test_bump_words_keeps_original_queue_excluded_across_fallback_selection(recall_service):
     queued_state = make_state(user_id=1, daily_selection=[make_word(7, "hej"), make_word(8, "tack")])
-    stale_state = make_state(user_id=1, daily_selection=[make_word(99, "stale")])
     replacement = make_word(9, "ny")
     refreshed_state = make_state(user_id=1, daily_selection=[replacement, make_word(10, "sen")])
     recall_service.recall_repository.get_recall_state_for_update.return_value = queued_state
@@ -328,7 +327,7 @@ async def test_bump_words_keeps_original_queue_excluded_across_fallback_selectio
         [make_word(10, "sen")],
     ]
 
-    result = await recall_service.bump_words(stale_state)
+    result = await recall_service.bump_words(1)
 
     assert result == refreshed_state
     recall_service.vocabulary_service.deprioritize_items.assert_awaited_once_with([7, 8], 1)
@@ -369,7 +368,7 @@ async def test_bump_words_deprioritizes_locked_queue_before_selecting_replacemen
 
     recall_service.vocabulary_service.select_alternative_candidates.side_effect = select_after_deprioritization
 
-    result = await recall_service.bump_words(queued_state)
+    result = await recall_service.bump_words(1)
 
     assert result == refreshed_state
     recall_service.recall_repository.replace_queue.assert_awaited_once_with(

--- a/tests/recall/test_service.py
+++ b/tests/recall/test_service.py
@@ -5,7 +5,12 @@ from unittest.mock import AsyncMock, Mock, call
 import pytest
 from sqlalchemy.exc import SQLAlchemyError
 
-from runestone.core.exceptions import RecallOperationError, RecallStateNotFoundError, TelegramUsernameConflictError
+from runestone.core.exceptions import (
+    RecallOperationError,
+    RecallQueueWordNotFoundError,
+    RecallStateNotFoundError,
+    TelegramUsernameConflictError,
+)
 from runestone.db.models import User, Vocabulary
 from runestone.db.recall_repository import RecallRepository
 from runestone.db.user_repository import UserRepository
@@ -124,6 +129,31 @@ async def test_get_state_for_telegram_username_does_not_hide_programming_errors(
     with pytest.raises(TypeError, match="broken collaborator contract"):
         await recall_service.get_state_for_telegram_username("linked")
 
+    recall_service.recall_repository.rollback.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_get_state_for_user_loads_transport_neutral_state(recall_service):
+    state = make_state(user_id=7, telegram_username="linked")
+    recall_service.recall_repository.get_recall_state.return_value = state
+
+    result = await recall_service.get_state_for_user(7)
+
+    assert result == state
+    recall_service.recall_repository.get_recall_state.assert_awaited_once_with(7)
+    recall_service.recall_repository.commit.assert_not_awaited()
+    recall_service.recall_repository.rollback.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_get_state_for_user_wraps_database_failure(recall_service):
+    database_error = SQLAlchemyError("database unavailable")
+    recall_service.recall_repository.get_recall_state.side_effect = database_error
+
+    with pytest.raises(RecallOperationError, match="Failed to load recall state") as exc_info:
+        await recall_service.get_state_for_user(7)
+
+    assert exc_info.value.__cause__ is database_error
     recall_service.recall_repository.rollback.assert_not_awaited()
 
 
@@ -391,6 +421,55 @@ async def test_postpone_word_excludes_removed_item_from_immediate_refill(recall_
 
 
 @pytest.mark.anyio
+async def test_postpone_queue_word_uses_locked_membership_and_refills(recall_service):
+    queued_state = make_state(user_id=1, daily_selection=[make_word(7, "hej")])
+    shortened_state = make_state(user_id=1)
+    replacement = make_word(8, "tack")
+    refreshed_state = make_state(user_id=1, daily_selection=[replacement])
+    recall_service.recall_repository.get_recall_state_for_update.return_value = queued_state
+    recall_service.recall_repository.remove_queue_word.return_value = SimpleNamespace(removed_position=0)
+    recall_service.recall_repository.get_recall_state.side_effect = [shortened_state, refreshed_state]
+    recall_service.vocabulary_service.select_daily_candidates.return_value = [replacement]
+
+    result = await recall_service.postpone_queue_word(1, 7)
+
+    assert result == refreshed_state
+    recall_service.recall_repository.remove_queue_word.assert_awaited_once_with(1, 7)
+    recall_service.vocabulary_service.deprioritize_item.assert_awaited_once_with(7, 1)
+    recall_service.vocabulary_service.select_daily_candidates.assert_awaited_once_with(
+        user_id=1,
+        cooldown_days=7,
+        limit=3,
+        excluded_word_ids=[7],
+    )
+    recall_service.recall_repository.append_queue_words.assert_awaited_once_with(1, [replacement])
+    recall_service.recall_repository.commit.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_postpone_queue_word_rejects_id_outside_locked_selection(recall_service):
+    queued_state = make_state(user_id=1, daily_selection=[make_word(7, "hej")])
+    recall_service.recall_repository.get_recall_state_for_update.return_value = queued_state
+
+    with pytest.raises(RecallQueueWordNotFoundError, match="not found in current selection"):
+        await recall_service.postpone_queue_word(1, 99)
+
+    recall_service.recall_repository.remove_queue_word.assert_not_awaited()
+    recall_service.vocabulary_service.deprioritize_item.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_postpone_queue_word_rejects_missing_recall_state(recall_service):
+    recall_service.recall_repository.get_recall_state_for_update.return_value = None
+
+    with pytest.raises(RecallStateNotFoundError):
+        await recall_service.postpone_queue_word(1, 7)
+
+    recall_service.recall_repository.remove_queue_word.assert_not_awaited()
+    recall_service.vocabulary_service.deprioritize_item.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_remove_word_completely_returns_transaction_snapshot_without_owning_transaction(recall_service):
     queued_state = make_state(user_id=1, daily_selection=[make_word(7, "hej")])
     shortened_state = make_state(user_id=1)
@@ -412,6 +491,51 @@ async def test_remove_word_completely_returns_transaction_snapshot_without_ownin
     recall_service.recall_repository.commit.assert_not_awaited()
     recall_service.recall_repository.rollback.assert_not_awaited()
     assert persistence_events == ["load"]
+
+
+@pytest.mark.anyio
+async def test_remove_queue_word_from_learning_deactivates_locked_membership_and_refills(recall_service):
+    queued_state = make_state(user_id=1, daily_selection=[make_word(7, "hej")])
+    shortened_state = make_state(user_id=1)
+    recall_service.recall_repository.get_recall_state_for_update.return_value = queued_state
+    recall_service.recall_repository.remove_queue_word.return_value = SimpleNamespace(removed_position=0)
+    recall_service.recall_repository.get_recall_state.return_value = shortened_state
+
+    result = await recall_service.remove_queue_word_from_learning(1, 7)
+
+    assert result == shortened_state
+    recall_service.vocabulary_service.deactivate_item.assert_awaited_once_with(7, 1)
+    recall_service.recall_repository.remove_queue_word.assert_awaited_once_with(1, 7)
+    recall_service.vocabulary_service.select_daily_candidates.assert_awaited_once_with(
+        user_id=1,
+        cooldown_days=7,
+        limit=3,
+        excluded_word_ids=None,
+    )
+    recall_service.recall_repository.commit.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_remove_queue_word_from_learning_rejects_id_outside_locked_selection(recall_service):
+    queued_state = make_state(user_id=1, daily_selection=[make_word(7, "hej")])
+    recall_service.recall_repository.get_recall_state_for_update.return_value = queued_state
+
+    with pytest.raises(RecallQueueWordNotFoundError, match="not found in current selection"):
+        await recall_service.remove_queue_word_from_learning(1, 99)
+
+    recall_service.vocabulary_service.deactivate_item.assert_not_awaited()
+    recall_service.recall_repository.remove_queue_word.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_remove_queue_word_from_learning_rejects_missing_recall_state(recall_service):
+    recall_service.recall_repository.get_recall_state_for_update.return_value = None
+
+    with pytest.raises(RecallStateNotFoundError):
+        await recall_service.remove_queue_word_from_learning(1, 7)
+
+    recall_service.vocabulary_service.deactivate_item.assert_not_awaited()
+    recall_service.recall_repository.remove_queue_word.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/tests/telegram/test_commands.py
+++ b/tests/telegram/test_commands.py
@@ -639,7 +639,7 @@ async def test_bump_words_preserves_nonempty_and_empty_responses(
 
     await processor.process_updates()
 
-    recall_service.bump_words.assert_awaited_once_with(original)
+    recall_service.bump_words.assert_awaited_once_with(original.user_id)
     processor._send_message.assert_awaited_once_with(123, expected, None)
 
 


### PR DESCRIPTION
## Summary
- add authenticated recall queue API for list, refresh, postpone, and soft removal
- add a responsive Recall page with icon-only accessible actions and read-only delivery status
- document web recall behavior, transactions, activation boundaries, and error handling

## Validation
- make check-readiness (1,092 backend and 546 frontend tests)
- browser verification with mocked recall responses: desktop/mobile states, hover and keyboard tooltips, mutation replacement, no console errors
- commit hooks: formatting, lint, security, and secret checks