### PR TITLE
feat: integrate Better Stack error tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,11 @@ HF_TOKEN=your_huggingface_token_here
 ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,http://frontend:3010
 FRONTEND_URL=http://localhost:5173
 
+# Better Stack Errors (Sentry-compatible). Set the real DSN only in deployment secrets.
+SENTRY_DSN=
+# SENTRY_ENVIRONMENT=production
+# SENTRY_RELEASE=runestone-api@1.0.0
+
 VERBOSE=true
 
 # Frontend API Configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",
     "fastapi>=0.136.3",
+    "sentry-sdk>=2.0.0",
     "uvicorn[standard]>=0.30.0",
     "python-multipart>=0.0.29",
     "sqlalchemy>=2.0.0",

--- a/src/runestone/api/main.py
+++ b/src/runestone/api/main.py
@@ -26,6 +26,7 @@ from runestone.core.clients.voice.voice_factory import (
     create_voice_synthesis_client,
     create_voice_transcription_client,
 )
+from runestone.core.error_tracking import setup_error_tracking
 from runestone.core.logging_config import setup_logging
 from runestone.core.service_llm import build_service_llm_model
 from runestone.db.database import setup_database
@@ -33,6 +34,9 @@ from runestone.rag.index import GrammarIndex
 from runestone.services.grammar_service import GrammarService
 from runestone.services.tts_service import TTSService
 from runestone.services.voice_service import VoiceService
+
+# Initialize before application startup so lifespan and request failures are captured.
+setup_error_tracking(settings)
 
 
 @asynccontextmanager

--- a/src/runestone/config.py
+++ b/src/runestone/config.py
@@ -115,6 +115,9 @@ class Settings(BaseSettings):
     allowed_origins: str
     cheatsheets_dir: str = "cheatsheets"
     frontend_url: str
+    sentry_dsn: Optional[str] = None
+    sentry_environment: Optional[str] = None
+    sentry_release: Optional[str] = None
 
     # HuggingFace / sentence-transformers cache (must be writable in containers)
     hf_cache_dir: str = "state/hf-cache"

--- a/src/runestone/core/error_tracking.py
+++ b/src/runestone/core/error_tracking.py
@@ -1,0 +1,38 @@
+"""Configure privacy-conscious application error tracking."""
+
+from typing import Any
+
+import sentry_sdk
+from sentry_sdk.integrations.logging import LoggingIntegration
+
+from runestone.config import Settings
+
+
+def _scrub_sensitive_event_data(event: dict[str, Any], _hint: dict[str, Any]) -> dict[str, Any]:
+    """Remove query values that may contain JWTs or user-entered text."""
+    request = event.get("request")
+    if isinstance(request, dict):
+        request.pop("query_string", None)
+        url = request.get("url")
+        if isinstance(url, str):
+            request["url"] = url.partition("?")[0]
+
+    return event
+
+
+def setup_error_tracking(settings: Settings) -> None:
+    """Initialize Sentry-compatible error reporting when a DSN is configured."""
+    if not settings.sentry_dsn:
+        return
+
+    sentry_sdk.init(
+        dsn=settings.sentry_dsn,
+        environment=settings.sentry_environment,
+        release=settings.sentry_release,
+        send_default_pii=False,
+        include_local_variables=False,
+        max_request_body_size="never",
+        traces_sample_rate=0.0,
+        before_send=_scrub_sensitive_event_data,
+        integrations=[LoggingIntegration(level=None, event_level=None, sentry_logs_level=None)],
+    )

