### PR TITLE
Refactor auth database access through service layer

### DIFF
--- a/src/runestone/api/auth_endpoints.py
+++ b/src/runestone/api/auth_endpoints.py
@@ -4,30 +4,29 @@ Authentication endpoints for Runestone.
 This module provides registration and login endpoints for user authentication.
 """
 
-from datetime import timedelta
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
-from runestone.api.schemas import LoginRequest
-from runestone.auth.security import create_access_token, hash_password, verify_password
-from runestone.config import settings
-from runestone.db.database import get_db
-from runestone.db.models import User
+from runestone.api.schemas import LoginRequest, RegisterRequest
+from runestone.core.exceptions import InactiveUserError, InvalidCredentialsError, RegistrationError
+from runestone.dependencies import get_auth_service
+from runestone.services.auth_service import AuthService
 
 router = APIRouter()
 
 
 @router.post("/register")
-async def register(user_data: dict, db: Annotated[AsyncSession, Depends(get_db)]):
+async def register(
+    user_data: RegisterRequest,
+    service: Annotated[AuthService, Depends(get_auth_service)],
+):
     """
     Register a new user.
 
     Args:
-        user_data: Dictionary containing 'email' and 'password'
-        db: Database session
+        user_data: Registration email and password
+        service: Authentication use-case service
 
     Returns:
         User creation confirmation
