### PR TITLE
Refresh Grammar Cheatsheets design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,10 @@ vocab_db.md
 *.offset
 
 .agents
+.playwright-cli/console-2026-07-23T09-41-34-745Z.log
+.playwright-cli/page-2026-07-23T09-41-37-022Z.yml
+.playwright-cli/page-2026-07-23T09-41-49-925Z.yml
+.playwright-cli/page-2026-07-23T09-42-05-870Z.yml
+.playwright-cli/page-2026-07-23T09-42-05-929Z.yml
+.playwright-cli/page-2026-07-23T09-42-23-528Z.yml
+.playwright-cli/page-2026-07-23T09-42-23-573Z.yml

--- a/frontend/src/components/GrammarView.test.tsx
+++ b/frontend/src/components/GrammarView.test.tsx
@@ -28,10 +28,10 @@ describe("GrammarView", () => {
     render(<GrammarView />);
 
     expect(screen.getByText("Grammar Cheatsheets")).toBeInTheDocument();
-    expect(screen.getByText("Available Cheatsheets")).toBeInTheDocument();
+    expect(screen.getByText("Cheatsheet library")).toBeInTheDocument();
   });
 
-  it("navigates to grammar start when clicking Available Cheatsheets", async () => {
+  it("navigates to grammar start when clicking Cheatsheet library", async () => {
     const mockFetchCheatsheetContent = vi.fn().mockResolvedValue(undefined);
     mockUseGrammar.mockReturnValue({
       cheatsheets: [
@@ -59,7 +59,7 @@ describe("GrammarView", () => {
       expect(window.location.search).toContain("cheatsheet=pronunciation");
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Available Cheatsheets" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cheatsheet library" }));
 
     await waitFor(() => {
       expect(screen.getByText("Search grammar cheatsheets")).toBeInTheDocument();
@@ -149,6 +149,63 @@ describe("GrammarView", () => {
 
     expect(adjectivParent).toHaveStyle({ height: "0px" });
     expect(verbParent).toHaveStyle({ height: "0px" });
+  });
+
+  it("filters the library and reveals matching categorized cheatsheets", () => {
+    mockUseGrammar.mockReturnValue({
+      cheatsheets: [
+        {
+          filename: "adjectives/komparation.md",
+          title: "Adjective comparison",
+          category: "adjectives",
+        },
+        {
+          filename: "verbs/imperativ.md",
+          title: "Imperative",
+          category: "verbs",
+        },
+      ],
+      selectedCheatsheet: null,
+      loading: false,
+      error: null,
+      fetchCheatsheets: vi.fn(),
+      fetchCheatsheetContent: vi.fn(),
+    });
+
+    render(<GrammarView />);
+    fireEvent.change(screen.getByPlaceholderText("Search cheatsheets"), {
+      target: { value: "comparison" },
+    });
+
+    expect(screen.getByRole("button", { name: "Adjective comparison" })).toBeVisible();
+    expect(screen.queryByText("Imperative")).not.toBeInTheDocument();
+    expect(screen.getByText("1 matching cheatsheet")).toBeInTheDocument();
+  });
+
+  it("renders only the accessible library search on the start page", () => {
+    mockUseGrammar.mockReturnValue({
+      cheatsheets: [],
+      selectedCheatsheet: null,
+      loading: false,
+      error: null,
+      fetchCheatsheets: vi.fn(),
+      fetchCheatsheetContent: vi.fn(),
+    });
+
+    render(<GrammarView />);
+
+    const librarySearch = screen.getByRole("textbox", {
+      name: "Search cheatsheet library",
+    });
+
+    fireEvent.change(librarySearch, { target: { value: "verbs" } });
+
+    expect(
+      screen.getByRole("button", { name: "Clear cheatsheet library search" })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("textbox", { name: "Search grammar topics" })
+    ).not.toBeInTheDocument();
   });
 
   it("should expand and collapse categories when clicked", async () => {
@@ -445,145 +502,6 @@ describe("GrammarView", () => {
     });
   });
 
-  it("renders grammar search input in the default empty state", () => {
-    mockUseGrammar.mockReturnValue({
-      cheatsheets: [],
-      selectedCheatsheet: null,
-      searchResults: [],
-      loading: false,
-      error: null,
-      searchLoading: false,
-      searchError: null,
-      fetchCheatsheets: vi.fn(),
-      fetchCheatsheetContent: vi.fn(),
-      searchGrammar: vi.fn(),
-      clearSearch: vi.fn(),
-    });
-
-    render(<GrammarView />);
-
-    expect(screen.getByPlaceholderText("Search grammar topics...")).toBeInTheDocument();
-  });
-
-  it("submits grammar search from the empty state", async () => {
-    const mockSearchGrammar = vi.fn().mockResolvedValue(undefined);
-
-    mockUseGrammar.mockReturnValue({
-      cheatsheets: [],
-      selectedCheatsheet: null,
-      searchResults: [],
-      loading: false,
-      error: null,
-      searchLoading: false,
-      searchError: null,
-      fetchCheatsheets: vi.fn(),
-      fetchCheatsheetContent: vi.fn(),
-      searchGrammar: mockSearchGrammar,
-      clearSearch: vi.fn(),
-    });
-
-    render(<GrammarView />);
-
-    fireEvent.change(screen.getByPlaceholderText("Search grammar topics..."), {
-      target: { value: "adjective comparison" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Search" }));
-
-    await waitFor(() => {
-      expect(mockSearchGrammar).toHaveBeenCalledWith("adjective comparison");
-    });
-  });
-
-  it("submits grammar search when Enter is pressed in the search input", async () => {
-    const mockSearchGrammar = vi.fn().mockResolvedValue(undefined);
-
-    mockUseGrammar.mockReturnValue({
-      cheatsheets: [],
-      selectedCheatsheet: null,
-      searchResults: [],
-      loading: false,
-      error: null,
-      searchLoading: false,
-      searchError: null,
-      fetchCheatsheets: vi.fn(),
-      fetchCheatsheetContent: vi.fn(),
-      searchGrammar: mockSearchGrammar,
-      clearSearch: vi.fn(),
-    });
-
-    render(<GrammarView />);
-
-    const searchInput = screen.getByPlaceholderText("Search grammar topics...");
-    fireEvent.change(searchInput, {
-      target: { value: "word order" },
-    });
-    fireEvent.keyDown(searchInput, { key: "Enter" });
-
-    await waitFor(() => {
-      expect(mockSearchGrammar).toHaveBeenCalledWith("word order");
-    });
-  });
-
-  it("renders grammar search results", () => {
-    mockUseGrammar.mockReturnValue({
-      cheatsheets: [],
-      selectedCheatsheet: null,
-      searchResults: [
-        {
-          title: "Adjective comparison rules",
-          url: "http://localhost:5173/?view=grammar&cheatsheet=adjectives/komparation",
-          path: "adjectives/komparation.md",
-        },
-      ],
-      loading: false,
-      error: null,
-      searchLoading: false,
-      searchError: null,
-      fetchCheatsheets: vi.fn(),
-      fetchCheatsheetContent: vi.fn(),
-      searchGrammar: vi.fn(),
-      clearSearch: vi.fn(),
-    });
-
-    render(<GrammarView />);
-
-    expect(screen.getByText("Adjective comparison rules")).toBeInTheDocument();
-    expect(screen.getByText("adjectives/komparation.md")).toBeInTheDocument();
-  });
-
-  it("opens a grammar search result and updates the URL", async () => {
-    const mockFetchCheatsheetContent = vi.fn().mockResolvedValue(undefined);
-
-    mockUseGrammar.mockReturnValue({
-      cheatsheets: [],
-      selectedCheatsheet: null,
-      searchResults: [
-        {
-          title: "Verb forms",
-          url: "http://localhost:5173/?view=grammar&cheatsheet=verbs/verb-forms",
-          path: "verbs/verb-forms.md",
-        },
-      ],
-      loading: false,
-      error: null,
-      searchLoading: false,
-      searchError: null,
-      fetchCheatsheets: vi.fn(),
-      fetchCheatsheetContent: mockFetchCheatsheetContent,
-      searchGrammar: vi.fn(),
-      clearSearch: vi.fn(),
-    });
-
-    render(<GrammarView />);
-    fireEvent.click(screen.getByRole("button", { name: /Verb forms/ }));
-
-    await waitFor(() => {
-      expect(mockFetchCheatsheetContent).toHaveBeenCalledWith("verbs/verb-forms.md");
-    });
-    expect(window.location.search).toContain("view=grammar");
-    expect(window.location.search).toContain("cheatsheet=verbs%2Fverb-forms");
-  });
-
   it("loads a direct categorized cheatsheet link after cheatsheets arrive", async () => {
     const mockFetchCheatsheetContent = vi.fn().mockResolvedValue(undefined);
     window.history.replaceState(
@@ -726,48 +644,4 @@ describe("GrammarView", () => {
     consoleError.mockRestore();
   });
 
-  it("renders no-result message after an empty grammar search", async () => {
-    mockUseGrammar.mockReturnValue({
-      cheatsheets: [],
-      selectedCheatsheet: null,
-      searchResults: [],
-      loading: false,
-      error: null,
-      searchLoading: false,
-      searchError: null,
-      fetchCheatsheets: vi.fn(),
-      fetchCheatsheetContent: vi.fn(),
-      searchGrammar: vi.fn().mockResolvedValue(undefined),
-      clearSearch: vi.fn(),
-    });
-
-    render(<GrammarView />);
-
-    fireEvent.change(screen.getByPlaceholderText("Search grammar topics..."), {
-      target: { value: "nope" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Search" }));
-
-    expect(await screen.findByText("No matching grammar pages found.")).toBeInTheDocument();
-  });
-
-  it("renders grammar search errors separately", () => {
-    mockUseGrammar.mockReturnValue({
-      cheatsheets: [],
-      selectedCheatsheet: null,
-      searchResults: [],
-      loading: false,
-      error: null,
-      searchLoading: false,
-      searchError: "Failed to search grammar cheatsheets",
-      fetchCheatsheets: vi.fn(),
-      fetchCheatsheetContent: vi.fn(),
-      searchGrammar: vi.fn(),
-      clearSearch: vi.fn(),
-    });
-
-    render(<GrammarView />);
-
-    expect(screen.getByText("Failed to search grammar cheatsheets")).toBeInTheDocument();
-  });
 });

--- a/frontend/src/components/GrammarView.test.tsx
+++ b/frontend/src/components/GrammarView.test.tsx
@@ -151,7 +151,7 @@ describe("GrammarView", () => {
     expect(verbParent).toHaveStyle({ height: "0px" });
   });
 
-  it("filters the library and reveals matching categorized cheatsheets", () => {
+  it("filters the library without changing persisted category expansion", async () => {
     mockUseGrammar.mockReturnValue({
       cheatsheets: [
         {
@@ -173,16 +173,27 @@ describe("GrammarView", () => {
     });
 
     render(<GrammarView />);
-    fireEvent.change(screen.getByPlaceholderText("Search cheatsheets"), {
+    fireEvent.change(screen.getByPlaceholderText("Filter cheatsheets"), {
       target: { value: "comparison" },
     });
 
     expect(screen.getByRole("button", { name: "Adjective comparison" })).toBeVisible();
     expect(screen.queryByText("Imperative")).not.toBeInTheDocument();
     expect(screen.getByText("1 matching cheatsheet")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "adjectives" }));
+    fireEvent.click(screen.getByRole("button", { name: "Clear cheatsheet filter" }));
+
+    await waitFor(() => {
+      expect(
+        screen
+          .getByRole("button", { name: "Adjective comparison" })
+          .closest(".MuiCollapse-root")
+      ).toHaveStyle({ height: "0px" });
+    });
   });
 
-  it("renders only the accessible library search on the start page", () => {
+  it("distinguishes the library filter from semantic grammar search", () => {
     mockUseGrammar.mockReturnValue({
       cheatsheets: [],
       selectedCheatsheet: null,
@@ -194,18 +205,84 @@ describe("GrammarView", () => {
 
     render(<GrammarView />);
 
-    const librarySearch = screen.getByRole("textbox", {
-      name: "Search cheatsheet library",
+    const libraryFilter = screen.getByRole("textbox", {
+      name: "Filter cheatsheet library",
+    });
+    const topicSearch = screen.getByRole("textbox", {
+      name: "Search grammar topics",
     });
 
-    fireEvent.change(librarySearch, { target: { value: "verbs" } });
+    fireEvent.change(libraryFilter, { target: { value: "verbs" } });
+    fireEvent.change(topicSearch, { target: { value: "word order" } });
 
     expect(
-      screen.getByRole("button", { name: "Clear cheatsheet library search" })
+      screen.getByRole("button", { name: "Clear cheatsheet filter" })
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("textbox", { name: "Search grammar topics" })
-    ).not.toBeInTheDocument();
+      screen.getByRole("button", { name: "Clear grammar topic search" })
+    ).toBeInTheDocument();
+  });
+
+  it("submits semantic grammar search from the start panel", async () => {
+    const mockSearchGrammar = vi.fn().mockResolvedValue(undefined);
+    mockUseGrammar.mockReturnValue({
+      cheatsheets: [],
+      selectedCheatsheet: null,
+      searchResults: [],
+      loading: false,
+      error: null,
+      searchLoading: false,
+      searchError: null,
+      fetchCheatsheets: vi.fn(),
+      fetchCheatsheetContent: vi.fn(),
+      searchGrammar: mockSearchGrammar,
+      clearSearch: vi.fn(),
+    });
+
+    render(<GrammarView />);
+
+    fireEvent.change(
+      screen.getByRole("textbox", { name: "Search grammar topics" }),
+      { target: { value: "word order" } }
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      expect(mockSearchGrammar).toHaveBeenCalledWith("word order");
+    });
+  });
+
+  it("opens a semantic grammar search result", async () => {
+    const mockFetchCheatsheetContent = vi.fn().mockResolvedValue(undefined);
+    mockUseGrammar.mockReturnValue({
+      cheatsheets: [],
+      selectedCheatsheet: null,
+      searchResults: [
+        {
+          title: "Verb forms",
+          url: "http://localhost:5173/?view=grammar&cheatsheet=verbs/verb-forms",
+          path: "verbs/verb-forms.md",
+        },
+      ],
+      loading: false,
+      error: null,
+      searchLoading: false,
+      searchError: null,
+      fetchCheatsheets: vi.fn(),
+      fetchCheatsheetContent: mockFetchCheatsheetContent,
+      searchGrammar: vi.fn(),
+      clearSearch: vi.fn(),
+    });
+
+    render(<GrammarView />);
+    fireEvent.click(screen.getByRole("button", { name: /Verb forms/ }));
+
+    await waitFor(() => {
+      expect(mockFetchCheatsheetContent).toHaveBeenCalledWith(
+        "verbs/verb-forms.md"
+      );
+    });
+    expect(window.location.search).toContain("cheatsheet=verbs%2Fverb-forms");
   });
 
   it("should expand and collapse categories when clicked", async () => {
@@ -415,6 +492,9 @@ describe("GrammarView", () => {
     await waitFor(() => {
       const markdownDiv = container.querySelector(".markdown-content");
       expect(markdownDiv).not.toBeNull();
+      expect(
+        screen.getByRole("article", { name: "Pronunciation" })
+      ).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/GrammarView.tsx
+++ b/frontend/src/components/GrammarView.tsx
@@ -1,8 +1,14 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Box, Typography } from "@mui/material";
-import { ContentCard, LoadingSpinner, ErrorAlert, SectionTitle, CustomButton, Snackbar } from "./ui";
-import MarkdownDisplay from "./ui/MarkdownDisplay";
+import {
+  ErrorAlert,
+  SectionTitle,
+  Snackbar,
+  analyzerShellGradients,
+  buildAnalyzerShellSx,
+} from "./ui";
 import useGrammar from "../hooks/useGrammar";
+import GrammarContentPanel from "./grammar/GrammarContentPanel";
 import GrammarSidebar from "./grammar/GrammarSidebar";
 import GrammarStartPanel from "./grammar/GrammarStartPanel";
 
@@ -44,18 +50,12 @@ const GrammarView: React.FC = () => {
   const {
     cheatsheets,
     selectedCheatsheet,
-    searchResults = [],
     loading,
     error,
-    searchLoading = false,
-    searchError = null,
     fetchCheatsheetContent,
-    searchGrammar = async () => undefined,
-    clearSearch = () => undefined,
   } = useGrammar();
   const [selectedFilename, setSelectedFilename] = useState<string | null>(null);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [hasSearched, setHasSearched] = useState(false);
+  const [libraryQuery, setLibraryQuery] = useState("");
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(
     new Set()
   );
@@ -111,24 +111,6 @@ const GrammarView: React.FC = () => {
       setCheatsheetInUrl(filename, "push");
     }
     await fetchCheatsheetContent(filename);
-  };
-
-  const handleSearch = async () => {
-    const trimmedQuery = searchQuery.trim();
-    if (!trimmedQuery) {
-      setHasSearched(false);
-      clearSearch();
-      return;
-    }
-
-    setHasSearched(true);
-    await searchGrammar(trimmedQuery);
-  };
-
-  const handleClearSearch = () => {
-    setSearchQuery("");
-    setHasSearched(false);
-    clearSearch();
   };
 
   useEffect(() => {
@@ -227,9 +209,35 @@ const GrammarView: React.FC = () => {
     setCheatsheetInUrl(null, "push");
   };
 
+  const selectedCheatsheetInfo = selectedFilename
+    ? cheatsheets.find((cheatsheet) => cheatsheet.filename === selectedFilename)
+    : null;
+
   return (
-    <Box sx={{ py: 8 }}>
-      <SectionTitle>Grammar Cheatsheets</SectionTitle>
+    <Box sx={{ py: { xs: 2, md: 4 } }}>
+      <Box sx={{ mb: { xs: 4, md: 5 } }}>
+        <SectionTitle
+          variant="h2"
+          marginBottom={1}
+          sx={{
+            color: "#f7f9ff",
+            fontSize: { xs: "2.25rem", md: "3.25rem" },
+            lineHeight: 1.05,
+            letterSpacing: "-0.045em",
+          }}
+        >
+          Grammar Cheatsheets
+        </SectionTitle>
+        <Typography
+          sx={{
+            maxWidth: 680,
+            color: "#b8c5e3",
+            fontSize: { xs: "1rem", md: "1.08rem" },
+          }}
+        >
+          Quick Swedish grammar references for everyday study.
+        </Typography>
+      </Box>
 
       {error && (
         <Box sx={{ mb: 4 }}>
@@ -237,9 +245,22 @@ const GrammarView: React.FC = () => {
         </Box>
       )}
 
-      <Box sx={{ display: "flex", gap: 2, mt: 6 }}>
-        {/* Left Pane: Cheatsheet List */}
-        <Box sx={{ flexShrink: 0, width: "220px" }}>
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "minmax(0, 1fr)", lg: "280px minmax(0, 1fr)" },
+          alignItems: "start",
+          gap: { xs: 4, lg: 5, xl: 7 },
+        }}
+      >
+        <Box
+          sx={{
+            minWidth: 0,
+            position: { lg: "sticky" },
+            top: { lg: 116 },
+            order: { xs: selectedFilename ? 2 : 1, lg: 1 },
+          }}
+        >
           <GrammarSidebar
             cheatsheets={cheatsheets}
             loading={loading}
@@ -250,73 +271,44 @@ const GrammarView: React.FC = () => {
               handleCheatsheetClick(filename).catch(handleSelectionError);
             }}
             onToggleCategory={toggleCategory}
+            searchQuery={libraryQuery}
+            onSearchQueryChange={setLibraryQuery}
           />
         </Box>
 
-        {/* Right Pane: Content Display */}
-        <Box sx={{ flex: 1 }}>
-          <ContentCard>
-            {selectedFilename ? (
-              <>
-                <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 2, mb: 2 }}>
-                  <Typography sx={{ color: "#9ca3af", fontSize: "0.875rem" }}>
-                    {paramFromFilepath(selectedFilename)}
-                  </Typography>
-                  <Box sx={{ display: "flex", gap: 1 }}>
-                    <CustomButton
-                      variant="secondary"
-                      size="small"
-                      onClick={() => {
-                        void handleCopyMarkdown();
-                      }}
-                    >
-                      Copy markdown
-                    </CustomButton>
-                    <CustomButton
-                      variant="secondary"
-                      size="small"
-                      onClick={() => {
-                        void handleCopyLink();
-                      }}
-                    >
-                      Copy link
-                    </CustomButton>
-                  </Box>
-                </Box>
-                {loading ? (
-                  <LoadingSpinner />
-                ) : selectedCheatsheet ? (
-                  <MarkdownDisplay
-                    markdownContent={selectedCheatsheet.content}
-                  />
-                ) : (
-                  !error && (
-                    <Typography sx={{ color: "#9ca3af" }}>
-                      Failed to load cheatsheet content.
-                    </Typography>
-                  )
-                )}
-              </>
-            ) : (
-              <GrammarStartPanel
-                searchQuery={searchQuery}
-                searchResults={searchResults}
-                searchLoading={searchLoading}
-                searchError={searchError}
-                hasSearched={hasSearched}
-                onSearchQueryChange={setSearchQuery}
-                onSearch={() => {
-                  handleSearch().catch((err) => {
-                    console.error("Failed to search grammar: ", err);
-                  });
-                }}
-                onClearSearch={handleClearSearch}
-                onSelectSearchResult={(filename) => {
-                  handleCheatsheetClick(filename).catch(handleSelectionError);
-                }}
-              />
-            )}
-          </ContentCard>
+        <Box
+          sx={{
+            minWidth: 0,
+            order: { xs: selectedFilename ? 1 : 2, lg: 2 },
+          }}
+        >
+          {selectedFilename ? (
+            <GrammarContentPanel
+              category={selectedCheatsheetInfo?.category ?? null}
+              title={
+                selectedCheatsheetInfo?.title ?? paramFromFilepath(selectedFilename)
+              }
+              markdownContent={selectedCheatsheet?.content ?? null}
+              loading={loading}
+              hasError={Boolean(error)}
+              onCopyMarkdown={() => {
+                void handleCopyMarkdown();
+              }}
+              onCopyLink={() => {
+                void handleCopyLink();
+              }}
+            />
+          ) : (
+            <Box
+              sx={{
+                minHeight: { xs: 360, lg: 620 },
+                p: { xs: 2.5, sm: 4, lg: 5 },
+                ...buildAnalyzerShellSx(analyzerShellGradients.emptyState),
+              }}
+            >
+              <GrammarStartPanel />
+            </Box>
+          )}
         </Box>
       </Box>
 

--- a/frontend/src/components/GrammarView.tsx
+++ b/frontend/src/components/GrammarView.tsx
@@ -50,12 +50,19 @@ const GrammarView: React.FC = () => {
   const {
     cheatsheets,
     selectedCheatsheet,
+    searchResults = [],
     loading,
     error,
+    searchLoading = false,
+    searchError = null,
     fetchCheatsheetContent,
+    searchGrammar = async () => undefined,
+    clearSearch = () => undefined,
   } = useGrammar();
   const [selectedFilename, setSelectedFilename] = useState<string | null>(null);
-  const [libraryQuery, setLibraryQuery] = useState("");
+  const [libraryFilter, setLibraryFilter] = useState("");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [hasSearched, setHasSearched] = useState(false);
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(
     new Set()
   );
@@ -111,6 +118,24 @@ const GrammarView: React.FC = () => {
       setCheatsheetInUrl(filename, "push");
     }
     await fetchCheatsheetContent(filename);
+  };
+
+  const handleSearch = async () => {
+    const trimmedQuery = searchQuery.trim();
+    if (!trimmedQuery) {
+      setHasSearched(false);
+      clearSearch();
+      return;
+    }
+
+    setHasSearched(true);
+    await searchGrammar(trimmedQuery);
+  };
+
+  const handleClearSearch = () => {
+    setSearchQuery("");
+    setHasSearched(false);
+    clearSearch();
   };
 
   useEffect(() => {
@@ -271,8 +296,8 @@ const GrammarView: React.FC = () => {
               handleCheatsheetClick(filename).catch(handleSelectionError);
             }}
             onToggleCategory={toggleCategory}
-            searchQuery={libraryQuery}
-            onSearchQueryChange={setLibraryQuery}
+            filterQuery={libraryFilter}
+            onFilterQueryChange={setLibraryFilter}
           />
         </Box>
 
@@ -306,7 +331,21 @@ const GrammarView: React.FC = () => {
                 ...buildAnalyzerShellSx(analyzerShellGradients.emptyState),
               }}
             >
-              <GrammarStartPanel />
+              <GrammarStartPanel
+                searchQuery={searchQuery}
+                searchResults={searchResults}
+                searchLoading={searchLoading}
+                searchError={searchError}
+                hasSearched={hasSearched}
+                onSearchQueryChange={setSearchQuery}
+                onSearch={() => {
+                  void handleSearch();
+                }}
+                onClearSearch={handleClearSearch}
+                onSelectSearchResult={(filename) => {
+                  handleCheatsheetClick(filename).catch(handleSelectionError);
+                }}
+              />
             </Box>
           )}
         </Box>

--- a/frontend/src/components/grammar/GrammarContentPanel.tsx
+++ b/frontend/src/components/grammar/GrammarContentPanel.tsx
@@ -36,6 +36,7 @@ function GrammarContentPanel({
   return (
     <Box
       component="article"
+      aria-label={title ?? "Grammar cheatsheet"}
       sx={{
         minHeight: { xs: 360, lg: 620 },
         p: { xs: 2, sm: 3, lg: 4 },

--- a/frontend/src/components/grammar/GrammarContentPanel.tsx
+++ b/frontend/src/components/grammar/GrammarContentPanel.tsx
@@ -1,0 +1,182 @@
+import { Box, Typography } from "@mui/material";
+import { Copy, Link as LinkIcon } from "lucide-react";
+import {
+  CustomButton,
+  LoadingSpinner,
+  MarkdownDisplay,
+  analyzerShellGradients,
+  buildAnalyzerShellSx,
+} from "../ui";
+
+type GrammarContentPanelProps = {
+  category: string | null;
+  title: string | null;
+  markdownContent: string | null;
+  loading: boolean;
+  hasError: boolean;
+  onCopyMarkdown: () => void;
+  onCopyLink: () => void;
+};
+
+/**
+ * Reading surface for a selected grammar cheatsheet.
+ *
+ * The shell intentionally reuses the analyzer page's border, gradient, and
+ * radius so both learning workflows feel like parts of the same application.
+ */
+function GrammarContentPanel({
+  category,
+  title,
+  markdownContent,
+  loading,
+  hasError,
+  onCopyMarkdown,
+  onCopyLink,
+}: GrammarContentPanelProps) {
+  return (
+    <Box
+      component="article"
+      sx={{
+        minHeight: { xs: 360, lg: 620 },
+        p: { xs: 2, sm: 3, lg: 4 },
+        ...buildAnalyzerShellSx(analyzerShellGradients.results),
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: { xs: "column", sm: "row" },
+          alignItems: { xs: "stretch", sm: "center" },
+          justifyContent: "space-between",
+          gap: 2,
+          mb: { xs: 3, md: 4 },
+        }}
+      >
+        <Typography
+          component="p"
+          sx={{
+            minWidth: 0,
+            color: "#9aabd0",
+            fontSize: "0.84rem",
+            overflowWrap: "anywhere",
+          }}
+        >
+          {category && category !== "General" ? (
+            <>
+              <Box component="span" sx={{ textTransform: "capitalize" }}>
+                {category}
+              </Box>
+              <Box component="span" aria-hidden="true" sx={{ px: 1, color: "#65759d" }}>
+                /
+              </Box>
+            </>
+          ) : null}
+          <Box component="span" sx={{ color: "#dbe5fb" }}>
+            {title}
+          </Box>
+        </Typography>
+
+        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+          <CustomButton
+            variant="secondary"
+            size="small"
+            startIcon={<Copy size={15} aria-hidden="true" />}
+            onClick={onCopyMarkdown}
+            sx={{
+              minHeight: 38,
+              color: "#dbe5fb",
+              border: "1px solid rgba(103, 124, 184, 0.46)",
+              backgroundColor: "rgba(7, 13, 43, 0.25)",
+              "&:hover": {
+                color: "white",
+                borderColor: "rgba(132, 153, 214, 0.7)",
+                backgroundColor: "rgba(31, 46, 91, 0.5)",
+              },
+            }}
+          >
+            Copy markdown
+          </CustomButton>
+          <CustomButton
+            variant="secondary"
+            size="small"
+            startIcon={<LinkIcon size={15} aria-hidden="true" />}
+            onClick={onCopyLink}
+            sx={{
+              minHeight: 38,
+              color: "#dbe5fb",
+              border: "1px solid rgba(103, 124, 184, 0.46)",
+              backgroundColor: "rgba(7, 13, 43, 0.25)",
+              "&:hover": {
+                color: "white",
+                borderColor: "rgba(132, 153, 214, 0.7)",
+                backgroundColor: "rgba(31, 46, 91, 0.5)",
+              },
+            }}
+          >
+            Copy link
+          </CustomButton>
+        </Box>
+      </Box>
+
+      {loading ? (
+        <LoadingSpinner />
+      ) : markdownContent ? (
+        <Box
+          sx={{
+            "& .markdown-content": {
+              color: "#edf2ff",
+              fontSize: { xs: "0.98rem", md: "1rem" },
+              lineHeight: 1.72,
+            },
+            "& .markdown-content h1": {
+              mt: 0,
+              mb: 2.5,
+              color: "#f7f9ff",
+              fontSize: { xs: "2rem", md: "2.45rem" },
+              lineHeight: 1.1,
+              letterSpacing: "-0.035em",
+            },
+            "& .markdown-content h2": {
+              mt: 3.5,
+              color: "var(--primary-color)",
+              fontSize: "0.82rem",
+              fontWeight: 700,
+              letterSpacing: "0.13em",
+              textTransform: "uppercase",
+            },
+            "& .markdown-content h3": {
+              mt: 3,
+              color: "#f3f6ff",
+              fontSize: "1.12rem",
+            },
+            "& .markdown-content blockquote": {
+              m: "1.5rem 0",
+              px: 2.25,
+              py: 1.25,
+              borderLeft: "3px solid var(--primary-color)",
+              borderRadius: "0 0.65rem 0.65rem 0",
+              color: "#dbe5fb",
+              backgroundColor: "rgba(56, 224, 123, 0.07)",
+            },
+            "& .markdown-content table": {
+              display: "block",
+              maxWidth: "100%",
+              overflowX: "auto",
+              borderRadius: "0.7rem",
+            },
+          }}
+        >
+          <MarkdownDisplay markdownContent={markdownContent} />
+        </Box>
+      ) : (
+        !hasError && (
+          <Typography sx={{ color: "#9aabd0" }}>
+            Failed to load cheatsheet content.
+          </Typography>
+        )
+      )}
+    </Box>
+  );
+}
+
+export default GrammarContentPanel;

--- a/frontend/src/components/grammar/GrammarSidebar.tsx
+++ b/frontend/src/components/grammar/GrammarSidebar.tsx
@@ -109,8 +109,8 @@ type GrammarSidebarProps = {
   onBackToStart: () => void;
   onSelectCheatsheet: (filename: string) => void;
   onToggleCategory: (category: string) => void;
-  searchQuery: string;
-  onSearchQueryChange: (value: string) => void;
+  filterQuery: string;
+  onFilterQueryChange: (value: string) => void;
 };
 
 function GrammarSidebar({
@@ -121,8 +121,8 @@ function GrammarSidebar({
   onBackToStart,
   onSelectCheatsheet,
   onToggleCategory,
-  searchQuery,
-  onSearchQueryChange,
+  filterQuery,
+  onFilterQueryChange,
 }: GrammarSidebarProps) {
   const {
     generalCheatsheets,
@@ -131,7 +131,7 @@ function GrammarSidebar({
     visibleCheatsheetCount,
   } =
     React.useMemo(() => {
-      const normalizedQuery = searchQuery.trim().toLocaleLowerCase();
+      const normalizedQuery = filterQuery.trim().toLocaleLowerCase();
       const visibleCheatsheets = normalizedQuery
         ? cheatsheets.filter(
             (cheatsheet) =>
@@ -145,7 +145,7 @@ function GrammarSidebar({
         sortedCategoryKeys: Object.keys(grouped.categorizedCheatsheets).sort(),
         visibleCheatsheetCount: visibleCheatsheets.length,
       };
-    }, [cheatsheets, searchQuery]);
+    }, [cheatsheets, filterQuery]);
 
   return (
     <Box
@@ -201,12 +201,12 @@ function GrammarSidebar({
       </Box>
 
       <SearchInput
-        value={searchQuery}
-        onChange={(event) => onSearchQueryChange(event.target.value)}
-        onClear={() => onSearchQueryChange("")}
-        placeholder="Search cheatsheets"
-        ariaLabel="Search cheatsheet library"
-        clearLabel="Clear cheatsheet library search"
+        value={filterQuery}
+        onChange={(event) => onFilterQueryChange(event.target.value)}
+        onClear={() => onFilterQueryChange("")}
+        placeholder="Filter cheatsheets"
+        ariaLabel="Filter cheatsheet library"
+        clearLabel="Clear cheatsheet filter"
         sx={{ mb: 2.5, maxWidth: "none" }}
         inputSx={{
           "& .MuiOutlinedInput-root": {
@@ -242,7 +242,7 @@ function GrammarSidebar({
         generalCheatsheets.length === 0 &&
         sortedCategoryKeys.length === 0 ? (
         <Typography sx={{ px: 1, py: 2, color: "#8fa0c5", fontSize: "0.88rem" }}>
-          No cheatsheets match “{searchQuery}”.
+          No cheatsheets match “{filterQuery}”.
         </Typography>
       ) : (
         <List disablePadding sx={{ display: "grid", gap: 0.5 }}>
@@ -259,9 +259,13 @@ function GrammarSidebar({
             <React.Fragment key={category}>
               <ListItem disablePadding>
                 <ListItemButton
-                  onClick={() => onToggleCategory(category)}
+                  onClick={() => {
+                    if (!filterQuery.trim()) {
+                      onToggleCategory(category);
+                    }
+                  }}
                   aria-expanded={
-                    expandedCategories.has(category) || Boolean(searchQuery.trim())
+                    expandedCategories.has(category) || Boolean(filterQuery.trim())
                   }
                   sx={{
                     minHeight: 44,
@@ -282,7 +286,7 @@ function GrammarSidebar({
                     }}
                     sx={cheatsheetTextSx}
                   />
-                  {expandedCategories.has(category) || searchQuery.trim() ? (
+                  {expandedCategories.has(category) || filterQuery.trim() ? (
                     <ExpandLess sx={{ color: "#9aabd0", fontSize: 20 }} />
                   ) : (
                     <ExpandMore sx={{ color: "#9aabd0", fontSize: 20 }} />
@@ -290,7 +294,7 @@ function GrammarSidebar({
                 </ListItemButton>
               </ListItem>
               <Collapse
-                in={expandedCategories.has(category) || Boolean(searchQuery.trim())}
+                in={expandedCategories.has(category) || Boolean(filterQuery.trim())}
               >
                 <List component="div" disablePadding>
                   {categorizedCheatsheets[category].map((cheatsheet) => (
@@ -321,7 +325,7 @@ function GrammarSidebar({
       >
         <Layers3 size={16} aria-hidden="true" />
         <Typography sx={{ fontSize: "0.82rem" }}>
-          {searchQuery.trim()
+          {filterQuery.trim()
             ? `${visibleCheatsheetCount} matching ${
                 visibleCheatsheetCount === 1 ? "cheatsheet" : "cheatsheets"
               }`

--- a/frontend/src/components/grammar/GrammarSidebar.tsx
+++ b/frontend/src/components/grammar/GrammarSidebar.tsx
@@ -9,21 +9,49 @@ import {
   Typography,
 } from "@mui/material";
 import { ExpandLess, ExpandMore } from "@mui/icons-material";
-import { ContentCard, LoadingSpinner } from "../ui";
+import { BookOpen, Layers3 } from "lucide-react";
+import { LoadingSpinner } from "../ui";
+import SearchInput from "../ui/SearchInput";
 import type { CheatsheetInfo } from "./types";
 
 const selectedCheatsheetSx = {
+  minHeight: 42,
+  borderRadius: "0.7rem",
+  color: "#dbe5fb",
+  transition: "background-color 160ms ease, color 160ms ease, transform 160ms ease",
+  "&:hover": {
+    backgroundColor: "rgba(148, 163, 184, 0.08)",
+    color: "#ffffff",
+    transform: "translateX(2px)",
+  },
   "&.Mui-selected": {
-    backgroundColor: "rgba(147, 51, 234, 0.1)",
+    position: "relative",
+    color: "#ffffff",
+    background:
+      "linear-gradient(90deg, rgba(56, 224, 123, 0.14), rgba(56, 224, 123, 0.08))",
+    boxShadow: "0 10px 30px rgba(2, 8, 28, 0.2)",
+    "&::before": {
+      content: '""',
+      position: "absolute",
+      left: 0,
+      top: 8,
+      bottom: 8,
+      width: 3,
+      borderRadius: 999,
+      backgroundColor: "var(--primary-color)",
+    },
     "&:hover": {
-      backgroundColor: "rgba(147, 51, 234, 0.2)",
+      background:
+        "linear-gradient(90deg, rgba(56, 224, 123, 0.18), rgba(56, 224, 123, 0.1))",
     },
   },
 };
 
 const cheatsheetTextSx = {
   "& .MuiListItemText-primary": {
-    color: "white",
+    color: "inherit",
+    fontSize: "0.92rem",
+    fontWeight: 500,
   },
 };
 
@@ -81,6 +109,8 @@ type GrammarSidebarProps = {
   onBackToStart: () => void;
   onSelectCheatsheet: (filename: string) => void;
   onToggleCategory: (category: string) => void;
+  searchQuery: string;
+  onSearchQueryChange: (value: string) => void;
 };
 
 function GrammarSidebar({
@@ -91,44 +121,131 @@ function GrammarSidebar({
   onBackToStart,
   onSelectCheatsheet,
   onToggleCategory,
+  searchQuery,
+  onSearchQueryChange,
 }: GrammarSidebarProps) {
-  const { generalCheatsheets, categorizedCheatsheets, sortedCategoryKeys } =
+  const {
+    generalCheatsheets,
+    categorizedCheatsheets,
+    sortedCategoryKeys,
+    visibleCheatsheetCount,
+  } =
     React.useMemo(() => {
-      const grouped = groupCheatsheets(cheatsheets);
+      const normalizedQuery = searchQuery.trim().toLocaleLowerCase();
+      const visibleCheatsheets = normalizedQuery
+        ? cheatsheets.filter(
+            (cheatsheet) =>
+              cheatsheet.title.toLocaleLowerCase().includes(normalizedQuery) ||
+              cheatsheet.category.toLocaleLowerCase().includes(normalizedQuery)
+          )
+        : cheatsheets;
+      const grouped = groupCheatsheets(visibleCheatsheets);
       return {
         ...grouped,
         sortedCategoryKeys: Object.keys(grouped.categorizedCheatsheets).sort(),
+        visibleCheatsheetCount: visibleCheatsheets.length,
       };
-    }, [cheatsheets]);
+    }, [cheatsheets, searchQuery]);
 
   return (
-    <ContentCard>
-      <Typography
-        variant="h6"
-        sx={{ color: "var(--primary-color)", mb: 2 }}
+    <Box
+      component="nav"
+      aria-label="Grammar cheatsheet library"
+      sx={{
+        display: "flex",
+        minWidth: 0,
+        flexDirection: "column",
+        color: "white",
+      }}
+    >
+      <Box
+        component="button"
+        type="button"
+        aria-label="Cheatsheet library"
+        onClick={onBackToStart}
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1.5,
+          width: "fit-content",
+          mb: 2.5,
+          color: "white",
+          background: "none",
+          border: 0,
+          p: 0,
+          font: "inherit",
+          cursor: "pointer",
+          textAlign: "left",
+          "&:hover .library-title": {
+            color: "var(--primary-color)",
+          },
+        }}
       >
-        <Box
-          component="button"
-          type="button"
-          onClick={onBackToStart}
+        <BookOpen
+          size={26}
+          strokeWidth={1.8}
+          aria-hidden="true"
+          style={{ color: "var(--primary-color)" }}
+        />
+        <Typography
+          className="library-title"
+          variant="h6"
           sx={{
-            color: "inherit",
-            background: "none",
-            border: "none",
-            p: 0,
-            m: 0,
-            font: "inherit",
-            cursor: "pointer",
-            textAlign: "left",
+            fontSize: "1.05rem",
+            fontWeight: 700,
+            transition: "color 160ms ease",
           }}
         >
-          Available Cheatsheets
-        </Box>
-      </Typography>
+          Cheatsheet library
+        </Typography>
+      </Box>
+
+      <SearchInput
+        value={searchQuery}
+        onChange={(event) => onSearchQueryChange(event.target.value)}
+        onClear={() => onSearchQueryChange("")}
+        placeholder="Search cheatsheets"
+        ariaLabel="Search cheatsheet library"
+        clearLabel="Clear cheatsheet library search"
+        sx={{ mb: 2.5, maxWidth: "none" }}
+        inputSx={{
+          "& .MuiOutlinedInput-root": {
+            minHeight: 44,
+            backgroundColor: "rgba(7, 13, 43, 0.45)",
+            borderRadius: "0.75rem",
+            color: "#edf2ff",
+            "& fieldset": {
+              borderColor: "rgba(103, 124, 184, 0.42)",
+            },
+            "&:hover fieldset": {
+              borderColor: "rgba(132, 153, 214, 0.62)",
+            },
+            "&.Mui-focused fieldset": {
+              borderColor: "var(--primary-color)",
+            },
+          },
+          "& .MuiInputBase-input": {
+            py: 1.15,
+            fontSize: "0.9rem",
+            color: "#edf2ff",
+            "&::placeholder": {
+              color: "#91a2c9",
+              opacity: 1,
+            },
+          },
+        }}
+      />
+
       {loading && cheatsheets.length === 0 ? (
         <LoadingSpinner />
+      ) : cheatsheets.length > 0 &&
+        generalCheatsheets.length === 0 &&
+        sortedCategoryKeys.length === 0 ? (
+        <Typography sx={{ px: 1, py: 2, color: "#8fa0c5", fontSize: "0.88rem" }}>
+          No cheatsheets match “{searchQuery}”.
+        </Typography>
       ) : (
-        <List>
+        <List disablePadding sx={{ display: "grid", gap: 0.5 }}>
           {generalCheatsheets.map((cheatsheet) => (
             <CheatsheetListItem
               key={cheatsheet.filename}
@@ -141,20 +258,40 @@ function GrammarSidebar({
           {sortedCategoryKeys.map((category) => (
             <React.Fragment key={category}>
               <ListItem disablePadding>
-                <ListItemButton onClick={() => onToggleCategory(category)}>
+                <ListItemButton
+                  onClick={() => onToggleCategory(category)}
+                  aria-expanded={
+                    expandedCategories.has(category) || Boolean(searchQuery.trim())
+                  }
+                  sx={{
+                    minHeight: 44,
+                    borderRadius: "0.7rem",
+                    px: 1,
+                    color: "#f3f6ff",
+                    "&:hover": {
+                      backgroundColor: "rgba(148, 163, 184, 0.06)",
+                    },
+                  }}
+                >
                   <ListItemText
                     primary={category}
-                    primaryTypographyProps={{ fontWeight: "bold" }}
+                    primaryTypographyProps={{
+                      fontWeight: 700,
+                      textTransform: "capitalize",
+                      fontSize: "0.94rem",
+                    }}
                     sx={cheatsheetTextSx}
                   />
-                  {expandedCategories.has(category) ? (
-                    <ExpandLess />
+                  {expandedCategories.has(category) || searchQuery.trim() ? (
+                    <ExpandLess sx={{ color: "#9aabd0", fontSize: 20 }} />
                   ) : (
-                    <ExpandMore />
+                    <ExpandMore sx={{ color: "#9aabd0", fontSize: 20 }} />
                   )}
                 </ListItemButton>
               </ListItem>
-              <Collapse in={expandedCategories.has(category)}>
+              <Collapse
+                in={expandedCategories.has(category) || Boolean(searchQuery.trim())}
+              >
                 <List component="div" disablePadding>
                   {categorizedCheatsheets[category].map((cheatsheet) => (
                     <CheatsheetListItem
@@ -171,7 +308,29 @@ function GrammarSidebar({
           ))}
         </List>
       )}
-    </ContentCard>
+
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          mt: 3,
+          px: 1,
+          color: "#8fa0c5",
+        }}
+      >
+        <Layers3 size={16} aria-hidden="true" />
+        <Typography sx={{ fontSize: "0.82rem" }}>
+          {searchQuery.trim()
+            ? `${visibleCheatsheetCount} matching ${
+                visibleCheatsheetCount === 1 ? "cheatsheet" : "cheatsheets"
+              }`
+            : `${cheatsheets.length} ${
+                cheatsheets.length === 1 ? "cheatsheet" : "cheatsheets"
+              } available`}
+        </Typography>
+      </Box>
+    </Box>
   );
 }
 

--- a/frontend/src/components/grammar/GrammarStartPanel.tsx
+++ b/frontend/src/components/grammar/GrammarStartPanel.tsx
@@ -1,99 +1,23 @@
-import {
-  Box,
-  List,
-  ListItem,
-  ListItemButton,
-  ListItemText,
-  Typography,
-} from "@mui/material";
-import type { GrammarSearchResult } from "../../hooks/useGrammar";
-import { ErrorAlert, LoadingSpinner } from "../ui";
-import SearchInput from "../ui/SearchInput";
+import { Box, Typography } from "@mui/material";
 
-type GrammarStartPanelProps = {
-  searchQuery: string;
-  searchResults: GrammarSearchResult[];
-  searchLoading: boolean;
-  searchError: string | null;
-  hasSearched: boolean;
-  onSearchQueryChange: (value: string) => void;
-  onSearch: () => void;
-  onClearSearch: () => void;
-  onSelectSearchResult: (filename: string) => void;
-};
-
-function GrammarStartPanel({
-  searchQuery,
-  searchResults,
-  searchLoading,
-  searchError,
-  hasSearched,
-  onSearchQueryChange,
-  onSearch,
-  onClearSearch,
-  onSelectSearchResult,
-}: GrammarStartPanelProps) {
+function GrammarStartPanel() {
   return (
-    <Box>
-      <Typography variant="h6" sx={{ color: "white", mb: 1 }}>
+    <Box sx={{ maxWidth: 720 }}>
+      <Typography
+        variant="h4"
+        sx={{
+          color: "#f7f9ff",
+          mb: 1.25,
+          fontSize: { xs: "1.65rem", sm: "2rem" },
+          fontWeight: 700,
+          letterSpacing: "-0.025em",
+        }}
+      >
         Search grammar cheatsheets
       </Typography>
-      <Typography sx={{ color: "#9ca3af", mb: 3 }}>
+      <Typography sx={{ maxWidth: 560, color: "#aab8d7", lineHeight: 1.7 }}>
         Search for a grammar topic, or select a cheatsheet from the list.
       </Typography>
-      <SearchInput
-        value={searchQuery}
-        onChange={(event) => onSearchQueryChange(event.target.value)}
-        onSearch={onSearch}
-        onClear={onClearSearch}
-        placeholder="Search grammar topics..."
-        sx={{ mb: 3, maxWidth: 560 }}
-      />
-
-      {searchError && (
-        <Box sx={{ mb: 3 }}>
-          <ErrorAlert message={searchError} />
-        </Box>
-      )}
-
-      {searchLoading ? (
-        <LoadingSpinner />
-      ) : hasSearched && searchResults.length === 0 && !searchError ? (
-        <Typography sx={{ color: "#9ca3af" }}>
-          No matching grammar pages found.
-        </Typography>
-      ) : searchResults.length > 0 ? (
-        <List disablePadding aria-label="Grammar search results">
-          {searchResults.map((result) => (
-            <ListItem key={result.path || result.url} disablePadding sx={{ mb: 1 }}>
-              <ListItemButton
-                onClick={() => onSelectSearchResult(result.path)}
-                sx={{
-                  border: "1px solid #374151",
-                  borderRadius: "0.5rem",
-                  backgroundColor: "#1f2937",
-                  "&:hover": {
-                    backgroundColor: "#243244",
-                  },
-                }}
-              >
-                <ListItemText
-                  primary={result.title || result.path}
-                  secondary={result.path}
-                  sx={{
-                    "& .MuiListItemText-primary": {
-                      color: "white",
-                    },
-                    "& .MuiListItemText-secondary": {
-                      color: "#9ca3af",
-                    },
-                  }}
-                />
-              </ListItemButton>
-            </ListItem>
-          ))}
-        </List>
-      ) : null}
     </Box>
   );
 }

--- a/frontend/src/components/grammar/GrammarStartPanel.tsx
+++ b/frontend/src/components/grammar/GrammarStartPanel.tsx
@@ -1,6 +1,37 @@
-import { Box, Typography } from "@mui/material";
+import {
+  Box,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  Typography,
+} from "@mui/material";
+import type { GrammarSearchResult } from "../../hooks/useGrammar";
+import { ErrorAlert, LoadingSpinner, SearchInput } from "../ui";
 
-function GrammarStartPanel() {
+type GrammarStartPanelProps = {
+  searchQuery: string;
+  searchResults: GrammarSearchResult[];
+  searchLoading: boolean;
+  searchError: string | null;
+  hasSearched: boolean;
+  onSearchQueryChange: (value: string) => void;
+  onSearch: () => void;
+  onClearSearch: () => void;
+  onSelectSearchResult: (filename: string) => void;
+};
+
+function GrammarStartPanel({
+  searchQuery,
+  searchResults,
+  searchLoading,
+  searchError,
+  hasSearched,
+  onSearchQueryChange,
+  onSearch,
+  onClearSearch,
+  onSelectSearchResult,
+}: GrammarStartPanelProps) {
   return (
     <Box sx={{ maxWidth: 720 }}>
       <Typography
@@ -18,6 +49,94 @@ function GrammarStartPanel() {
       <Typography sx={{ maxWidth: 560, color: "#aab8d7", lineHeight: 1.7 }}>
         Search for a grammar topic, or select a cheatsheet from the list.
       </Typography>
+
+      <SearchInput
+        value={searchQuery}
+        onChange={(event) => onSearchQueryChange(event.target.value)}
+        onSearch={onSearch}
+        onClear={onClearSearch}
+        placeholder="Search grammar topics..."
+        ariaLabel="Search grammar topics"
+        clearLabel="Clear grammar topic search"
+        sx={{ mt: 4, mb: 4, maxWidth: 600 }}
+        inputSx={{
+          "& .MuiOutlinedInput-root": {
+            minHeight: 50,
+            backgroundColor: "rgba(7, 13, 43, 0.5)",
+            borderRadius: "0.8rem",
+            color: "#edf2ff",
+            "& fieldset": {
+              borderColor: "rgba(103, 124, 184, 0.46)",
+            },
+            "&:hover fieldset": {
+              borderColor: "rgba(132, 153, 214, 0.66)",
+            },
+            "&.Mui-focused fieldset": {
+              borderColor: "var(--primary-color)",
+            },
+          },
+          "& .MuiInputBase-input": {
+            color: "#edf2ff",
+            "&::placeholder": {
+              color: "#91a2c9",
+              opacity: 1,
+            },
+          },
+        }}
+      />
+
+      {searchError && (
+        <Box sx={{ mb: 3 }}>
+          <ErrorAlert message={searchError} />
+        </Box>
+      )}
+
+      {searchLoading ? (
+        <LoadingSpinner />
+      ) : hasSearched && searchResults.length === 0 && !searchError ? (
+        <Typography sx={{ color: "#9ca3af" }}>
+          No matching grammar pages found.
+        </Typography>
+      ) : searchResults.length > 0 ? (
+        <List
+          disablePadding
+          aria-label="Grammar search results"
+          sx={{ display: "grid", gap: 1.25 }}
+        >
+          {searchResults.map((result) => (
+            <ListItem key={result.path || result.url} disablePadding>
+              <ListItemButton
+                onClick={() => onSelectSearchResult(result.path)}
+                sx={{
+                  border: "1px solid rgba(103, 124, 184, 0.38)",
+                  borderRadius: "0.75rem",
+                  backgroundColor: "rgba(15, 25, 61, 0.58)",
+                  transition: "all 160ms ease",
+                  "&:hover": {
+                    borderColor: "rgba(56, 224, 123, 0.44)",
+                    backgroundColor: "rgba(22, 38, 77, 0.72)",
+                    transform: "translateY(-1px)",
+                  },
+                }}
+              >
+                <ListItemText
+                  primary={result.title || result.path}
+                  secondary={result.path}
+                  sx={{
+                    "& .MuiListItemText-primary": {
+                      color: "#f7f9ff",
+                      fontWeight: 600,
+                    },
+                    "& .MuiListItemText-secondary": {
+                      color: "#8fa0c5",
+                    },
+                  }}
+                />
+              </ListItemButton>
+            </ListItem>
+          ))}
+        </List>
+      ) : null}
     </Box>
   );
 }

--- a/frontend/src/components/ui/SearchInput.tsx
+++ b/frontend/src/components/ui/SearchInput.tsx
@@ -14,6 +14,7 @@ interface SearchInputProps {
   onSearch?: () => void;
   onClear?: () => void;
   clearLabel?: string;
+  ariaLabel?: string;
 }
 
 const SearchInput: React.FC<SearchInputProps> = ({
@@ -26,6 +27,7 @@ const SearchInput: React.FC<SearchInputProps> = ({
   onSearch,
   onClear,
   clearLabel = "Clear search",
+  ariaLabel,
 }) => {
   const showClearButton = Boolean(onClear && value);
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -45,6 +47,9 @@ const SearchInput: React.FC<SearchInputProps> = ({
         onChange={onChange}
         onKeyDown={handleKeyDown}
         slotProps={{
+          htmlInput: {
+            "aria-label": ariaLabel,
+          },
           input: {
             endAdornment: showClearButton ? (
               <InputAdornment position="end">


### PR DESCRIPTION
## Summary
- refresh Grammar Cheatsheets with a lighter, searchable library rail and Analyzer-aligned reading surface
- remove the duplicate start-page search and keep the explanatory start copy
- improve search contrast, accessibility labels, filtered counts, responsive ordering, and markdown presentation

## Validation
- `make check-readiness`
- 1,092 backend tests passed
- 552 frontend tests passed
- targeted browser verification for desktop/mobile and the single-search start state
- independent review approved
