### PR TITLE
test: cover extra info assist in vocabulary modal

### DIFF
--- a/frontend/src/components/AddEditVocabularyModal.test.tsx
+++ b/frontend/src/components/AddEditVocabularyModal.test.tsx
@@ -285,6 +285,32 @@ describe("AddEditVocabularyModal", () => {
     });
   });
 
+  it("fills extra info when Fill Extra Info is clicked", async () => {
+    const user = userEvent.setup();
+    mockImproveVocabularyItem.mockResolvedValue({
+      extra_info: "en-word, noun, base form: hej",
+    });
+
+    renderWithAuthProvider(<AddEditVocabularyModal {...defaultProps} />);
+
+    await user.type(screen.getByLabelText("Swedish Word/Phrase"), "hej");
+    await user.click(screen.getByTitle("Fill Extra Info"));
+
+    await waitFor(() => {
+      expect(mockImproveVocabularyItem).toHaveBeenCalledWith(
+        expect.any(Object),
+        "hej",
+        VOCABULARY_IMPROVEMENT_MODES.EXTRA_INFO_ONLY
+      );
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByDisplayValue("en-word, noun, base form: hej")
+      ).toBeInTheDocument();
+    });
+  });
+
   it("hides suggestion actions until a word phrase is available", () => {
     renderWithAuthProvider(<AddEditVocabularyModal {...defaultProps} />);
 


### PR DESCRIPTION
## Summary
- add focused coverage for the Add/Edit Vocabulary modal's Fill Extra Info assist path
- assert the extra-info-only improvement mode is used and the returned value is rendered

## Validation
- npm run test:run -- src/components/AddEditVocabularyModal.test.tsx
- make check-readiness (lint and full backend/frontend test suites passed; lockfile check passed after pinned npm sync)