### PR TITLE
feat: renovate Recall page design

### DIFF
--- a/frontend/src/components/RecallView.test.tsx
+++ b/frontend/src/components/RecallView.test.tsx
@@ -144,6 +144,17 @@ describe("RecallView", () => {
   it("renders an ordered queue with optional word details", () => {
     render(<RecallView />);
 
+    expect(
+      screen.getByRole("heading", {
+        name: "Recall Your Swedish Vocabulary",
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("complementary", {
+        name: "Recall session summary",
+      })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Changes sync with Telegram.")).toBeInTheDocument();
     expect(screen.getByRole("list")).toBeInTheDocument();
     expect(screen.getAllByRole("listitem")).toHaveLength(2);
     expect(screen.getByText("kontanter")).toBeInTheDocument();
@@ -154,7 +165,7 @@ describe("RecallView", () => {
     expect(screen.getByText("lagom")).toBeInTheDocument();
   });
 
-  it("uses compact accessible action buttons with the agreed tooltips", async () => {
+  it("uses a prominent refresh action and compact row actions with the agreed tooltips", async () => {
     const user = userEvent.setup();
     render(<RecallView />);
 
@@ -168,7 +179,7 @@ describe("RecallView", () => {
       name: "Remove kontanter from learning",
     });
 
-    expect(refresh).toHaveTextContent("");
+    expect(refresh).toHaveTextContent("Refresh selection");
     expect(postpone).toHaveTextContent("");
     expect(remove).toHaveTextContent("");
 

--- a/frontend/src/components/RecallView.tsx
+++ b/frontend/src/components/RecallView.tsx
@@ -1,33 +1,13 @@
-import {
-  Box,
-  Chip,
-  CircularProgress,
-  IconButton,
-  Stack,
-  Tooltip,
-  Typography,
-} from "@mui/material";
-import {
-  InfoOutlined,
-  Refresh,
-  RemoveCircleOutline,
-  Snooze,
-} from "@mui/icons-material";
+import { Box, CircularProgress, Stack, Typography } from "@mui/material";
 import { useRecall } from "../hooks/useRecall";
 import {
   CustomButton,
   ErrorAlert,
   SectionTitle,
   Snackbar,
-  SurfaceCard,
 } from "./ui";
-
-const REFRESH_TOOLTIP =
-  "Refresh selection: lowers the priority of all current words and replaces the selection.";
-const POSTPONE_TOOLTIP =
-  "Postpone: moves this word out of the current selection and lowers its recall priority.";
-const REMOVE_TOOLTIP =
-  "Remove from learning: stops learning this word and removes it from the current selection.";
+import RecallQueuePanel from "./recall/RecallQueuePanel";
+import RecallSummaryPanel from "./recall/RecallSummaryPanel";
 
 const RecallView = () => {
   const {
@@ -83,254 +63,57 @@ const RecallView = () => {
   }
 
   return (
-    <Box sx={{ py: { xs: 4, md: 8 }, maxWidth: 900, mx: "auto" }}>
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          gap: 2,
-          mb: 4,
-        }}
-      >
-        <Box>
-          <SectionTitle marginBottom={0}>Recall</SectionTitle>
-          <Typography sx={{ color: "rgba(255,255,255,0.64)", mt: 0.75 }}>
-            Manage the words selected for your next recall sessions.
-          </Typography>
-        </Box>
-        <Tooltip title={REFRESH_TOOLTIP}>
-          <span>
-            <IconButton
-              aria-label="Refresh selection"
-              disabled={!recall.configured || isMutating}
-              onClick={() => void refreshSelection()}
-              sx={{
-                color: "rgba(255,255,255,0.78)",
-                border: "1px solid rgba(255,255,255,0.16)",
-                borderRadius: 1.5,
-                "&:hover": {
-                  color: "white",
-                  borderColor: "rgba(255,255,255,0.36)",
-                  backgroundColor: "rgba(255,255,255,0.07)",
-                },
-              }}
-            >
-              {pendingAction?.type === "refresh" ? (
-                <CircularProgress size={20} color="inherit" />
-              ) : (
-                <Refresh fontSize="small" />
-              )}
-            </IconButton>
-          </span>
-        </Tooltip>
-      </Box>
-
-      <SurfaceCard padding={2} sx={{ mb: 2 }}>
-        <Box
+    <Box sx={{ py: { xs: 3, md: 5 } }}>
+      <Box sx={{ mb: { xs: 4, md: 5 } }}>
+        <SectionTitle
+          variant="h2"
+          marginBottom={0}
           sx={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            gap: 2,
-            flexWrap: "wrap",
+            color: "#f8fafc",
+            fontSize: { xs: "2.35rem", sm: "3rem" },
+            lineHeight: 1.05,
+            letterSpacing: "-0.04em",
           }}
         >
-          <Box>
-            <Typography
-              sx={{
-                color: "rgba(255,255,255,0.62)",
-                fontSize: "0.76rem",
-                textTransform: "uppercase",
-                letterSpacing: "0.08em",
-              }}
-            >
-              Selected words
-            </Typography>
-            <Typography sx={{ color: "white", fontSize: "1.7rem", fontWeight: 700 }}>
-              {recall.words.length}
-            </Typography>
-          </Box>
-          <Chip
-            label={
-              recall.configured
-                ? `Delivery ${recall.delivery_enabled ? "enabled" : "disabled"}`
-                : "Not configured"
-            }
-            color={
-              recall.configured && recall.delivery_enabled
-                ? "success"
-                : "default"
-            }
-            variant="outlined"
-            sx={{
-              color: "rgba(255,255,255,0.78)",
-              borderColor:
-                recall.configured && recall.delivery_enabled
-                  ? "rgba(52,211,153,0.55)"
-                  : "rgba(255,255,255,0.2)",
-            }}
-          />
-        </Box>
-      </SurfaceCard>
+          Recall Your Swedish Vocabulary
+        </SectionTitle>
+        <Typography
+          sx={{
+            color: "#b3bfd9",
+            fontSize: { xs: "1rem", sm: "1.1rem" },
+            lineHeight: 1.7,
+            mt: 1.5,
+          }}
+        >
+          Manage the words selected for your next recall sessions.
+        </Typography>
+      </Box>
 
-      {!recall.configured ? (
-        <SurfaceCard>
-          <Stack alignItems="center" spacing={1.5} sx={{ textAlign: "center", py: 3 }}>
-            <InfoOutlined sx={{ color: "rgba(255,255,255,0.58)", fontSize: 34 }} />
-            <Typography variant="h6" sx={{ color: "white", fontWeight: 650 }}>
-              Recall is not configured
-            </Typography>
-            <Typography sx={{ color: "rgba(255,255,255,0.66)", maxWidth: 560 }}>
-              Link your Telegram username in Profile, then send{" "}
-              <Box component="span" sx={{ color: "white", fontFamily: "monospace" }}>
-                /start
-              </Box>{" "}
-              to the bot to create your recall selection.
-            </Typography>
-          </Stack>
-        </SurfaceCard>
-      ) : recall.words.length === 0 ? (
-        <SurfaceCard>
-          <Stack alignItems="center" spacing={1} sx={{ textAlign: "center", py: 3 }}>
-            <Typography variant="h6" sx={{ color: "white", fontWeight: 650 }}>
-              No words selected
-            </Typography>
-            <Typography sx={{ color: "rgba(255,255,255,0.66)" }}>
-              There are currently no eligible vocabulary words for recall.
-            </Typography>
-          </Stack>
-        </SurfaceCard>
-      ) : (
-        <Stack component="ol" spacing={1.25} sx={{ listStyle: "none", p: 0, m: 0 }}>
-          {recall.words.map((word, index) => {
-            const postponing =
-              pendingAction?.type === "postpone" &&
-              pendingAction.vocabularyId === word.id;
-            const removing =
-              pendingAction?.type === "remove" &&
-              pendingAction.vocabularyId === word.id;
-
-            return (
-              <Box
-                component="li"
-                key={word.id}
-              >
-                <SurfaceCard
-                  padding={2}
-                  sx={{
-                    "&:hover": { borderColor: "rgba(255,255,255,0.18)" },
-                  }}
-                >
-                  <Box
-                    sx={{
-                      display: "grid",
-                      gridTemplateColumns: "auto minmax(0, 1fr) auto",
-                      gap: { xs: 1.25, sm: 2 },
-                      alignItems: "center",
-                    }}
-                  >
-                    <Typography
-                      aria-hidden="true"
-                      sx={{
-                        color: "rgba(255,255,255,0.38)",
-                        fontSize: "0.78rem",
-                        fontWeight: 700,
-                        width: 20,
-                        textAlign: "center",
-                      }}
-                    >
-                      {index + 1}
-                    </Typography>
-                    <Box sx={{ minWidth: 0 }}>
-                      <Typography
-                        sx={{
-                          color: "white",
-                          fontWeight: 700,
-                          fontSize: { xs: "1rem", sm: "1.08rem" },
-                          overflowWrap: "anywhere",
-                        }}
-                      >
-                        {word.word_phrase}
-                      </Typography>
-                      {word.translation && (
-                        <Typography
-                          sx={{
-                            color: "rgba(255,255,255,0.7)",
-                            mt: 0.25,
-                            overflowWrap: "anywhere",
-                          }}
-                        >
-                          {word.translation}
-                        </Typography>
-                      )}
-                      {word.example_phrase && (
-                        <Typography
-                          sx={{
-                            color: "rgba(255,255,255,0.5)",
-                            fontSize: "0.86rem",
-                            fontStyle: "italic",
-                            mt: 0.75,
-                            overflowWrap: "anywhere",
-                          }}
-                        >
-                          {word.example_phrase}
-                        </Typography>
-                      )}
-                    </Box>
-                    <Stack direction="row" spacing={0.5}>
-                      <Tooltip title={POSTPONE_TOOLTIP}>
-                        <span>
-                          <IconButton
-                            aria-label={`Postpone ${word.word_phrase}`}
-                            disabled={isMutating}
-                            onClick={() =>
-                              void postponeWord(word.id, word.word_phrase)
-                            }
-                            size="small"
-                            sx={{ color: "rgba(255,255,255,0.68)" }}
-                          >
-                            {postponing ? (
-                              <CircularProgress size={18} color="inherit" />
-                            ) : (
-                              <Snooze fontSize="small" />
-                            )}
-                          </IconButton>
-                        </span>
-                      </Tooltip>
-                      <Tooltip title={REMOVE_TOOLTIP}>
-                        <span>
-                          <IconButton
-                            aria-label={`Remove ${word.word_phrase} from learning`}
-                            disabled={isMutating}
-                            onClick={() =>
-                              void removeWord(word.id, word.word_phrase)
-                            }
-                            size="small"
-                            sx={{
-                              color: "rgba(248,113,113,0.72)",
-                              "&:hover": {
-                                color: "#fca5a5",
-                                backgroundColor: "rgba(239,68,68,0.1)",
-                              },
-                            }}
-                          >
-                            {removing ? (
-                              <CircularProgress size={18} color="inherit" />
-                            ) : (
-                              <RemoveCircleOutline fontSize="small" />
-                            )}
-                          </IconButton>
-                        </span>
-                      </Tooltip>
-                    </Stack>
-                  </Box>
-                </SurfaceCard>
-              </Box>
-            );
-          })}
-        </Stack>
-      )}
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", lg: "320px minmax(0, 1fr)" },
+          gap: { xs: 2, lg: 3 },
+          alignItems: "start",
+        }}
+      >
+        <RecallSummaryPanel
+          wordCount={recall.words.length}
+          configured={recall.configured}
+          deliveryEnabled={recall.delivery_enabled}
+          refreshing={pendingAction?.type === "refresh"}
+          disabled={!recall.configured || isMutating}
+          onRefresh={() => void refreshSelection()}
+        />
+        <RecallQueuePanel
+          configured={recall.configured}
+          words={recall.words}
+          pendingAction={pendingAction}
+          isMutating={isMutating}
+          onPostpone={(id, phrase) => void postponeWord(id, phrase)}
+          onRemove={(id, phrase) => void removeWord(id, phrase)}
+        />
+      </Box>
 
       <Snackbar
         open={Boolean(success)}

--- a/frontend/src/components/recall/RecallQueuePanel.tsx
+++ b/frontend/src/components/recall/RecallQueuePanel.tsx
@@ -1,0 +1,258 @@
+import {
+  Box,
+  CircularProgress,
+  IconButton,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  InfoOutlined,
+  RemoveCircleOutline,
+  Snooze,
+} from "@mui/icons-material";
+import type {
+  RecallPendingAction,
+  RecallWord,
+} from "../../types/recall";
+import { buildAnalyzerShellSx } from "../ui";
+
+const POSTPONE_TOOLTIP =
+  "Postpone: moves this word out of the current selection and lowers its recall priority.";
+const REMOVE_TOOLTIP =
+  "Remove from learning: stops learning this word and removes it from the current selection.";
+
+interface RecallQueuePanelProps {
+  configured: boolean;
+  words: RecallWord[];
+  pendingAction: RecallPendingAction | null;
+  isMutating: boolean;
+  onPostpone: (vocabularyId: number, wordPhrase: string) => void;
+  onRemove: (vocabularyId: number, wordPhrase: string) => void;
+}
+
+const QueueEmptyState = ({ configured }: { configured: boolean }) => (
+  <Stack
+    alignItems="center"
+    justifyContent="center"
+    spacing={1.5}
+    sx={{ minHeight: 360, px: 3, py: 7, textAlign: "center" }}
+  >
+    <InfoOutlined sx={{ color: "#8799c4", fontSize: 38 }} />
+    <Typography
+      component="h3"
+      sx={{ color: "#f8fafc", fontSize: "1.35rem", fontWeight: 700 }}
+    >
+      {configured ? "No words selected" : "Recall is not configured"}
+    </Typography>
+    <Typography sx={{ color: "#aebbd8", maxWidth: 560, lineHeight: 1.7 }}>
+      {configured ? (
+        "There are currently no eligible vocabulary words for recall."
+      ) : (
+        <>
+          Link your Telegram username in Profile, then send{" "}
+          <Box
+            component="span"
+            sx={{ color: "#f8fafc", fontFamily: "monospace" }}
+          >
+            /start
+          </Box>{" "}
+          to the bot to create your recall selection.
+        </>
+      )}
+    </Typography>
+  </Stack>
+);
+
+const RecallQueuePanel = ({
+  configured,
+  words,
+  pendingAction,
+  isMutating,
+  onPostpone,
+  onRemove,
+}: RecallQueuePanelProps) => (
+  <Box
+    component="section"
+    aria-labelledby="recall-queue-title"
+    sx={{
+      ...buildAnalyzerShellSx(
+        "radial-gradient(circle at 12% 5%, rgba(27, 42, 101, 0.46), rgba(6, 11, 40, 0.98))"
+      ),
+      overflow: "hidden",
+      minWidth: 0,
+    }}
+  >
+    <Box
+      sx={{
+        px: { xs: 2.25, sm: 3 },
+        py: 2.5,
+        borderBottom: "1px solid rgba(126,145,194,0.25)",
+        display: "flex",
+        alignItems: "baseline",
+        gap: 1.5,
+        flexWrap: "wrap",
+      }}
+    >
+      <Typography
+        id="recall-queue-title"
+        component="h3"
+        sx={{ color: "#f8fafc", fontSize: "1.3rem", fontWeight: 700 }}
+      >
+        Selected words
+      </Typography>
+      <Typography sx={{ color: "#9cadd4", fontSize: "0.92rem" }}>
+        {words.length} in queue
+      </Typography>
+    </Box>
+
+    {!configured || words.length === 0 ? (
+      <QueueEmptyState configured={configured} />
+    ) : (
+      <Box component="ol" sx={{ listStyle: "none", p: 0, m: 0 }}>
+        {words.map((word, index) => {
+          const postponing =
+            pendingAction?.type === "postpone" &&
+            pendingAction.vocabularyId === word.id;
+          const removing =
+            pendingAction?.type === "remove" &&
+            pendingAction.vocabularyId === word.id;
+
+          return (
+            <Box
+              component="li"
+              key={word.id}
+              sx={{
+                display: "grid",
+                gridTemplateColumns: {
+                  xs: "24px minmax(0, 1fr) auto",
+                  sm: "30px minmax(0, 1fr) auto",
+                },
+                alignItems: "center",
+                gap: { xs: 1, sm: 2 },
+                px: { xs: 2, sm: 3 },
+                py: { xs: 2.25, sm: 2.75 },
+                borderBottom:
+                  index < words.length - 1
+                    ? "1px solid rgba(126,145,194,0.24)"
+                    : "none",
+                transition: "background-color 160ms ease",
+                "&:hover": {
+                  backgroundColor: "rgba(88,109,174,0.07)",
+                },
+              }}
+            >
+              <Typography
+                aria-hidden="true"
+                sx={{
+                  color: "#7181a9",
+                  fontSize: "0.84rem",
+                  fontWeight: 700,
+                }}
+              >
+                {index + 1}
+              </Typography>
+
+              <Box sx={{ minWidth: 0 }}>
+                <Stack
+                  direction={{ xs: "column", sm: "row" }}
+                  spacing={{ xs: 0.25, sm: 2 }}
+                  alignItems={{ xs: "flex-start", sm: "baseline" }}
+                >
+                  <Typography
+                    sx={{
+                      color: "#f8fafc",
+                      fontSize: "1.06rem",
+                      fontWeight: 700,
+                      overflowWrap: "anywhere",
+                    }}
+                  >
+                    {word.word_phrase}
+                  </Typography>
+                  {word.translation && (
+                    <Typography
+                      sx={{
+                        color: "#b8c4df",
+                        fontSize: "0.92rem",
+                        overflowWrap: "anywhere",
+                      }}
+                    >
+                      {word.translation}
+                    </Typography>
+                  )}
+                </Stack>
+                {word.example_phrase && (
+                  <Typography
+                    sx={{
+                      color: "#8999bd",
+                      fontSize: "0.88rem",
+                      fontStyle: "italic",
+                      lineHeight: 1.55,
+                      mt: 0.6,
+                      overflowWrap: "anywhere",
+                    }}
+                  >
+                    {word.example_phrase}
+                  </Typography>
+                )}
+              </Box>
+
+              <Stack direction="row" spacing={{ xs: 0, sm: 0.5 }}>
+                <Tooltip title={POSTPONE_TOOLTIP}>
+                  <span>
+                    <IconButton
+                      aria-label={`Postpone ${word.word_phrase}`}
+                      disabled={isMutating}
+                      onClick={() => onPostpone(word.id, word.word_phrase)}
+                      sx={{
+                        color: "#9dadd4",
+                        border: "1px solid transparent",
+                        "&:hover": {
+                          color: "#dbe5ff",
+                          borderColor: "rgba(156,173,216,0.34)",
+                          backgroundColor: "rgba(101,124,190,0.12)",
+                        },
+                      }}
+                    >
+                      {postponing ? (
+                        <CircularProgress size={20} color="inherit" />
+                      ) : (
+                        <Snooze fontSize="small" />
+                      )}
+                    </IconButton>
+                  </span>
+                </Tooltip>
+                <Tooltip title={REMOVE_TOOLTIP}>
+                  <span>
+                    <IconButton
+                      aria-label={`Remove ${word.word_phrase} from learning`}
+                      disabled={isMutating}
+                      onClick={() => onRemove(word.id, word.word_phrase)}
+                      sx={{
+                        color: "#ff656d",
+                        border: "1px solid transparent",
+                        "&:hover": {
+                          color: "#ff848a",
+                          borderColor: "rgba(255,101,109,0.34)",
+                          backgroundColor: "rgba(255,83,93,0.09)",
+                        },
+                      }}
+                    >
+                      {removing ? (
+                        <CircularProgress size={20} color="inherit" />
+                      ) : (
+                        <RemoveCircleOutline fontSize="small" />
+                      )}
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              </Stack>
+            </Box>
+          );
+        })}
+      </Box>
+    )}
+  </Box>
+);
+
+export default RecallQueuePanel;

--- a/frontend/src/components/recall/RecallSummaryPanel.tsx
+++ b/frontend/src/components/recall/RecallSummaryPanel.tsx
@@ -1,0 +1,181 @@
+import {
+  Box,
+  Chip,
+  CircularProgress,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  CheckCircleOutline,
+  Refresh,
+  ShieldOutlined,
+} from "@mui/icons-material";
+import { CustomButton, buildAnalyzerShellSx } from "../ui";
+
+const REFRESH_TOOLTIP =
+  "Refresh selection: lowers the priority of all current words and replaces the selection.";
+
+interface RecallSummaryPanelProps {
+  wordCount: number;
+  configured: boolean;
+  deliveryEnabled: boolean;
+  refreshing: boolean;
+  disabled: boolean;
+  onRefresh: () => void;
+}
+
+const RecallSummaryPanel = ({
+  wordCount,
+  configured,
+  deliveryEnabled,
+  refreshing,
+  disabled,
+  onRefresh,
+}: RecallSummaryPanelProps) => {
+  const deliveryLabel = configured
+    ? `Delivery ${deliveryEnabled ? "enabled" : "disabled"}`
+    : "Not configured";
+
+  return (
+    <Box
+      component="aside"
+      aria-label="Recall session summary"
+      sx={{
+        ...buildAnalyzerShellSx(
+          "radial-gradient(circle at 20% 8%, rgba(32, 48, 112, 0.54), rgba(7, 12, 42, 0.98))"
+        ),
+        p: { xs: 3, md: 4 },
+        minHeight: { lg: 520 },
+        display: "flex",
+        flexDirection: "column",
+        position: { lg: "sticky" },
+        top: { lg: 96 },
+      }}
+    >
+      <Typography
+        sx={{
+          color: "#9cadd4",
+          fontSize: "0.78rem",
+          fontWeight: 600,
+          letterSpacing: "0.08em",
+          textTransform: "uppercase",
+        }}
+      >
+        Next session
+      </Typography>
+
+      <Stack
+        direction="row"
+        alignItems="baseline"
+        spacing={1.25}
+        sx={{ mt: 2.5 }}
+      >
+        <Typography
+          sx={{
+            color: "#f8fafc",
+            fontSize: { xs: "4rem", md: "4.5rem" },
+            fontWeight: 700,
+            letterSpacing: "-0.06em",
+            lineHeight: 0.95,
+          }}
+        >
+          {wordCount}
+        </Typography>
+        <Typography
+          sx={{
+            color: "#f8fafc",
+            fontSize: { xs: "1.6rem", md: "1.8rem" },
+            fontWeight: 700,
+          }}
+        >
+          {wordCount === 1 ? "word" : "words"}
+        </Typography>
+      </Stack>
+
+      <Chip
+        icon={deliveryEnabled ? <CheckCircleOutline /> : undefined}
+        label={deliveryLabel}
+        variant="outlined"
+        sx={{
+          alignSelf: "flex-start",
+          mt: 3,
+          height: 42,
+          px: 1,
+          color: deliveryEnabled ? "#51e58e" : "#b7c2dd",
+          borderColor: deliveryEnabled
+            ? "rgba(81,229,142,0.86)"
+            : "rgba(155,171,211,0.38)",
+          fontSize: "0.95rem",
+          "& .MuiChip-icon": {
+            color: "inherit",
+          },
+        }}
+      />
+
+      <Typography
+        sx={{
+          color: "#bdc9e4",
+          fontSize: "0.98rem",
+          lineHeight: 1.65,
+          mt: 3.5,
+        }}
+      >
+        {configured
+          ? "Your queue is ready for the next scheduled session."
+          : "Connect Recall to prepare your next scheduled session."}
+      </Typography>
+
+      <Tooltip title={REFRESH_TOOLTIP}>
+        <span>
+          <CustomButton
+            type="button"
+            fullWidth
+            size="large"
+            startIcon={
+              refreshing ? (
+                <CircularProgress size={20} color="inherit" />
+              ) : (
+                <Refresh fontSize="small" />
+              )
+            }
+            disabled={disabled}
+            onClick={onRefresh}
+            aria-label="Refresh selection"
+            sx={{
+              mt: 4.5,
+              minHeight: 54,
+              fontSize: "1rem",
+              boxShadow: "0 12px 28px rgba(56,224,123,0.16)",
+              "&:hover": {
+                transform: "translateY(-1px)",
+                boxShadow: "0 16px 32px rgba(56,224,123,0.24)",
+              },
+            }}
+          >
+            Refresh selection
+          </CustomButton>
+        </span>
+      </Tooltip>
+
+      <Box
+        sx={{
+          mt: "auto",
+          pt: 3.5,
+          borderTop: "1px solid rgba(126,145,194,0.24)",
+          display: "flex",
+          alignItems: "center",
+          gap: 1.25,
+          color: "#9cadd4",
+        }}
+      >
+        <ShieldOutlined fontSize="small" />
+        <Typography sx={{ fontSize: "0.86rem" }}>
+          Changes sync with Telegram.
+        </Typography>
+      </Box>
+    </Box>
+  );
+};
+
+export default RecallSummaryPanel;


### PR DESCRIPTION
## Summary
- apply the approved Analyze-inspired Recall page redesign
- split the view into reusable summary and queue panels
- preserve refresh, postpone, remove, loading, empty, and unconfigured behavior
- add responsive and accessibility-focused Recall view assertions

## Validation
- `make check-readiness` (run with local Postgres access)
- desktop and 390px mobile Playwright visual review
- independent code review approved

Task: FFZRU2EphLeB