### PR TITLE
test: cover chat controls collapse

### DIFF
--- a/frontend/src/components/ChatView.test.tsx
+++ b/frontend/src/components/ChatView.test.tsx
@@ -161,6 +161,26 @@ describe('ChatView', () => {
     expect(screen.getByText('Speed:')).toBeInTheDocument();
   });
 
+  it('collapses teacher chat controls and restores the show-toggle label', async () => {
+    render(
+      <AuthProvider>
+        <ChatView />
+      </AuthProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /show chat controls/i }));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /hide chat controls/i })).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /hide chat controls/i }));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /show chat controls/i })).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    expect(document.getElementById('teacher-chat-controls-panel')).not.toBeInTheDocument();
+  });
+
   it('keeps chat controls expanded and disables the toggle while recording', () => {
     const startRecording = vi.fn();
     const stopRecording = vi.fn();


### PR DESCRIPTION
## Summary
- cover collapsing the redesigned teacher chat controls
- verify the toggle restores the show label and removes the collapsed panel

## Validation
- npm run test:run -- src/components/ChatView.test.tsx passed
- git diff --check passed
- make check-readiness reached 1,036 passing backend tests but reported 15 failures and 50 errors in unrelated existing backend/database/memory paths; frontend lint was not reached after backend-test failure

## Scope
Frontend test-only change in ChatView.test.tsx.