--- a/tests/core/test_error_tracking.py
+++ b/tests/core/test_error_tracking.py
@@ -1,0 +1,59 @@
+"""Tests for error tracking initialization."""
+
+from unittest.mock import Mock, patch
+
+from runestone.config import Settings
+from runestone.core.error_tracking import _scrub_sensitive_event_data, setup_error_tracking
+
+
+def test_error_tracking_is_disabled_without_dsn() -> None:
+    """Do not initialize reporting unless a deployment explicitly configures it."""
+    settings = Mock(spec=Settings)
+    settings.sentry_dsn = None
+
+    with patch("runestone.core.error_tracking.sentry_sdk.init") as init:
+        setup_error_tracking(settings)
+
+    init.assert_not_called()
+
+
+def test_error_tracking_uses_privacy_conscious_defaults() -> None:
+    """Configure Better Stack without request bodies, default PII, or tracing."""
+    settings = Mock(spec=Settings)
+    settings.sentry_dsn = "https://token@example.com/123"
+    settings.sentry_environment = "production"
+    settings.sentry_release = "runestone-api@abc123"
+
+    with patch("runestone.core.error_tracking.sentry_sdk.init") as init:
+        setup_error_tracking(settings)
+
+    init.assert_called_once()
+    options = init.call_args.kwargs
+    assert options["dsn"] == "https://token@example.com/123"
+    assert options["environment"] == "production"
+    assert options["release"] == "runestone-api@abc123"
+    assert options["send_default_pii"] is False
+    assert options["include_local_variables"] is False
+    assert options["max_request_body_size"] == "never"
+    assert options["traces_sample_rate"] == 0.0
+    assert options["before_send"] is _scrub_sensitive_event_data
+
+    logging_integration = options["integrations"][0]
+    assert logging_integration._breadcrumb_handler is None
+    assert logging_integration._handler is None
+    assert logging_integration._sentry_logs_handler is None
+
+
+def test_sensitive_query_data_is_removed_from_events() -> None:
+    """Never export JWT query parameters or user-entered query content."""
+    event = {
+        "request": {
+            "url": "https://example.com/audio/ws?token=secret-jwt",
+            "query_string": "token=secret-jwt",
+        }
+    }
+
+    scrubbed_event = _scrub_sensitive_event_data(event, {})
+
+    assert scrubbed_event["request"] == {"url": "https://example.com/audio/ws"}
+    assert "secret-jwt" not in str(scrubbed_event)

--- a/uv.lock
+++ b/uv.lock
@@ -2728,6 +2728,7 @@ dependencies = [
     { name = "readability-lxml" },
     { name = "rich" },
     { name = "sentence-transformers" },
+    { name = "sentry-sdk" },
     { name = "sqlalchemy" },
     { name = "torch", version = "2.12.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
     { name = "torch", version = "2.12.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
@@ -2789,6 +2790,7 @@ requires-dist = [
     { name = "readability-lxml", specifier = ">=0.8.1" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "sentence-transformers", specifier = ">=3.0.0" },
+    { name = "sentry-sdk", specifier = ">=2.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "torch", specifier = ">=2.5.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "trafilatura", specifier = ">=2.0.0" },
@@ -2912,6 +2914,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f9/56/d2cb00765a6b15c994a7fccf20f9032f16e8193ca49147cb5155166ad744/sentence_transformers-5.6.0.tar.gz", hash = "sha256:0e7164d051e416c1853ade7c274ff52af3f9da0f4be7f0b83d734c27699e1057", size = 453194, upload-time = "2026-06-16T14:01:56.42Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c1/dc1582b79e9a2eb0cddf9559cd9bcdff084f541d6fe881fdd9d98630dba7/sentence_transformers-5.6.0-py3-none-any.whl", hash = "sha256:d2075b5e687a1611005e20ab04a6846994d51adfcf39610aed066af3c0c0b81f", size = 596411, upload-time = "2026-06-16T14:01:55.103Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.66.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/6f/d59cad0889d15fde85254cf58e701484de3f3f0406003b3197746910b19b/sentry_sdk-2.66.1.tar.gz", hash = "sha256:f882fb08710c5f8bfc603aafa3e901b384009a19cc3f76a572b863392ee81cdc", size = 940543, upload-time = "2026-07-22T12:26:54.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/d3/726bd88f0eece09ddf431bea4c9191c18e7a8d070b854eb0014d447712ee/sentry_sdk-2.66.1-py3-none-any.whl", hash = "sha256:86002793161d9a95ef04bdd8d442e9bfece5d989b755f05d6360215094a7aff6", size = 505555, upload-time = "2026-07-22T12:26:52.71Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add opt-in Sentry SDK integration for FastAPI and Better Stack Errors
- configure privacy-safe defaults: no request bodies, query strings, stack locals, logging breadcrumbs, PII, or tracing
- add SENTRY_DSN, SENTRY_ENVIRONMENT, and SENTRY_RELEASE settings
- add focused initialization and event-sanitization tests

The real Better Stack DSN remains deployment-only via SENTRY_DSN; it is intentionally blank in .env.example.

## Validation
- make check-readiness
- make security-check
- independent privacy/security review approved

## Deployment
Set SENTRY_DSN in Coolify/deployment secrets. Set SENTRY_RELEASE to runestone-api@{FULL_GIT_COMMIT_SHA} for immutable release tracking.