@@ -35,50 +34,25 @@ async def register(user_data: dict, db: Annotated[AsyncSession, Depends(get_db)]
     Raises:
         HTTPException: If email already exists or password is too short
     """
-    email = user_data.get("email")
-    password = user_data.get("password")
+    try:
+        user = await service.register_user(user_data.email, user_data.password)
+    except RegistrationError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
-    if not email or not password:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email and password are required")
-
-    if len(password) < settings.min_password_length:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Password must be at least {settings.min_password_length} characters long",
-        )
-
-    # Check if user already exists
-    stmt = select(User).filter(User.email == email)
-    result = await db.execute(stmt)
-    existing_user = result.scalars().first()
-    if existing_user:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already registered")
-
-    # Create new user
-    hashed_password = hash_password(password)
-    db_user = User(
-        email=email,
-        hashed_password=hashed_password,
-        name=email.split("@")[0],  # Use email prefix as default name
-        timezone="UTC",
-        pages_recognised_count=0,
-    )
-
-    db.add(db_user)
-    await db.commit()
-    await db.refresh(db_user)
-
-    return {"message": "User registered successfully", "user_id": db_user.id}
+    return {"message": "User registered successfully", "user_id": user.id}
 
 
 @router.post("/")
-async def login(login_data: LoginRequest, db: Annotated[AsyncSession, Depends(get_db)]):
+async def login(
+    login_data: LoginRequest,
+    service: Annotated[AuthService, Depends(get_auth_service)],
+):
     """
     Authenticate user and return access token.
 
     Args:
         login_data: Login request with email and password
-        db: Database session
+        service: Authentication use-case service
 
     Returns:
         Access token and token type
@@ -86,25 +60,13 @@ async def login(login_data: LoginRequest, db: Annotated[AsyncSession, Depends(ge
     Raises:
         HTTPException: If credentials are invalid
     """
-    stmt = select(User).filter(User.email == login_data.email)
-    result = await db.execute(stmt)
-    user = result.scalars().first()
-    if not user or not verify_password(login_data.password, user.hashed_password):
+    try:
+        access_token = await service.login(login_data.email, login_data.password)
+    except (InvalidCredentialsError, InactiveUserError) as exc:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Incorrect email or password",
+            detail=str(exc),
             headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    if not user.active:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="User is not active",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    # Create access token
-    access_token_expires = timedelta(days=settings.jwt_expiration_days)
-    access_token = create_access_token(data={"sub": str(user.id)}, expires_delta=access_token_expires)
+        ) from exc
 
     return {"access_token": access_token, "token_type": "bearer"}

--- a/src/runestone/api/schemas.py
+++ b/src/runestone/api/schemas.py
@@ -45,6 +45,8 @@ __all__ = [
     "LearnedTimesDistributionItem",
     "UserProfileResponse",
     "UserProfileUpdate",
+    "RegisterRequest",
+    "LoginRequest",
     "MemoryMaintenanceStatusResponse",
 ]
 
@@ -248,8 +250,17 @@ class UserProfileUpdate(BaseModel):
 
 
 class LoginRequest(BaseModel):
+    """Credentials submitted for login."""
+
     email: str
     password: str
+
+
+class RegisterRequest(BaseModel):
+    """Registration fields with service-owned required-value validation."""
+
+    email: Optional[str] = None
+    password: Optional[str] = None
 
 
 class MemoryMaintenanceStatusResponse(BaseModel):

--- a/src/runestone/auth/dependencies.py
+++ b/src/runestone/auth/dependencies.py
@@ -5,19 +5,23 @@ This module provides dependency functions for user authentication,
 including the get_current_user dependency for securing endpoints.
 """
 
-from fastapi import Depends, HTTPException, status
-from fastapi.security import HTTPBearer
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
+from typing import Annotated
 
-from runestone.auth.security import verify_token
-from runestone.db.database import get_db
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from runestone.core.exceptions import InactiveUserError, InvalidAccessTokenError
 from runestone.db.models import User
+from runestone.dependencies import get_auth_service
+from runestone.services.auth_service import AuthService
 
 security = HTTPBearer()
 
 
-async def get_current_user(token: str = Depends(security), db: AsyncSession = Depends(get_db)) -> User:
+async def get_current_user(
+    token: Annotated[HTTPAuthorizationCredentials, Depends(security)],
+    service: Annotated[AuthService, Depends(get_auth_service)],
+) -> User:
     """
     FastAPI dependency to get the current authenticated user.
 
@@ -26,7 +30,7 @@ async def get_current_user(token: str = Depends(security), db: AsyncSession = De
 
     Args:
         token: JWT token from Authorization header
-        db: Database session
+        service: Authentication use-case service
 
     Returns:
         User model instance for the authenticated user
@@ -34,46 +38,16 @@ async def get_current_user(token: str = Depends(security), db: AsyncSession = De
     Raises:
         HTTPException: If token is invalid or user not found
     """
-    payload = verify_token(token.credentials)
-    if not payload:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid authentication credentials",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    user_id = payload.get("sub")
-    if not user_id:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid token payload",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
     try:
-        user_id_int = int(user_id)
-    except ValueError:
+        return await service.resolve_access_token(token.credentials)
+    except InvalidAccessTokenError as exc:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid user ID in token",
+            detail=str(exc),
             headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    stmt = select(User).filter(User.id == user_id_int)
-    result = await db.execute(stmt)
-    user = result.scalars().first()
-
-    if not user:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="User not found",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    if not user.active:
+        ) from exc
+    except InactiveUserError as exc:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="User is not active",
-        )
-
-    return user
+            detail=str(exc),
+        ) from exc

--- a/src/runestone/core/exceptions.py
+++ b/src/runestone/core/exceptions.py
@@ -127,6 +127,26 @@ class UserNotFoundError(ValueError):
     pass
 
 
+class RegistrationError(ValueError):
+    """Raised when submitted registration data cannot create an account."""
+
+
+class UserEmailAlreadyExistsError(RegistrationError):
+    """Raised when a user email conflicts with the persisted unique constraint."""
+
+
+class InvalidCredentialsError(ValueError):
+    """Raised when login credentials do not identify a valid user."""
+
+
+class InvalidAccessTokenError(ValueError):
+    """Raised when an access token cannot resolve an authenticated user."""
+
+
+class InactiveUserError(ValueError):
+    """Raised when an otherwise authenticated user is inactive."""
+
+
 class PermissionDeniedError(ValueError):
     """Raised when a user lacks permission to perform an action."""
 

--- a/src/runestone/db/user_repository.py
+++ b/src/runestone/db/user_repository.py
@@ -1,9 +1,10 @@
 from typing import Optional
 
 from sqlalchemy import select, update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..core.exceptions import UserNotFoundError
+from ..core.exceptions import UserEmailAlreadyExistsError, UserNotFoundError
 from ..db.models import User
 
 
@@ -41,12 +42,56 @@ class UserRepository:
         result = await self.db.execute(stmt)
         return list(result.scalars().all())
 
-    async def create(self, user: User) -> User:
-        """Create a new user."""
+    async def add_user(self, user: User) -> User:
+        """Add and flush a user without deciding the outer transaction."""
         self.db.add(user)
-        await self.db.commit()
-        await self.db.refresh(user)
+        try:
+            await self.db.flush()
+        except IntegrityError as exc:
+            if self._is_user_email_unique_violation(exc):
+                raise UserEmailAlreadyExistsError("Email already registered") from exc
+            raise
         return user
+
+    @staticmethod
+    def _is_user_email_unique_violation(exc: IntegrityError) -> bool:
+        """Identify only the supported database constraints for unique user email."""
+        supported_constraints = {"users_email_key", "ix_users_email"}
+        pending = [exc.orig]
+        seen: set[int] = set()
+        has_unique_violation_state = False
+        constraint_names: set[str] = set()
+
+        while pending:
+            current = pending.pop()
+            if current is None or id(current) in seen:
+                continue
+            seen.add(id(current))
+
+            if str(current) == "UNIQUE constraint failed: users.email":
+                return True
+
+            sqlstate = getattr(current, "sqlstate", None) or getattr(current, "pgcode", None)
+            has_unique_violation_state = has_unique_violation_state or sqlstate == "23505"
+
+            constraint_name = getattr(current, "constraint_name", None)
+            diagnostic = getattr(current, "diag", None)
+            if diagnostic is not None:
+                constraint_name = constraint_name or getattr(diagnostic, "constraint_name", None)
+            if constraint_name:
+                constraint_names.add(constraint_name)
+
+            pending.extend((getattr(current, "__cause__", None), getattr(current, "__context__", None)))
+
+        return has_unique_violation_state and bool(constraint_names & supported_constraints)
+
+    async def commit(self) -> None:
+        """Commit the current user use-case transaction."""
+        await self.db.commit()
+
+    async def rollback(self) -> None:
+        """Roll back the current user use-case transaction."""
+        await self.db.rollback()
 
     async def update(self, user: User) -> User:
         """Update an existing user."""

--- a/src/runestone/dependencies.py
+++ b/src/runestone/dependencies.py
@@ -28,6 +28,7 @@ from runestone.db.vocabulary_repository import VocabularyRepository
 from runestone.rag.index import GrammarIndex
 from runestone.recall.service import RecallService
 from runestone.services.agent_side_effect_service import AgentSideEffectService
+from runestone.services.auth_service import AuthService
 from runestone.services.chat_service import ChatService
 from runestone.services.chat_session_learning_focus_service import ChatSessionLearningFocusService
 from runestone.services.grammar_service import GrammarService
@@ -162,6 +163,14 @@ def get_user_service(
         UserService: Service instance with its repository dependency
     """
     return UserService(user_repo)
+
+
+def get_auth_service(
+    user_repo: Annotated[UserRepository, Depends(get_user_repository)],
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> AuthService:
+    """Build request-scoped authentication over the user repository."""
+    return AuthService(user_repo, settings)
 
 
 def get_memory_item_service(

--- a/src/runestone/services/auth_service.py
+++ b/src/runestone/services/auth_service.py
@@ -1,0 +1,90 @@
+"""Authentication use cases over the user account repository."""
+
+from datetime import timedelta
+
+from runestone.auth.security import create_access_token, hash_password, verify_password, verify_token
+from runestone.config import Settings
+from runestone.core.exceptions import (
+    InactiveUserError,
+    InvalidAccessTokenError,
+    InvalidCredentialsError,
+    RegistrationError,
+    UserEmailAlreadyExistsError,
+)
+from runestone.db.models import User
+from runestone.db.user_repository import UserRepository
+
+
+class AuthService:
+    """Coordinate account registration and authentication for API transports."""
+
+    def __init__(self, user_repository: UserRepository, settings: Settings):
+        """Initialize authentication with required persistence and configuration."""
+        self.user_repository = user_repository
+        self.settings = settings
+
+    async def register_user(self, email: str | None, password: str | None) -> User:
+        """Validate and persist a new inactive user in one transaction."""
+        if not email or not password:
+            raise RegistrationError("Email and password are required")
+
+        if len(password) < self.settings.min_password_length:
+            raise RegistrationError(f"Password must be at least {self.settings.min_password_length} characters long")
+
+        if await self.user_repository.get_by_email(email):
+            raise UserEmailAlreadyExistsError("Email already registered")
+
+        user = User(
+            email=email,
+            hashed_password=hash_password(password),
+            name=email.split("@")[0],
+            timezone="UTC",
+            pages_recognised_count=0,
+        )
+
+        try:
+            await self.user_repository.add_user(user)
+            await self.user_repository.commit()
+        except Exception:
+            await self.user_repository.rollback()
+            raise
+
+        return user
+
+    async def login(self, email: str, password: str) -> str:
+        """Authenticate active user credentials and return an access token."""
+        user = await self.user_repository.get_by_email(email)
+        if not user or not verify_password(password, user.hashed_password):
+            raise InvalidCredentialsError("Incorrect email or password")
+
+        if not user.active:
+            raise InactiveUserError("User is not active")
+
+        return create_access_token(
+            data={"sub": str(user.id)},
+            expires_delta=timedelta(days=self.settings.jwt_expiration_days),
+        )
+
+    async def resolve_access_token(self, token: str) -> User:
+        """Verify an access token and return its current active user."""
+        payload = verify_token(token)
+        if not payload:
+            raise InvalidAccessTokenError("Invalid authentication credentials")
+
+        user_id = payload.get("sub")
+        if not user_id:
+            raise InvalidAccessTokenError("Invalid token payload")
+
+        try:
+            user_id_int = int(user_id)
+        except (TypeError, ValueError) as exc:
+            raise InvalidAccessTokenError("Invalid user ID in token") from exc
+
+        user = await self.user_repository.get_by_id(user_id_int)
+        if not user:
+            raise InvalidAccessTokenError("User not found")
+
+        if not user.active:
+            raise InactiveUserError("User is not active")
+
+        return user

--- a/tests/api/test_auth_endpoints.py
+++ b/tests/api/test_auth_endpoints.py
@@ -1,0 +1,79 @@
+"""Integration coverage for registration and login contracts."""
+
+from fastapi import status
+from sqlalchemy import select
+
+from runestone.auth.dependencies import get_current_user
+from runestone.auth.security import hash_password
+from runestone.db.models import User
+
+
+async def test_register_persists_inactive_user_with_existing_response_contract(client):
+    response = await client.post(
+        "/api/auth/register",
+        json={"email": "registered@example.com", "password": "password123"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    result = await client.db.execute(select(User).where(User.email == "registered@example.com"))
+    user = result.scalar_one()
+    assert response.json() == {"message": "User registered successfully", "user_id": user.id}
+    assert user.name == "registered"
+    assert user.active is False
+
+
+async def test_register_preserves_required_fields_error(client):
+    response = await client.post("/api/auth/register", json={})
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "Email and password are required"
+
+
+async def test_register_preserves_short_password_error(client):
+    response = await client.post(
+        "/api/auth/register",
+        json={"email": "registered@example.com", "password": "short"},
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "Password must be at least 6 characters long"
+
+
+async def test_register_preserves_duplicate_email_error(client):
+    response = await client.post(
+        "/api/auth/register",
+        json={"email": client.user.email, "password": "password123"},
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "Email already registered"
+
+
+async def test_login_returns_token_that_resolves_current_user(client_with_overrides, user_factory):
+    email = "login@example.com"
+    password = "password123"
+    user = await user_factory(email=email, hashed_password=hash_password(password), active=True)
+
+    async for client, _ in client_with_overrides():
+        login_response = await client.post("/api/auth/", json={"email": email, "password": password})
+
+        assert login_response.status_code == status.HTTP_200_OK
+        assert login_response.json()["token_type"] == "bearer"
+        token = login_response.json()["access_token"]
+
+        client.app.dependency_overrides.pop(get_current_user)
+        profile_response = await client.get("/api/me", headers={"Authorization": f"Bearer {token}"})
+
+        assert profile_response.status_code == status.HTTP_200_OK
+        assert profile_response.json()["id"] == user.id
+
+
+async def test_login_preserves_incorrect_credentials_error(client):
+    response = await client.post(
+        "/api/auth/",
+        json={"email": "missing@example.com", "password": "password123"},
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json()["detail"] == "Incorrect email or password"
+    assert response.headers["www-authenticate"] == "Bearer"

--- a/tests/db/test_user_repository.py
+++ b/tests/db/test_user_repository.py
@@ -1,0 +1,68 @@
+"""Tests for user persistence behavior."""
+
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from runestone.core.exceptions import UserEmailAlreadyExistsError
+from runestone.db.models import User
+from runestone.db.user_repository import UserRepository
+
+
+def make_user(email: str) -> User:
+    """Build a valid user row for repository tests."""
+    return User(email=email, hashed_password="hashed", name="User", timezone="UTC")
+
+
+async def test_add_user_flushes_without_committing(user_repository):
+    user = make_user("new@example.com")
+
+    returned = await user_repository.add_user(user)
+
+    assert returned is user
+    assert user.id is not None
+    await user_repository.rollback()
+
+
+async def test_add_user_translates_email_unique_constraint(user_repository, db_session):
+    db_session.add(make_user("taken@example.com"))
+    await db_session.commit()
+
+    with pytest.raises(UserEmailAlreadyExistsError, match="Email already registered"):
+        await user_repository.add_user(make_user("taken@example.com"))
+
+    await user_repository.rollback()
+
+
+@pytest.mark.parametrize("constraint_name", ["users_email_key", "ix_users_email"])
+def test_email_unique_matcher_supports_postgresql_constraint_names(constraint_name):
+    violation = SimpleNamespace(sqlstate="23505", constraint_name=constraint_name)
+    error = IntegrityError("INSERT INTO users", {}, violation)
+
+    assert UserRepository._is_user_email_unique_violation(error) is True
+
+
+def test_email_unique_matcher_supports_exact_sqlite_error():
+    error = IntegrityError("INSERT INTO users", {}, Exception("UNIQUE constraint failed: users.email"))
+
+    assert UserRepository._is_user_email_unique_violation(error) is True
+
+
+def test_email_unique_matcher_ignores_constraint_names_outside_driver_metadata():
+    error = IntegrityError(
+        "INSERT INTO users /* ix_users_email users_email_key */",
+        {"email": "ix_users_email"},
+        SimpleNamespace(sqlstate="23505", constraint_name="ix_users_telegram_username"),
+    )
+
+    assert UserRepository._is_user_email_unique_violation(error) is False
+
+
+async def test_add_user_preserves_unrelated_integrity_errors(user_repository):
+    invalid_user = User(email="invalid@example.com", hashed_password=None, name="User", timezone="UTC")
+
+    with pytest.raises(IntegrityError):
+        await user_repository.add_user(invalid_user)
+
+    await user_repository.rollback()

--- a/tests/services/test_auth_service.py
+++ b/tests/services/test_auth_service.py
@@ -1,0 +1,201 @@
+"""Tests for authentication use cases and transaction ownership."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from runestone.core.exceptions import (
+    InactiveUserError,
+    InvalidAccessTokenError,
+    InvalidCredentialsError,
+    RegistrationError,
+    UserEmailAlreadyExistsError,
+)
+from runestone.db.models import User
+from runestone.services.auth_service import AuthService
+
+
+@pytest.fixture
+def auth_repository():
+    """Return an authentication-ready user repository double."""
+    repository = Mock()
+    repository.get_by_email = AsyncMock(return_value=None)
+    repository.get_by_id = AsyncMock(return_value=None)
+    repository.add_user = AsyncMock()
+    repository.commit = AsyncMock()
+    repository.rollback = AsyncMock()
+    return repository
+
+
+@pytest.fixture
+def auth_service(auth_repository):
+    """Build AuthService with explicit test settings."""
+    settings = SimpleNamespace(min_password_length=6, jwt_expiration_days=7)
+    return AuthService(auth_repository, settings)
+
+
+async def test_register_user_requires_email_and_password(auth_service, auth_repository):
+    with pytest.raises(RegistrationError, match="Email and password are required"):
+        await auth_service.register_user(None, None)
+
+    auth_repository.get_by_email.assert_not_awaited()
+    auth_repository.rollback.assert_not_awaited()
+
+
+async def test_register_user_rejects_short_password(auth_service, auth_repository):
+    with pytest.raises(RegistrationError, match="Password must be at least 6 characters long"):
+        await auth_service.register_user("new@example.com", "short")
+
+    auth_repository.get_by_email.assert_not_awaited()
+    auth_repository.rollback.assert_not_awaited()
+
+
+@patch("runestone.services.auth_service.hash_password")
+async def test_register_user_rejects_existing_email_before_add(hash_password, auth_service, auth_repository):
+    auth_repository.get_by_email.return_value = User(id=1, email="new@example.com")
+
+    with pytest.raises(UserEmailAlreadyExistsError, match="Email already registered"):
+        await auth_service.register_user("new@example.com", "password")
+
+    hash_password.assert_not_called()
+    auth_repository.add_user.assert_not_awaited()
+    auth_repository.commit.assert_not_awaited()
+    auth_repository.rollback.assert_not_awaited()
+
+
+@patch("runestone.services.auth_service.hash_password", return_value="hashed-password")
+async def test_register_user_commits_once_and_returns_default_account(hash_password, auth_service, auth_repository):
+    user = await auth_service.register_user("new@example.com", "password")
+
+    assert user.email == "new@example.com"
+    assert user.hashed_password == "hashed-password"
+    assert user.name == "new"
+    assert user.timezone == "UTC"
+    assert user.pages_recognised_count == 0
+    auth_repository.get_by_email.assert_awaited_once_with("new@example.com")
+    hash_password.assert_called_once_with("password")
+    auth_repository.add_user.assert_awaited_once_with(user)
+    auth_repository.commit.assert_awaited_once_with()
+    auth_repository.rollback.assert_not_awaited()
+
+
+async def test_register_user_rolls_back_repository_duplicate_race(auth_service, auth_repository):
+    auth_repository.add_user.side_effect = UserEmailAlreadyExistsError("Email already registered")
+
+    with pytest.raises(UserEmailAlreadyExistsError, match="Email already registered"):
+        await auth_service.register_user("new@example.com", "password")
+
+    auth_repository.add_user.assert_awaited_once()
+    auth_repository.commit.assert_not_awaited()
+    auth_repository.rollback.assert_awaited_once_with()
+
+
+async def test_register_user_rolls_back_unexpected_persistence_failure(auth_service, auth_repository):
+    failure = RuntimeError("database unavailable")
+    auth_repository.commit.side_effect = failure
+
+    with pytest.raises(RuntimeError, match="database unavailable"):
+        await auth_service.register_user("new@example.com", "password")
+
+    auth_repository.rollback.assert_awaited_once_with()
+
+
+@patch("runestone.services.auth_service.verify_password")
+async def test_login_rejects_unknown_email_without_password_check(verify_password, auth_service, auth_repository):
+    with pytest.raises(InvalidCredentialsError, match="Incorrect email or password"):
+        await auth_service.login("missing@example.com", "password")
+
+    verify_password.assert_not_called()
+
+
+@patch("runestone.services.auth_service.verify_password", return_value=False)
+async def test_login_rejects_wrong_password(verify_password, auth_service, auth_repository):
+    auth_repository.get_by_email.return_value = User(
+        id=1,
+        email="user@example.com",
+        hashed_password="stored-hash",
+        name="User",
+        active=True,
+    )
+
+    with pytest.raises(InvalidCredentialsError, match="Incorrect email or password"):
+        await auth_service.login("user@example.com", "wrong")
+
+    verify_password.assert_called_once_with("wrong", "stored-hash")
+
+
+@patch("runestone.services.auth_service.verify_password", return_value=True)
+async def test_login_rejects_inactive_user(_verify_password, auth_service, auth_repository):
+    auth_repository.get_by_email.return_value = User(
+        id=1,
+        email="user@example.com",
+        hashed_password="stored-hash",
+        name="User",
+        active=False,
+    )
+
+    with pytest.raises(InactiveUserError, match="User is not active"):
+        await auth_service.login("user@example.com", "password")
+
+
+@patch("runestone.services.auth_service.create_access_token", return_value="access-token")
+@patch("runestone.services.auth_service.verify_password", return_value=True)
+async def test_login_returns_access_token(verify_password, create_access_token, auth_service, auth_repository):
+    user = User(
+        id=42,
+        email="user@example.com",
+        hashed_password="stored-hash",
+        name="User",
+        active=True,
+    )
+    auth_repository.get_by_email.return_value = user
+
+    token = await auth_service.login("user@example.com", "password")
+
+    assert token == "access-token"
+    verify_password.assert_called_once_with("password", "stored-hash")
+    create_access_token.assert_called_once()
+    assert create_access_token.call_args.kwargs["data"] == {"sub": "42"}
+    assert create_access_token.call_args.kwargs["expires_delta"].days == 7
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        (None, "Invalid authentication credentials"),
+        ({"exp": 1}, "Invalid token payload"),
+        ({"sub": "not-an-id"}, "Invalid user ID in token"),
+        ({"sub": ["1"]}, "Invalid user ID in token"),
+    ],
+)
+async def test_resolve_access_token_rejects_invalid_payloads(payload, message, auth_service, auth_repository):
+    with patch("runestone.services.auth_service.verify_token", return_value=payload):
+        with pytest.raises(InvalidAccessTokenError, match=message):
+            await auth_service.resolve_access_token("token")
+
+    auth_repository.get_by_id.assert_not_awaited()
+
+
+@patch("runestone.services.auth_service.verify_token", return_value={"sub": "42"})
+async def test_resolve_access_token_rejects_missing_user(_verify_token, auth_service, auth_repository):
+    with pytest.raises(InvalidAccessTokenError, match="User not found"):
+        await auth_service.resolve_access_token("token")
+
+    auth_repository.get_by_id.assert_awaited_once_with(42)
+
+
+@patch("runestone.services.auth_service.verify_token", return_value={"sub": "42"})
+async def test_resolve_access_token_rejects_inactive_user(_verify_token, auth_service, auth_repository):
+    auth_repository.get_by_id.return_value = User(id=42, email="user@example.com", name="User", active=False)
+
+    with pytest.raises(InactiveUserError, match="User is not active"):
+        await auth_service.resolve_access_token("token")
+
+
+@patch("runestone.services.auth_service.verify_token", return_value={"sub": "42"})
+async def test_resolve_access_token_returns_active_user(_verify_token, auth_service, auth_repository):
+    user = User(id=42, email="user@example.com", name="User", active=True)
+    auth_repository.get_by_id.return_value = user
+
+    assert await auth_service.resolve_access_token("token") is user

--- a/tests/test_auth_dependencies.py
+++ b/tests/test_auth_dependencies.py
@@ -1,0 +1,49 @@
+"""Tests for FastAPI authentication dependency error mapping."""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from fastapi import HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials
+
+from runestone.auth.dependencies import get_current_user
+from runestone.core.exceptions import InactiveUserError, InvalidAccessTokenError
+from runestone.db.models import User
+
+
+def bearer_token() -> HTTPAuthorizationCredentials:
+    """Return a representative bearer credential."""
+    return HTTPAuthorizationCredentials(scheme="Bearer", credentials="token")
+
+
+async def test_get_current_user_delegates_token_resolution():
+    user = User(id=1, email="user@example.com", name="User", active=True)
+    service = Mock()
+    service.resolve_access_token = AsyncMock(return_value=user)
+
+    assert await get_current_user(bearer_token(), service) is user
+    service.resolve_access_token.assert_awaited_once_with("token")
+
+
+async def test_get_current_user_maps_invalid_token_to_unauthorized():
+    service = Mock()
+    service.resolve_access_token = AsyncMock(side_effect=InvalidAccessTokenError("Invalid token payload"))
+
+    with pytest.raises(HTTPException) as raised:
+        await get_current_user(bearer_token(), service)
+
+    assert raised.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert raised.value.detail == "Invalid token payload"
+    assert raised.value.headers == {"WWW-Authenticate": "Bearer"}
+
+
+async def test_get_current_user_maps_inactive_user_to_forbidden():
+    service = Mock()
+    service.resolve_access_token = AsyncMock(side_effect=InactiveUserError("User is not active"))
+
+    with pytest.raises(HTTPException) as raised:
+        await get_current_user(bearer_token(), service)
+
+    assert raised.value.status_code == status.HTTP_403_FORBIDDEN
+    assert raised.value.detail == "User is not active"
+    assert raised.value.headers is None

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -14,6 +14,7 @@ from runestone.core.analyzer import ContentAnalyzer
 from runestone.core.ocr import OCRProcessor
 from runestone.core.processor import RunestoneProcessor
 from runestone.dependencies import (
+    get_auth_service,
     get_content_analyzer,
     get_llm_model,
     get_ocr_llm_model,
@@ -145,6 +146,17 @@ class TestDependencyProviders:
 
         assert result == mock_user_service_class.return_value
         mock_user_service_class.assert_called_once_with(user_repository)
+
+    @patch("runestone.dependencies.AuthService")
+    def test_get_auth_service(self, mock_auth_service_class):
+        """Auth service receives its required repository and settings."""
+        user_repository = Mock()
+        mock_settings = Mock(spec=Settings)
+
+        result = get_auth_service(user_repository, mock_settings)
+
+        assert result == mock_auth_service_class.return_value
+        mock_auth_service_class.assert_called_once_with(user_repository, mock_settings)
 
     @patch("runestone.dependencies.RecallService")
     def test_get_recall_service(self, mock_recall_service_class):


### PR DESCRIPTION
## Summary
- move registration, login, and token-user resolution database orchestration into `AuthService`
- keep API and auth dependencies transport-focused while assembling repositories at the composition root
- give registration one explicit transaction boundary with a primary email lookup and repository-level uniqueness fallback
- translate only confirmed email uniqueness violations for SQLite and PostgreSQL
- add focused service, repository, dependency, and API coverage

## Validation
- `make check-readiness` (1,130 backend tests; 558 frontend tests; lint, lockfile check, and production build)
- `make security-check`
- independent code review: approved with no findings

## Task
- [SG5VdM7R5npd](https://app.dartai.com/t/SG5VdM7R5npd-Refactor-authentication-databa)